### PR TITLE
#27 Support OBF symbol attribute and image priority

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-da/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-da/strings.xml
@@ -312,4 +312,6 @@
     <string name="ui_settings_auditory_fishing_desc">Hvisk mærkaten når en knap berøres eller holdes over.</string>
     <string name="ui_settings_usage_logging_title">Standardiseret logning (OBL)</string>
     <string name="ui_settings_usage_logging_desc">Optag brugsdata i Open Logging Format til klinisk gennemgang.</string>
+    <string name="board_symbol_unavailable">Symbolbibliotek utilgængeligt</string>
+    <string name="board_symbol_unavailable_set">Symbolbiblioteket “%1$s” er utilgængeligt</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -312,4 +312,6 @@
     <string name="ui_settings_auditory_fishing_desc">Whisper the label when a button is hovered or touched.</string>
     <string name="ui_settings_usage_logging_title">Standardized logging (OBL)</string>
     <string name="ui_settings_usage_logging_desc">Record usage data in Open Logging Format for clinical review.</string>
+    <string name="board_symbol_unavailable">Symbol set unavailable</string>
+    <string name="board_symbol_unavailable_set">Symbol set “%1$s” unavailable</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.unit.sp
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
 import io.github.jdreioe.wingmate.domain.obf.ObfButton
 import io.github.jdreioe.wingmate.domain.obf.ObfImage
+import io.github.jdreioe.wingmate.domain.obf.ObfImageSource
+import io.github.jdreioe.wingmate.domain.obf.resolveObfImageSource
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -58,6 +60,8 @@ import kotlinx.coroutines.launch
 import androidx.compose.runtime.rememberCoroutineScope
 import org.jetbrains.compose.resources.stringResource
 import wingmatekmp.composeapp.generated.resources.Res
+import wingmatekmp.composeapp.generated.resources.board_symbol_unavailable
+import wingmatekmp.composeapp.generated.resources.board_symbol_unavailable_set
 import wingmatekmp.composeapp.generated.resources.board_workspace_clear_sentence
 import wingmatekmp.composeapp.generated.resources.board_workspace_delete_last
 import wingmatekmp.composeapp.generated.resources.board_workspace_save_phrase
@@ -492,21 +496,35 @@ fun ObfButtonItem(
         else -> MaterialTheme.colorScheme.onSurface
     }
     
-    // Try to load image from various sources synchronously first
-    val syncBitmap = remember(image, extractedImageBytes) {
-        extractedImageBytes?.let { bytes ->
-            runCatching { bytes.toComposeImageBitmap() }.getOrNull()
-        } ?: image?.data?.let { data ->
-            runCatching {
-                val base64 = if (data.contains(",")) data.substringAfter(",") else data
-                val bytes = java.util.Base64.getDecoder().decode(base64)
-                bytes.toComposeImageBitmap()
-            }.getOrNull()
+    // Spec priority: data → path → url → symbol (extracted zip bytes count as path).
+    val imageSource = remember(image) { resolveObfImageSource(image) }
+    val syncBitmap = remember(imageSource, extractedImageBytes) {
+        when {
+            extractedImageBytes != null && imageSource is ObfImageSource.Path -> {
+                runCatching { extractedImageBytes.toComposeImageBitmap() }.getOrNull()
+            }
+            imageSource is ObfImageSource.DataUri -> {
+                runCatching {
+                    val data = imageSource.data
+                    val base64 = if (data.contains(",")) data.substringAfter(",") else data
+                    val bytes = java.util.Base64.getDecoder().decode(base64)
+                    bytes.toComposeImageBitmap()
+                }.getOrNull()
+            }
+            extractedImageBytes != null -> {
+                runCatching { extractedImageBytes.toComposeImageBitmap() }.getOrNull()
+            }
+            else -> null
         }
     }
-    
+
     val imageBitmap = syncBitmap
-    val imageModel = image?.url ?: image?.path
+    val imageModel = when (imageSource) {
+        is ObfImageSource.Url -> imageSource.url
+        is ObfImageSource.Path -> imageSource.path
+        else -> null
+    }
+    val symbolUnavailable = imageSource is ObfImageSource.Symbol && imageBitmap == null
     
     Card(
         modifier = Modifier
@@ -580,7 +598,8 @@ fun ObfButtonItem(
                 verticalArrangement = Arrangement.Center,
                 modifier = Modifier.fillMaxSize()
             ) {
-                val showImg = settings.showSymbols && (imageBitmap != null || !imageModel.isNullOrBlank())
+                val showImg = settings.showSymbols &&
+                    (imageBitmap != null || !imageModel.isNullOrBlank() || symbolUnavailable)
                 val showLbl = settings.showLabels && !(button.label.isNullOrBlank() && button.vocalization.isNullOrBlank())
 
                 if (settings.labelAtTop && showImg && showLbl) {
@@ -595,21 +614,37 @@ fun ObfButtonItem(
                         overflow = TextOverflow.Ellipsis
                     )
                     Spacer(modifier = Modifier.height(4.dp))
-                    BoardSymbolImage(
-                        bitmap = imageBitmap,
-                        model = imageModel,
-                        contentDescription = button.label,
-                        modifier = Modifier.weight(1f).fillMaxWidth().padding(2.dp)
-                    )
-                } else {
-                    // Normal order (Image at Top)
-                    if (showImg) {
+                    if (symbolUnavailable) {
+                        SymbolUnavailablePlaceholder(
+                            symbolSet = (imageSource as ObfImageSource.Symbol).symbol.set,
+                            modifier = Modifier.weight(1f).fillMaxWidth().padding(2.dp),
+                            contentColor = contentColor
+                        )
+                    } else {
                         BoardSymbolImage(
                             bitmap = imageBitmap,
                             model = imageModel,
                             contentDescription = button.label,
                             modifier = Modifier.weight(1f).fillMaxWidth().padding(2.dp)
                         )
+                    }
+                } else {
+                    // Normal order (Image at Top)
+                    if (showImg) {
+                        if (symbolUnavailable) {
+                            SymbolUnavailablePlaceholder(
+                                symbolSet = (imageSource as ObfImageSource.Symbol).symbol.set,
+                                modifier = Modifier.weight(1f).fillMaxWidth().padding(2.dp),
+                                contentColor = contentColor
+                            )
+                        } else {
+                            BoardSymbolImage(
+                                bitmap = imageBitmap,
+                                model = imageModel,
+                                contentDescription = button.label,
+                                modifier = Modifier.weight(1f).fillMaxWidth().padding(2.dp)
+                            )
+                        }
                     }
                     if (showLbl) {
                         val labelText = button.label ?: button.vocalization ?: ""
@@ -648,6 +683,29 @@ private fun BoardSymbolImage(
             contentDescription = contentDescription,
             contentScale = ContentScale.Fit,
             modifier = modifier
+        )
+    }
+}
+
+@Composable
+private fun SymbolUnavailablePlaceholder(
+    symbolSet: String?,
+    modifier: Modifier,
+    contentColor: Color
+) {
+    val message = if (symbolSet.isNullOrBlank()) {
+        stringResource(Res.string.board_symbol_unavailable)
+    } else {
+        stringResource(Res.string.board_symbol_unavailable_set, symbolSet)
+    }
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.labelSmall,
+            color = contentColor.copy(alpha = 0.7f),
+            textAlign = TextAlign.Center,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.draw.scale
 import io.github.jdreioe.wingmate.domain.AacLogger
+import io.github.jdreioe.wingmate.domain.Base64Decoder
 import io.github.jdreioe.wingmate.domain.SpeechService
 import io.github.jdreioe.wingmate.domain.withLanguageOverride
 import io.github.jdreioe.wingmate.application.VoiceUseCase
@@ -507,7 +508,7 @@ fun ObfButtonItem(
                 runCatching {
                     val data = imageSource.data
                     val base64 = if (data.contains(",")) data.substringAfter(",") else data
-                    val bytes = java.util.Base64.getDecoder().decode(base64)
+                    val bytes = Base64Decoder.decode(base64)
                     bytes.toComposeImageBitmap()
                 }.getOrNull()
             }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -24,5 +24,10 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
             }
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/Base64Decoder.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/Base64Decoder.kt
@@ -1,0 +1,44 @@
+package io.github.jdreioe.wingmate.domain
+
+object Base64Decoder {
+    private val table by lazy {
+        val t = IntArray(128) { -1 }
+        val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+        alphabet.forEachIndexed { index, c -> t[c.code] = index }
+        t
+    }
+
+    fun decode(input: String): ByteArray {
+        val cleaned = input.filterNot { it.isWhitespace() }
+        if (cleaned.isEmpty()) return ByteArray(0)
+
+        val padding = when {
+            cleaned.endsWith("==") -> 2
+            cleaned.endsWith("=") -> 1
+            else -> 0
+        }
+        val out = ByteArray(cleaned.length / 4 * 3 - padding)
+        var outIndex = 0
+        var i = 0
+        while (i < cleaned.length) {
+            val c0 = charValue(cleaned[i])
+            val c1 = charValue(cleaned[i + 1])
+            val c2 = if (cleaned[i + 2] == '=') 0 else charValue(cleaned[i + 2])
+            val c3 = if (cleaned[i + 3] == '=') 0 else charValue(cleaned[i + 3])
+            val triple = (c0 shl 18) or (c1 shl 12) or (c2 shl 6) or c3
+            if (outIndex < out.size) out[outIndex++] = ((triple shr 16) and 0xFF).toByte()
+            if (outIndex < out.size) out[outIndex++] = ((triple shr 8) and 0xFF).toByte()
+            if (outIndex < out.size) out[outIndex++] = (triple and 0xFF).toByte()
+            i += 4
+        }
+        return out
+    }
+
+    fun decodeOrNull(input: String): ByteArray? = runCatching { decode(input) }.getOrNull()
+
+    private fun charValue(c: Char): Int {
+        val v = table.getOrElse(c.code) { -1 }
+        require(v >= 0) { "Invalid base64 char: $c" }
+        return v
+    }
+}

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfImageSource.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfImageSource.kt
@@ -1,0 +1,31 @@
+package io.github.jdreioe.wingmate.domain.obf
+
+/**
+ * Resolved image source following the OBF priority order:
+ * **data → path → url → symbol**.
+ */
+sealed class ObfImageSource {
+    data class DataUri(val data: String) : ObfImageSource()
+    data class Path(val path: String) : ObfImageSource()
+    data class Url(val url: String) : ObfImageSource()
+    data class Symbol(val symbol: ObfSymbol) : ObfImageSource()
+    data object None : ObfImageSource()
+}
+
+/**
+ * Pick the highest-priority non-blank image reference on [image].
+ */
+fun resolveObfImageSource(image: ObfImage?): ObfImageSource {
+    if (image == null) return ObfImageSource.None
+    val data = image.data?.takeIf { it.isNotBlank() }
+    if (data != null) return ObfImageSource.DataUri(data)
+    val path = image.path?.takeIf { it.isNotBlank() }
+    if (path != null) return ObfImageSource.Path(path)
+    val url = image.url?.takeIf { it.isNotBlank() }
+    if (url != null) return ObfImageSource.Url(url)
+    val symbol = image.symbol
+    if (symbol != null && (!symbol.set.isNullOrBlank() || !symbol.filename.isNullOrBlank() || !symbol.libraryKey.isNullOrBlank())) {
+        return ObfImageSource.Symbol(symbol)
+    }
+    return ObfImageSource.None
+}

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfModels.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfModels.kt
@@ -67,7 +67,17 @@ data class ObfImage(
     val url: String? = null, // External URL
     val path: String? = null, // Relative path in OBZ or local storage
     val data: String? = null,  // Base64 data URI
+    /** Proprietary symbol-set reference (e.g. SymbolStix). Lowest priority after data/path/url. */
+    val symbol: ObfSymbol? = null,
     val license: ObfLicense? = null
+)
+
+@Serializable
+data class ObfSymbol(
+    val set: String? = null,
+    val filename: String? = null,
+    @SerialName("library_key")
+    val libraryKey: String? = null
 )
 
 @Serializable

--- a/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfImageSourceTest.kt
+++ b/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfImageSourceTest.kt
@@ -1,0 +1,68 @@
+package io.github.jdreioe.wingmate.domain.obf
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ObfImageSourceTest {
+
+    @Test
+    fun prefersDataOverPathUrlAndSymbol() {
+        val image = ObfImage(
+            id = "1",
+            data = "data:image/png;base64,abc",
+            path = "images/a.png",
+            url = "https://example.com/a.png",
+            symbol = ObfSymbol(set = "symbolstix", filename = "happy.png")
+        )
+        assertEquals(ObfImageSource.DataUri("data:image/png;base64,abc"), resolveObfImageSource(image))
+    }
+
+    @Test
+    fun prefersPathOverUrlAndSymbol() {
+        val image = ObfImage(
+            id = "1",
+            path = "images/a.png",
+            url = "https://example.com/a.png",
+            symbol = ObfSymbol(set = "symbolstix", filename = "happy.png")
+        )
+        assertEquals(ObfImageSource.Path("images/a.png"), resolveObfImageSource(image))
+    }
+
+    @Test
+    fun prefersUrlOverSymbol() {
+        val image = ObfImage(
+            id = "1",
+            url = "https://example.com/a.png",
+            symbol = ObfSymbol(set = "symbolstix", filename = "happy.png")
+        )
+        assertEquals(ObfImageSource.Url("https://example.com/a.png"), resolveObfImageSource(image))
+    }
+
+    @Test
+    fun fallsBackToSymbol() {
+        val symbol = ObfSymbol(set = "symbolstix", filename = "happy.png")
+        val image = ObfImage(id = "1", symbol = symbol)
+        assertEquals(ObfImageSource.Symbol(symbol), resolveObfImageSource(image))
+    }
+
+    @Test
+    fun blankFieldsAreIgnored() {
+        val image = ObfImage(
+            id = "1",
+            data = "   ",
+            path = "",
+            url = null,
+            symbol = ObfSymbol(set = "pcs", filename = "yes.png")
+        )
+        val source = resolveObfImageSource(image)
+        assertTrue(source is ObfImageSource.Symbol)
+        assertEquals("pcs", (source as ObfImageSource.Symbol).symbol.set)
+    }
+
+    @Test
+    fun noneWhenEmpty() {
+        assertEquals(ObfImageSource.None, resolveObfImageSource(null))
+        assertEquals(ObfImageSource.None, resolveObfImageSource(ObfImage(id = "1")))
+    }
+}


### PR DESCRIPTION
## Summary
- Model `symbol` on `ObfImage` per spec.  
- Priority order: data → path → url → symbol.  
- Symbol-only boards show an "unavailable" placeholder with set name.

Closes #27

## Test plan
- [x] `./gradlew :core:domain:jvmTest --tests ObfImageSourceTest`
- [x] `./gradlew :composeApp:compileAndroidMain`