### PR TITLE
#23 Tolerate numeric IDs in OBF/OBZ imports

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/ObfParser.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/ObfParser.kt
@@ -3,9 +3,17 @@ package io.github.jdreioe.wingmate.infrastructure
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
 import io.github.jdreioe.wingmate.domain.obf.ObfManifest
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
 
 class ObfParser {
-    
+
     private val json = Json {
         ignoreUnknownKeys = true
         isLenient = true
@@ -14,13 +22,70 @@ class ObfParser {
 
     fun parseBoard(jsonContent: String): Result<ObfBoard> {
         return runCatching {
-            json.decodeFromString<ObfBoard>(jsonContent)
+            val element = json.parseToJsonElement(jsonContent)
+            json.decodeFromJsonElement(ObfBoard.serializer(), stringifyObfIds(element))
         }
     }
 
     fun parseManifest(jsonContent: String): Result<ObfManifest> {
         return runCatching {
-            json.decodeFromString<ObfManifest>(jsonContent)
+            val element = json.parseToJsonElement(jsonContent)
+            json.decodeFromJsonElement(ObfManifest.serializer(), stringifyObfIds(element))
         }
+    }
+
+    /**
+     * OBF/OBZ parsing guidelines require numeric IDs to be cast to strings.
+     * Real-world boards often emit JSON numbers for id / image_id / sound_id / grid order cells.
+     */
+    internal fun stringifyObfIds(element: JsonElement): JsonElement {
+        return when (element) {
+            is JsonObject -> JsonObject(
+                element.mapValues { (key, value) ->
+                    when {
+                        key in ID_KEYS -> stringifyIdValue(value)
+                        key == "order" -> stringifyGridOrder(value)
+                        else -> stringifyObfIds(value)
+                    }
+                }
+            )
+            is JsonArray -> JsonArray(element.map { stringifyObfIds(it) })
+            else -> element
+        }
+    }
+
+    private fun stringifyIdValue(value: JsonElement): JsonElement {
+        return when (value) {
+            is JsonNull -> value
+            is JsonPrimitive -> {
+                if (value.isString) value else JsonPrimitive(value.content)
+            }
+            else -> stringifyObfIds(value)
+        }
+    }
+
+    private fun stringifyGridOrder(value: JsonElement): JsonElement {
+        if (value !is JsonArray) return stringifyObfIds(value)
+        return JsonArray(
+            value.map { row ->
+                if (row !is JsonArray) return@map stringifyObfIds(row)
+                JsonArray(
+                    row.map { cell ->
+                        when (cell) {
+                            is JsonNull -> cell
+                            is JsonPrimitive -> {
+                                if (cell.isString || cell.contentOrNull == null) cell
+                                else JsonPrimitive(cell.content)
+                            }
+                            else -> stringifyObfIds(cell)
+                        }
+                    }
+                )
+            }
+        )
+    }
+
+    private companion object {
+        val ID_KEYS = setOf("id", "image_id", "sound_id")
     }
 }

--- a/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/ObfNumericIdParserTest.kt
+++ b/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/ObfNumericIdParserTest.kt
@@ -1,0 +1,138 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ObfNumericIdParserTest {
+
+    private val parser = ObfParser()
+
+    @Test
+    fun parseBoard_stringifiesNumericIds() {
+        val json = """
+            {
+              "format": "open-board-0.1",
+              "id": 42,
+              "name": "Numeric",
+              "buttons": [
+                {
+                  "id": 7,
+                  "label": "Hi",
+                  "image_id": 3,
+                  "sound_id": 9
+                }
+              ],
+              "grid": {
+                "rows": 1,
+                "columns": 1,
+                "order": [[7]]
+              },
+              "images": [
+                { "id": 3, "url": "https://example.com/a.png" }
+              ],
+              "sounds": [
+                { "id": 9, "path": "sounds/a.mp3" }
+              ]
+            }
+        """.trimIndent()
+
+        val board = parser.parseBoard(json).getOrThrow()
+
+        assertEquals("42", board.id)
+        assertEquals("7", board.buttons.single().id)
+        assertEquals("3", board.buttons.single().imageId)
+        assertEquals("9", board.buttons.single().soundId)
+        assertEquals("3", board.images.single().id)
+        assertEquals("9", board.sounds.single().id)
+        assertEquals(listOf(listOf("7")), board.grid?.order)
+    }
+
+    @Test
+    fun parseBoard_keepsStringIds() {
+        val json = """
+            {
+              "format": "open-board-0.1",
+              "id": "board-a",
+              "buttons": [
+                { "id": "btn-1", "label": "A", "image_id": "img-1" }
+              ],
+              "grid": {
+                "rows": 1,
+                "columns": 1,
+                "order": [["btn-1", null]]
+              },
+              "images": [
+                { "id": "img-1", "path": "images/a.png" }
+              ]
+            }
+        """.trimIndent()
+
+        val board = parser.parseBoard(json).getOrThrow()
+
+        assertEquals("board-a", board.id)
+        assertEquals("btn-1", board.buttons.single().id)
+        assertEquals("img-1", board.buttons.single().imageId)
+        assertEquals(listOf(listOf("btn-1", null)), board.grid?.order)
+    }
+
+    @Test
+    fun parseBoard_supportsMixedStringAndNumericIds() {
+        val json = """
+            {
+              "format": "open-board-0.1",
+              "id": "root",
+              "buttons": [
+                { "id": 1, "label": "One" },
+                { "id": "two", "label": "Two", "image_id": 5 }
+              ],
+              "grid": {
+                "rows": 1,
+                "columns": 2,
+                "order": [[1, "two"]]
+              },
+              "images": [
+                { "id": 5, "url": "https://example.com/x.png" }
+              ]
+            }
+        """.trimIndent()
+
+        val board = parser.parseBoard(json).getOrThrow()
+
+        assertEquals("root", board.id)
+        assertEquals(listOf("1", "two"), board.buttons.map { it.id })
+        assertEquals("5", board.buttons[1].imageId)
+        assertEquals(listOf(listOf("1", "two")), board.grid?.order)
+        assertEquals("5", board.images.single().id)
+    }
+
+    @Test
+    fun parseManifest_stringifiesNumericBoardKeysAndRootPathStillWorks() {
+        val json = """
+            {
+              "format": "open-board-0.1",
+              "root": "boards/root.obf",
+              "paths": {
+                "boards": {
+                  "1": "boards/root.obf",
+                  "home": "boards/home.obf"
+                },
+                "images": {
+                  "10": "images/a.png"
+                },
+                "sounds": {}
+              }
+            }
+        """.trimIndent()
+
+        val manifest = parser.parseManifest(json).getOrThrow()
+
+        assertEquals("boards/root.obf", manifest.root)
+        assertEquals("boards/root.obf", manifest.paths.boards["1"])
+        assertEquals("boards/home.obf", manifest.paths.boards["home"])
+        assertEquals("images/a.png", manifest.paths.images["10"])
+        assertNotNull(manifest.paths.boards)
+        assertTrue(manifest.paths.sounds.isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
- Pre-decode transform in `ObfParser` stringifies numeric `id` / `image_id` / `sound_id` values and grid `order` cells per the OBF parsing guidelines.
- Unit tests cover numeric, string, and mixed ID boards plus manifests.

Closes #23

## Test plan
- [x] `./gradlew :core:data:jvmTest --tests ObfNumericIdParserTest`