### PR TITLE
#26 Persist full OBZ contents on import

### DIFF
--- a/composeApp/src/desktopMain/kotlin/io/github/jdreioe/wingmate/DesktopDi.kt
+++ b/composeApp/src/desktopMain/kotlin/io/github/jdreioe/wingmate/DesktopDi.kt
@@ -11,6 +11,8 @@ import io.github.jdreioe.wingmate.domain.PhraseRecordingService
 import io.github.jdreioe.wingmate.domain.CategoryRepository
 import io.github.jdreioe.wingmate.domain.BoardRepository
 import io.github.jdreioe.wingmate.domain.BoardSetRepository
+import io.github.jdreioe.wingmate.domain.FileStorage
+import io.github.jdreioe.wingmate.infrastructure.JvmFileStorage
 import io.github.jdreioe.wingmate.infrastructure.DesktopSpeechService
 import io.github.jdreioe.wingmate.infrastructure.DesktopPhraseRecordingService
 import io.github.jdreioe.wingmate.infrastructure.SimpleNGramPredictionService
@@ -68,6 +70,7 @@ fun overrideDesktopSpeechService() {
             singleOf(::SimpleNGramPredictionService) { bind<TextPredictionService>() }
             // File picker for importing files
             singleOf(::DesktopFilePicker) { bind<FilePicker>() }
+            singleOf(::JvmFileStorage) { bind<FileStorage>() }
             singleOf(::JvmImageCacher) { bind<ImageCacher>() }
             
             single { FileSystem.SYSTEM }

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/BoardImportService.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/BoardImportService.kt
@@ -1,214 +1,303 @@
 package io.github.jdreioe.wingmate.infrastructure
 
-import io.github.jdreioe.wingmate.domain.CategoryItem
-import io.github.jdreioe.wingmate.domain.CategoryRepository
-import io.github.jdreioe.wingmate.domain.Phrase
-import io.github.jdreioe.wingmate.domain.PhraseRepository
+import io.github.jdreioe.wingmate.domain.BoardRepository
+import io.github.jdreioe.wingmate.domain.BoardSetRepository
+import io.github.jdreioe.wingmate.domain.FileStorage
+import io.github.jdreioe.wingmate.domain.obf.BoardSetGraph
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
+import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
 import io.github.jdreioe.wingmate.domain.obf.ObfButton
 import io.github.jdreioe.wingmate.domain.obf.ObfImage
+import io.github.jdreioe.wingmate.domain.obf.ObfLoadBoard
+import io.github.jdreioe.wingmate.domain.obf.ObfSound
 import io.github.jdreioe.wingmate.platform.FilePicker
-import kotlinx.datetime.Clock
 import kotlin.random.Random
+import kotlin.time.Clock
 
+/**
+ * Imports OBF/OBZ packages into the board-set system, persisting every board in the
+ * graph and rewriting zipped media paths into app-private [FileStorage] locations.
+ */
 class BoardImportService(
     private val obfParser: ObfParser,
-    private val phraseRepository: PhraseRepository,
-    private val categoryRepository: CategoryRepository,
-    private val filePicker: FilePicker
+    private val boardRepository: BoardRepository,
+    private val boardSetRepository: BoardSetRepository,
+    private val filePicker: FilePicker,
+    private val fileStorage: FileStorage? = null
 ) {
-    private fun newId(): String {
-        val alphabet = "0123456789abcdef"
-        return buildString(32) {
-            repeat(32) {
-                append(alphabet[Random.nextInt(alphabet.length)])
-            }
-        }
+    /**
+     * Opens a file picker and imports the selected OBF/OBZ as a new board set.
+     * @return the created board set, or null if cancelled / failed
+     */
+    suspend fun importBoardSet(): ObfBoardSet? {
+        val filePath = filePicker.pickFile("Select Board File", listOf("obf", "obz", "json"))
+            ?: return null
+        return importBoardSetFromPath(filePath)
     }
 
-    suspend fun importBoards(isModern: Boolean): Boolean {
-        // 1. Pick file
-        val filePath = filePicker.pickFile("Select Board File", listOf("obf", "obz", "json")) ?: return false
+    /**
+     * Legacy entry point used by onboarding. Prefer [importBoardSet].
+     * @return true when a board set was created
+     */
+    suspend fun importBoards(isModern: Boolean = true): Boolean {
+        return importBoardSet() != null
+    }
+
+    suspend fun importBoardSetFromPath(filePath: String): ObfBoardSet? {
         val isObz = filePath.lowercase().endsWith(".obz")
-
-        if (isObz) {
-            return importObz(filePath, isModern)
+        val graph = if (isObz) {
+            importObzGraph(filePath)
         } else {
-            return importSingleObf(filePath, isModern)
+            importSingleObfGraph(filePath)
+        } ?: return null
+
+        val canonical = graph.canonicalizeBoardLinks()
+        canonical.boards.forEach { boardRepository.saveBoard(it) }
+        boardSetRepository.saveBoardSet(canonical.boardSet)
+        return canonical.boardSet
+    }
+
+    private suspend fun importSingleObfGraph(filePath: String): BoardSetGraph? {
+        val content = filePicker.readFileAsText(filePath) ?: return null
+        val board = obfParser.parseBoard(content).getOrNull() ?: return null
+        return buildGraph(listOf(board to true), emptyMap())
+    }
+
+    private suspend fun importObzGraph(filePath: String): BoardSetGraph? {
+        val entries = filePicker.readZipEntries(filePath) ?: return null
+        val manifestContent = entries["manifest.json"]?.decodeToString() ?: return null
+        val manifest = obfParser.parseManifest(manifestContent).getOrNull() ?: return null
+
+        val mediaEntries = entries.filterKeys { key ->
+            !key.endsWith(".json", ignoreCase = true) &&
+                !key.endsWith(".obf", ignoreCase = true) &&
+                key != "manifest.json"
         }
-    }
 
-    private suspend fun importSingleObf(filePath: String, isModern: Boolean): Boolean {
-        val content = filePicker.readFileAsText(filePath) ?: return false
-        val boardResult = obfParser.parseBoard(content)
-        val board = boardResult.getOrNull() ?: return false
-        
-        // Single file treated as Root. Remapping context is local to this single board.
-        // But to avoid collisions, we must remap its ID.
-        importBoardsWithRemapping(listOf(board to true), isModern, emptyMap())
-        return true
-    }
-
-    private suspend fun importObz(filePath: String, isModern: Boolean): Boolean {
-        val entries = filePicker.readZipEntries(filePath) ?: return false
-        
-        val manifestContent = entries["manifest.json"]?.decodeToString() ?: return false
-        val manifestResult = obfParser.parseManifest(manifestContent)
-        val manifest = manifestResult.getOrNull() ?: return false
-
-        val zipImages = entries.filterKeys { !it.endsWith(".json") && !it.endsWith(".obf") }
-        
-        val boardsToImport = mutableListOf<Pair<ObfBoard, Boolean>>() // Board, isRoot
-
-        // Parse Root
+        val boards = mutableListOf<Pair<ObfBoard, Boolean>>()
         val rootPath = manifest.root
         val rootContent = entries[rootPath]?.decodeToString()
+            ?: entries.entries.firstOrNull { it.key.equals(rootPath, ignoreCase = true) }?.value?.decodeToString()
         if (rootContent != null) {
-            val rootBoard = obfParser.parseBoard(rootContent).getOrNull()
-            if (rootBoard != null) {
-                boardsToImport.add(rootBoard to true)
+            obfParser.parseBoard(rootContent).getOrNull()?.let { boards.add(it to true) }
+        }
+        if (boards.none { it.second }) return null
+
+        manifest.paths.boards.forEach { (_, path) ->
+            if (path == rootPath) return@forEach
+            val content = entries[path]?.decodeToString()
+                ?: entries.entries.firstOrNull { it.key.equals(path, ignoreCase = true) }?.value?.decodeToString()
+            if (content != null) {
+                obfParser.parseBoard(content).getOrNull()?.let { boards.add(it to false) }
             }
         }
 
-        // Parse Others
-        manifest.paths.boards.forEach { (id, path) ->
-            if (path != rootPath) { 
-                val content = entries[path]?.decodeToString()
-                if (content != null) {
-                    val board = obfParser.parseBoard(content).getOrNull()
-                    if (board != null) {
-                        boardsToImport.add(board to false)
-                    }
-                }
-            }
-        }
-
-        importBoardsWithRemapping(boardsToImport, isModern, zipImages)
-        return true
+        return buildGraph(boards, mediaEntries)
     }
 
-    private suspend fun importBoardsWithRemapping(
+    private suspend fun buildGraph(
         boards: List<Pair<ObfBoard, Boolean>>,
-        isModern: Boolean,
-        zipImages: Map<String, ByteArray>
-    ) {
-        // 1. Build ID Map (Old ID -> New UUID)
-        // This ensures every import gets fresh IDs, avoiding PK collisions.
-        val idMap = mutableMapOf<String, String>()
+        zipMedia: Map<String, ByteArray>
+    ): BoardSetGraph? {
+        if (boards.isEmpty()) return null
+
+        val now = Clock.System.now().toEpochMilliseconds()
+        val setId = newId("set")
+        val boardIdMap = linkedMapOf<String, String>()
         boards.forEach { (board, _) ->
             if (board.id.isNotEmpty()) {
-                idMap[board.id] = newId()
+                boardIdMap.putIfAbsent(board.id, newId("board"))
             }
         }
 
-        // 2. Import each board using the map
-        boards.forEach { (board, isRoot) ->
-            importBoard(board, isRoot, isModern, zipImages, idMap)
+        val rootOriginalId = boards.first { it.second }.first.id
+        val rootNewId = boardIdMap[rootOriginalId] ?: newId("board").also {
+            boardIdMap[rootOriginalId] = it
+        }
+
+        val rewrittenBoards = boards.map { (board, _) ->
+            val newBoardId = boardIdMap.getValue(board.id.ifEmpty { rootOriginalId })
+            rewriteBoard(board, newBoardId, boardIdMap, setId, zipMedia)
+        }
+
+        val boardSet = ObfBoardSet(
+            id = setId,
+            name = rewrittenBoards.firstOrNull { it.id == rootNewId }?.name
+                ?: rewrittenBoards.first().name
+                ?: "Imported board set",
+            rootBoardId = rootNewId,
+            boardIds = rewrittenBoards.map { it.id }.distinct(),
+            isLocked = false,
+            createdAt = now,
+            updatedAt = now
+        )
+        return BoardSetGraph(boardSet, rewrittenBoards)
+    }
+
+    private suspend fun rewriteBoard(
+        board: ObfBoard,
+        newBoardId: String,
+        boardIdMap: Map<String, String>,
+        setId: String,
+        zipMedia: Map<String, ByteArray>
+    ): ObfBoard {
+        val imageIdMap = board.images.associate { it.id to it.id }
+        val soundIdMap = board.sounds.associate { it.id to it.id }
+
+        val images = board.images.map { image ->
+            persistImage(image, setId, zipMedia)
+        }
+        val sounds = board.sounds.map { sound ->
+            persistSound(sound, setId, zipMedia)
+        }
+        val buttons = board.buttons.map { button ->
+            rewriteButton(button, boardIdMap, imageIdMap, soundIdMap)
+        }
+        val grid = board.grid
+        return board.copy(
+            id = newBoardId,
+            buttons = buttons,
+            images = images,
+            sounds = sounds,
+            grid = grid
+        )
+    }
+
+    private fun rewriteButton(
+        button: ObfButton,
+        boardIdMap: Map<String, String>,
+        imageIdMap: Map<String, String>,
+        soundIdMap: Map<String, String>
+    ): ObfButton {
+        val loadBoard = button.loadBoard?.let { link ->
+            val mappedId = link.id?.let { boardIdMap[it] } ?: link.id
+            ObfLoadBoard(
+                id = mappedId,
+                name = link.name,
+                url = link.url,
+                path = link.path,
+                dataUrl = link.dataUrl
+            )
+        }
+        return button.copy(
+            imageId = button.imageId?.let { imageIdMap[it] ?: it },
+            soundId = button.soundId?.let { soundIdMap[it] ?: it },
+            loadBoard = loadBoard
+        )
+    }
+
+    private suspend fun persistImage(
+        image: ObfImage,
+        setId: String,
+        zipMedia: Map<String, ByteArray>
+    ): ObfImage {
+        val storage = fileStorage ?: return image
+        val imagePath = image.path
+        val imageData = image.data
+        val bytes = when {
+            imagePath != null -> zipMedia[imagePath] ?: zipMedia.entries
+                .firstOrNull { it.key.equals(imagePath, ignoreCase = true) || it.key.endsWith("/$imagePath") }
+                ?.value
+            imageData != null -> decodeDataUri(imageData)
+            else -> null
+        } ?: return image
+
+        val extension = extensionFor(image.contentType, image.path, default = "bin")
+        val storedPath = "boardsets/$setId/images/${sanitize(image.id)}.$extension"
+        storage.saveBytes(storedPath, bytes)
+        return image.copy(path = storedPath, data = null, url = image.url)
+    }
+
+    private suspend fun persistSound(
+        sound: ObfSound,
+        setId: String,
+        zipMedia: Map<String, ByteArray>
+    ): ObfSound {
+        val storage = fileStorage ?: return sound
+        val soundPath = sound.path
+        val soundData = sound.data
+        val bytes = when {
+            soundPath != null -> zipMedia[soundPath] ?: zipMedia.entries
+                .firstOrNull { it.key.equals(soundPath, ignoreCase = true) || it.key.endsWith("/$soundPath") }
+                ?.value
+            soundData != null -> decodeDataUri(soundData)
+            else -> null
+        } ?: return sound
+
+        val extension = extensionFor(sound.contentType, sound.path, default = "mp3")
+        val storedPath = "boardsets/$setId/sounds/${sanitize(sound.id)}.$extension"
+        storage.saveBytes(storedPath, bytes)
+        return sound.copy(path = storedPath, data = null, url = sound.url)
+    }
+
+    private fun decodeDataUri(data: String): ByteArray? {
+        val payload = data.substringAfter("base64,", missingDelimiterValue = data)
+        return runCatching { payload.decodeBase64Bytes() }.getOrNull()
+    }
+
+    private fun extensionFor(contentType: String?, path: String?, default: String): String {
+        path?.substringAfterLast('.', missingDelimiterValue = "")
+            ?.takeIf { it.isNotBlank() && it.length <= 5 }
+            ?.let { return it.lowercase() }
+        return when (contentType?.lowercase()) {
+            "image/png" -> "png"
+            "image/jpeg", "image/jpg" -> "jpg"
+            "image/gif" -> "gif"
+            "image/svg+xml" -> "svg"
+            "image/webp" -> "webp"
+            "audio/mpeg", "audio/mp3" -> "mp3"
+            "audio/wav", "audio/x-wav" -> "wav"
+            "audio/ogg" -> "ogg"
+            else -> default
         }
     }
 
-    private suspend fun importBoard(
-        board: ObfBoard, 
-        isRoot: Boolean, 
-        isModern: Boolean,
-        zipImages: Map<String, ByteArray>,
-        idMap: Map<String, String>
-    ) {
-        // Resolve new Board ID
-        val originalBoardId = board.id
-        val newBoardId = idMap[originalBoardId] ?: newId()
-        val boardName = board.name ?: "Imported Board"
-        
-        val createCategoryChip = isModern
-        val createGridFolder = !isModern && isRoot
-        
-        if (createCategoryChip || createGridFolder) {
-            val folderPhrase = Phrase(
-                id = newBoardId,
-                text = boardName,
-                name = boardName,
-                createdAt = Clock.System.now().toEpochMilliseconds(),
-                parentId = null, // Top level
-                linkedBoardId = newBoardId, // Self-link
-                isGridItem = createGridFolder
-            )
-            phraseRepository.add(folderPhrase)
-            
-            if (createCategoryChip) {
-                categoryRepository.add(CategoryItem(
-                    id = folderPhrase.id,
-                    name = boardName,
-                    isFolder = true
-                ))
-            }
-        }
-        
-        val contextId = newBoardId 
-        val boardImages = board.images.associateBy { it.id }
-        
-        board.buttons.forEach { button ->
-            importButton(button, contextId, boardImages, zipImages, isModern, idMap)
-        }
-    }
+    private fun sanitize(value: String): String =
+        value.replace(Regex("[^A-Za-z0-9._-]"), "_").ifBlank { newId("media") }
 
-    private suspend fun importButton(
-        button: ObfButton, 
-        parentId: String, 
-        boardImages: Map<String, ObfImage>,
-        zipImages: Map<String, ByteArray>,
-        isModern: Boolean,
-        idMap: Map<String, String>
-    ) {
-        var imageUrl = button.imageId?.let { id ->
-            val img = boardImages[id]
-            val path = img?.path
-            if (path != null && zipImages.containsKey(path)) {
-                 // skip bytes for now, just null or placeholder?
-                 // Ideally we'd write to file.
-                null
-            } else {
-                img?.url ?: img?.data
-            }
+    private fun newId(prefix: String): String {
+        val alphabet = "0123456789abcdef"
+        val suffix = buildString(8) {
+            repeat(8) { append(alphabet[Random.nextInt(alphabet.length)]) }
         }
-
-        val loadBoard = button.loadBoard
-        if (loadBoard != null) {
-            // Remap the link target!
-            val originalLinkId = loadBoard.id
-            // If originalLink is null, check path?
-            // Manifest logic uses IDs.
-            
-            val newLinkId = if (originalLinkId != null) {
-                idMap[originalLinkId] ?: newId() // Fallback if unknown
-            } else {
-                 newId()
-            }
-            
-            val folderName = button.label ?: loadBoard.name ?: "Folder"
-            
-            val folderPhrase = Phrase(
-                id = newId(),
-                text = folderName,
-                imageUrl = imageUrl,
-                backgroundColor = button.backgroundColor,
-                createdAt = Clock.System.now().toEpochMilliseconds(),
-                parentId = parentId,
-                linkedBoardId = newLinkId,
-                isGridItem = true
-            )
-            phraseRepository.add(folderPhrase)
-        } else {
-             val phrase = Phrase(
-            id = newId(), // Always new ID for buttons to avoid collision
-                text = button.label ?: "",
-                name = button.vocalization,
-                imageUrl = imageUrl,
-                backgroundColor = button.backgroundColor,
-                createdAt = Clock.System.now().toEpochMilliseconds(),
-                parentId = parentId,
-                isGridItem = true
-            )
-            phraseRepository.add(phrase)
-        }
+        return "${prefix}_$suffix"
     }
+}
+
+/** Minimal base64 decoder for data-URI payloads. */
+private fun String.decodeBase64Bytes(): ByteArray {
+    val table = IntArray(128) { -1 }
+    val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    alphabet.forEachIndexed { index, c -> table[c.code] = index }
+
+    val cleaned = filterNot { it.isWhitespace() }
+    if (cleaned.isEmpty()) return ByteArray(0)
+    require(cleaned.length % 4 == 0) { "Invalid base64 length" }
+
+    val padding = when {
+        cleaned.endsWith("==") -> 2
+        cleaned.endsWith("=") -> 1
+        else -> 0
+    }
+    val out = ByteArray(cleaned.length / 4 * 3 - padding)
+    var outIndex = 0
+    var i = 0
+    while (i < cleaned.length) {
+        val c0 = decodeBase64Char(table, cleaned[i])
+        val c1 = decodeBase64Char(table, cleaned[i + 1])
+        val c2 = if (cleaned[i + 2] == '=') 0 else decodeBase64Char(table, cleaned[i + 2])
+        val c3 = if (cleaned[i + 3] == '=') 0 else decodeBase64Char(table, cleaned[i + 3])
+        val triple = (c0 shl 18) or (c1 shl 12) or (c2 shl 6) or c3
+        if (outIndex < out.size) out[outIndex++] = ((triple shr 16) and 0xFF).toByte()
+        if (outIndex < out.size) out[outIndex++] = ((triple shr 8) and 0xFF).toByte()
+        if (outIndex < out.size) out[outIndex++] = (triple and 0xFF).toByte()
+        i += 4
+    }
+    return out
+}
+
+private fun decodeBase64Char(table: IntArray, char: Char): Int {
+    val value = table.getOrElse(char.code) { -1 }
+    require(value >= 0) { "Invalid base64 char: $char" }
+    return value
 }

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/InMemoryFileStorage.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/InMemoryFileStorage.kt
@@ -1,0 +1,23 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.domain.FileStorage
+
+class InMemoryFileStorage : FileStorage {
+    private val text = mutableMapOf<String, String>()
+    private val bytes = mutableMapOf<String, ByteArray>()
+
+    override suspend fun save(fileName: String, content: String) {
+        text[fileName] = content
+    }
+
+    override suspend fun load(fileName: String): String? = text[fileName]
+
+    override suspend fun saveBytes(fileName: String, content: ByteArray) {
+        bytes[fileName] = content.copyOf()
+    }
+
+    override suspend fun loadBytes(fileName: String): ByteArray? = bytes[fileName]?.copyOf()
+
+    override suspend fun exists(fileName: String): Boolean =
+        text.containsKey(fileName) || bytes.containsKey(fileName)
+}

--- a/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/BoardImportServiceTest.kt
+++ b/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/BoardImportServiceTest.kt
@@ -1,0 +1,175 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.platform.FilePicker
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class BoardImportServiceTest {
+
+    @Test
+    fun importSingleObf_persistsBoardSetGraph() = runBlocking {
+        val boardRepo = InMemoryBoardRepository()
+        val setRepo = InMemoryBoardSetRepository()
+        val storage = InMemoryFileStorage()
+        val picker = FakeFilePicker(
+            textFiles = mapOf(
+                "board.obf" to """
+                    {
+                      "format": "open-board-0.1",
+                      "id": "home",
+                      "name": "Home",
+                      "buttons": [
+                        { "id": "b1", "label": "Hi", "image_id": "img1" }
+                      ],
+                      "grid": { "rows": 1, "columns": 1, "order": [["b1"]] },
+                      "images": [
+                        {
+                          "id": "img1",
+                          "content_type": "image/png",
+                          "data": "data:image/png;base64,aGVsbG8="
+                        }
+                      ]
+                    }
+                """.trimIndent()
+            )
+        )
+        val service = BoardImportService(
+            obfParser = ObfParser(),
+            boardRepository = boardRepo,
+            boardSetRepository = setRepo,
+            filePicker = picker,
+            fileStorage = storage
+        )
+
+        val set = service.importBoardSetFromPath("board.obf")
+        assertNotNull(set)
+        assertEquals(1, set.boardIds.size)
+        val board = boardRepo.getBoard(set.rootBoardId)
+        assertNotNull(board)
+        assertEquals("Home", board.name)
+        val imagePath = board.images.single().path
+        assertNotNull(imagePath)
+        assertTrue(imagePath.startsWith("boardsets/"))
+        assertTrue(storage.exists(imagePath))
+        assertEquals(
+            "hello".encodeToByteArray().toList(),
+            storage.loadBytes(imagePath)?.toList().orEmpty()
+        )
+    }
+
+    @Test
+    fun importObz_persistsLinkedBoardsAndMedia() = runBlocking {
+        val boardRepo = InMemoryBoardRepository()
+        val setRepo = InMemoryBoardSetRepository()
+        val storage = InMemoryFileStorage()
+        val homeJson = """
+            {
+              "format": "open-board-0.1",
+              "id": "home",
+              "name": "Home",
+              "buttons": [
+                {
+                  "id": "to-food",
+                  "label": "Food",
+                  "load_board": { "id": "food", "path": "boards/food.obf" },
+                  "image_id": "img1"
+                }
+              ],
+              "grid": { "rows": 1, "columns": 1, "order": [["to-food"]] },
+              "images": [
+                { "id": "img1", "path": "images/food.png", "content_type": "image/png" }
+              ],
+              "sounds": [
+                { "id": "snd1", "path": "sounds/beep.mp3", "content_type": "audio/mpeg" }
+              ]
+            }
+        """.trimIndent()
+        val foodJson = """
+            {
+              "format": "open-board-0.1",
+              "id": "food",
+              "name": "Food",
+              "buttons": [
+                { "id": "apple", "label": "Apple", "sound_id": "snd1" }
+              ],
+              "grid": { "rows": 1, "columns": 1, "order": [["apple"]] },
+              "sounds": [
+                { "id": "snd1", "path": "sounds/beep.mp3", "content_type": "audio/mpeg" }
+              ]
+            }
+        """.trimIndent()
+        val manifest = """
+            {
+              "format": "open-board-0.1",
+              "root": "boards/home.obf",
+              "paths": {
+                "boards": {
+                  "home": "boards/home.obf",
+                  "food": "boards/food.obf"
+                },
+                "images": { "img1": "images/food.png" },
+                "sounds": { "snd1": "sounds/beep.mp3" }
+              }
+            }
+        """.trimIndent()
+        val picker = FakeFilePicker(
+            zipFiles = mapOf(
+                "pack.obz" to mapOf(
+                    "manifest.json" to manifest.encodeToByteArray(),
+                    "boards/home.obf" to homeJson.encodeToByteArray(),
+                    "boards/food.obf" to foodJson.encodeToByteArray(),
+                    "images/food.png" to byteArrayOf(1, 2, 3, 4),
+                    "sounds/beep.mp3" to byteArrayOf(9, 8, 7)
+                )
+            )
+        )
+        val service = BoardImportService(
+            obfParser = ObfParser(),
+            boardRepository = boardRepo,
+            boardSetRepository = setRepo,
+            filePicker = picker,
+            fileStorage = storage
+        )
+
+        val set = service.importBoardSetFromPath("pack.obz")
+        assertNotNull(set)
+        assertEquals(2, set.boardIds.size)
+
+        val home = boardRepo.getBoard(set.rootBoardId)
+        assertNotNull(home)
+        val foodId = home.buttons.single().loadBoard?.id
+        assertNotNull(foodId)
+        val food = boardRepo.getBoard(foodId)
+        assertNotNull(food)
+        assertEquals("Food", food.name)
+
+        val imagePath = home.images.single().path
+        assertNotNull(imagePath)
+        assertEquals(
+            listOf<Byte>(1, 2, 3, 4),
+            storage.loadBytes(imagePath)?.toList().orEmpty()
+        )
+
+        val soundPath = food.sounds.single().path
+        assertNotNull(soundPath)
+        assertEquals(
+            listOf<Byte>(9, 8, 7),
+            storage.loadBytes(soundPath)?.toList().orEmpty()
+        )
+        assertEquals(soundPath, food.buttons.single().let { btn ->
+            food.sounds.first { it.id == btn.soundId }.path
+        })
+    }
+
+    private class FakeFilePicker(
+        private val textFiles: Map<String, String> = emptyMap(),
+        private val zipFiles: Map<String, Map<String, ByteArray>> = emptyMap()
+    ) : FilePicker {
+        override suspend fun pickFile(title: String, extensions: List<String>): String? = null
+        override suspend fun readFileAsText(path: String): String? = textFiles[path]
+        override suspend fun readZipEntries(path: String): Map<String, ByteArray>? = zipFiles[path]
+    }
+}

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosFileStorage.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosFileStorage.kt
@@ -1,0 +1,83 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.domain.FileStorage
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSString
+import platform.Foundation.NSUTF8StringEncoding
+import platform.Foundation.NSUserDomainMask
+import platform.Foundation.create
+import platform.Foundation.dataUsingEncoding
+import platform.Foundation.dataWithContentsOfFile
+import platform.Foundation.writeToFile
+import platform.posix.memcpy
+
+@OptIn(ExperimentalForeignApi::class)
+class IosFileStorage : FileStorage {
+    private val root: String by lazy {
+        val urls = NSFileManager.defaultManager.URLsForDirectory(
+            directory = NSDocumentDirectory,
+            inDomains = NSUserDomainMask
+        )
+        (urls.firstOrNull() as? platform.Foundation.NSURL)?.path ?: ""
+    }
+
+    override suspend fun save(fileName: String, content: String) {
+        val path = resolve(fileName)
+        ensureParent(path)
+        val data = (content as NSString).dataUsingEncoding(NSUTF8StringEncoding) ?: return
+        data.writeToFile(path, atomically = true)
+    }
+
+    override suspend fun load(fileName: String): String? {
+        val path = resolve(fileName)
+        val data = NSData.dataWithContentsOfFile(path) ?: return null
+        return NSString.create(data = data, encoding = NSUTF8StringEncoding)?.toString()
+    }
+
+    override suspend fun saveBytes(fileName: String, content: ByteArray) {
+        val path = resolve(fileName)
+        ensureParent(path)
+        val data = content.usePinned { pinned ->
+            NSData.create(bytes = pinned.addressOf(0), length = content.size.toULong())
+        }
+        data.writeToFile(path, atomically = true)
+    }
+
+    override suspend fun loadBytes(fileName: String): ByteArray? {
+        val path = resolve(fileName)
+        val data = NSData.dataWithContentsOfFile(path) ?: return null
+        val length = data.length.toInt()
+        if (length == 0) return ByteArray(0)
+        val bytes = ByteArray(length)
+        bytes.usePinned { pinned ->
+            memcpy(pinned.addressOf(0), data.bytes, data.length)
+        }
+        return bytes
+    }
+
+    override suspend fun exists(fileName: String): Boolean {
+        return NSFileManager.defaultManager.fileExistsAtPath(resolve(fileName))
+    }
+
+    private fun resolve(fileName: String): String {
+        val trimmed = fileName.trimStart('/')
+        return if (root.isBlank()) trimmed else "$root/$trimmed"
+    }
+
+    private fun ensureParent(path: String) {
+        val parent = path.substringBeforeLast('/', missingDelimiterValue = "")
+        if (parent.isNotBlank()) {
+            NSFileManager.defaultManager.createDirectoryAtPath(
+                path = parent,
+                withIntermediateDirectories = true,
+                attributes = null,
+                error = null
+            )
+        }
+    }
+}

--- a/core/data/src/jvmMain/kotlin/io/github/jdreioe/wingmate/infrastructure/JvmFileStorage.kt
+++ b/core/data/src/jvmMain/kotlin/io/github/jdreioe/wingmate/infrastructure/JvmFileStorage.kt
@@ -1,12 +1,17 @@
 package io.github.jdreioe.wingmate.infrastructure
 
-import android.content.Context
 import io.github.jdreioe.wingmate.domain.FileStorage
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
 
-class AndroidFileStorage(private val context: Context) : FileStorage {
+class JvmFileStorage(
+    private val rootDir: File = File(System.getProperty("user.home"), ".wingmate/files")
+) : FileStorage {
+    init {
+        rootDir.mkdirs()
+    }
+
     override suspend fun save(fileName: String, content: String) = withContext(Dispatchers.IO) {
         val file = resolve(fileName)
         file.parentFile?.mkdirs()
@@ -33,5 +38,5 @@ class AndroidFileStorage(private val context: Context) : FileStorage {
         resolve(fileName).exists()
     }
 
-    private fun resolve(fileName: String): File = File(context.filesDir, fileName)
+    private fun resolve(fileName: String): File = File(rootDir, fileName)
 }

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/FileStorage.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/FileStorage.kt
@@ -9,13 +9,25 @@ interface FileStorage {
      * Overwrites if exists.
      */
     suspend fun save(fileName: String, content: String)
-    
+
     /**
      * Reads text content from a file with the given name.
      * Returns null if file does not exist.
      */
     suspend fun load(fileName: String): String?
-    
+
+    /**
+     * Saves binary content to a file with the given name.
+     * Overwrites if exists. Parent directories are created as needed.
+     */
+    suspend fun saveBytes(fileName: String, content: ByteArray)
+
+    /**
+     * Reads binary content from a file with the given name.
+     * Returns null if the file does not exist.
+     */
+    suspend fun loadBytes(fileName: String): ByteArray?
+
     /**
      * Checks if a file exists.
      */

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/di/AppModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/di/AppModule.kt
@@ -41,7 +41,15 @@ val appModule = module {
     singleOf(::MovePhraseUseCase)
     singleOf(::GetAllItemsUseCase)
     
-    singleOf(::BoardImportService)
+    single {
+        BoardImportService(
+            obfParser = get(),
+            boardRepository = get(),
+            boardSetRepository = get(),
+            filePicker = get(),
+            fileStorage = getOrNull()
+        )
+    }
     
     single<AacLogger> { RealAacLogger(get(), getOrNull(named("logDir")), get()) }
 

--- a/shared/src/iosMain/kotlin/io/github/jdreioe/wingmate/IosDi.kt
+++ b/shared/src/iosMain/kotlin/io/github/jdreioe/wingmate/IosDi.kt
@@ -5,6 +5,7 @@ import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.github.jdreioe.wingmate.domain.CategoryRepository
 import io.github.jdreioe.wingmate.domain.ConfigRepository
+import io.github.jdreioe.wingmate.domain.FileStorage
 import io.github.jdreioe.wingmate.domain.PhraseRepository
 import io.github.jdreioe.wingmate.domain.PronunciationDictionaryRepository
 import io.github.jdreioe.wingmate.domain.SaidTextRepository
@@ -15,6 +16,7 @@ import io.github.jdreioe.wingmate.domain.VoiceRepository
 import io.github.jdreioe.wingmate.infrastructure.IosAudioClipboard
 import io.github.jdreioe.wingmate.infrastructure.IosCategoryRepository
 import io.github.jdreioe.wingmate.infrastructure.IosConfigRepository
+import io.github.jdreioe.wingmate.infrastructure.IosFileStorage
 import io.github.jdreioe.wingmate.infrastructure.IosPhraseRepository
 import io.github.jdreioe.wingmate.infrastructure.IosPronunciationDictionaryRepository
 import io.github.jdreioe.wingmate.infrastructure.IosSaidTextRepository
@@ -63,6 +65,7 @@ fun overrideIosSpeechService() {
             
             // Pronunciation dictionary (persisted)
             singleOf(::IosPronunciationDictionaryRepository) { bind<PronunciationDictionaryRepository>() }
+            singleOf(::IosFileStorage) { bind<FileStorage>() }
         }
     )
 }


### PR DESCRIPTION
## Summary
- Rewrite `BoardImportService` to create a full board-set graph (every board + remapped links).
- Extend `FileStorage` with binary save/load; Android/JVM/iOS + in-memory implementations.
- Persist zipped images/sounds and rewrite `path` references for restart-safe media.

Closes #26

## Test plan
- [x] `./gradlew :core:data:jvmTest --tests BoardImportServiceTest`