### PR TITLE
feat: #28 apply OBF strings localization when rendering boards

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -193,24 +193,8 @@ android {
     if (versionPropsFile.exists()) {
         versionPropsFile.inputStream().use { versionProps.load(it) }
     }
-
-    val isPublishOrBundleTask = gradle.startParameter.taskNames.any { taskName ->
-        taskName.contains("publishRelease") || taskName.contains("bundleRelease")
-    }
-
-    val vCode: Int
-    val vName: String
-    if (isPublishOrBundleTask) {
-        val currentCode = (versionProps.getProperty("versionCode") ?: "1").toInt()
-        vCode = currentCode + 1
-        versionProps.setProperty("versionCode", vCode.toString())
-        vName = versionProps.getProperty("versionName") ?: "1.0"
-        versionPropsFile.outputStream().use { versionProps.store(it, "Auto-incremented by build") }
-        logger.lifecycle("Version code auto-incremented to $vCode")
-    } else {
-        vCode = (versionProps.getProperty("versionCode") ?: "1").toInt()
-        vName = versionProps.getProperty("versionName") ?: "1.0"
-    }
+    val vCode = (versionProps.getProperty("versionCode") ?: "1").toInt()
+    val vName = versionProps.getProperty("versionName") ?: "1.0"
 
     val openSymbolsSecret = providers.provider { resolveOpenSymbolsSecretFromInfisical() }
         .orElse(providers.environmentVariable("WINGMATE_OPENSYMBOLS_SECRET"))
@@ -242,6 +226,22 @@ android {
             toBuildConfigStringLiteral(openSymbolsSecret.get())
         )
     }
+
+    tasks.register("incrementVersionCode") {
+        doLast {
+            val currentCode = versionProps.getProperty("versionCode")?.toInt() ?: 1
+            versionProps.setProperty("versionCode", (currentCode + 1).toString())
+            versionPropsFile.outputStream().use { versionProps.store(it, "Auto-incremented by build") }
+            println("Version code incremented to ${currentCode + 1}")
+        }
+    }
+
+    tasks.configureEach {
+        if (name == "bundleRelease" || name == "bundleReleaseStandard" || name == "bundleReleaseAab") {
+            dependsOn("incrementVersionCode")
+        }
+    }
+
 
     buildFeatures {
         compose = true

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -193,8 +193,24 @@ android {
     if (versionPropsFile.exists()) {
         versionPropsFile.inputStream().use { versionProps.load(it) }
     }
-    val vCode = (versionProps.getProperty("versionCode") ?: "1").toInt()
-    val vName = versionProps.getProperty("versionName") ?: "1.0"
+
+    val isPublishOrBundleTask = gradle.startParameter.taskNames.any { taskName ->
+        taskName.contains("publishRelease") || taskName.contains("bundleRelease")
+    }
+
+    val vCode: Int
+    val vName: String
+    if (isPublishOrBundleTask) {
+        val currentCode = (versionProps.getProperty("versionCode") ?: "1").toInt()
+        vCode = currentCode + 1
+        versionProps.setProperty("versionCode", vCode.toString())
+        vName = versionProps.getProperty("versionName") ?: "1.0"
+        versionPropsFile.outputStream().use { versionProps.store(it, "Auto-incremented by build") }
+        logger.lifecycle("Version code auto-incremented to $vCode")
+    } else {
+        vCode = (versionProps.getProperty("versionCode") ?: "1").toInt()
+        vName = versionProps.getProperty("versionName") ?: "1.0"
+    }
 
     val openSymbolsSecret = providers.provider { resolveOpenSymbolsSecretFromInfisical() }
         .orElse(providers.environmentVariable("WINGMATE_OPENSYMBOLS_SECRET"))
@@ -226,22 +242,6 @@ android {
             toBuildConfigStringLiteral(openSymbolsSecret.get())
         )
     }
-
-    tasks.register("incrementVersionCode") {
-        doLast {
-            val currentCode = versionProps.getProperty("versionCode")?.toInt() ?: 1
-            versionProps.setProperty("versionCode", (currentCode + 1).toString())
-            versionPropsFile.outputStream().use { versionProps.store(it, "Auto-incremented by build") }
-            println("Version code incremented to ${currentCode + 1}")
-        }
-    }
-
-    tasks.configureEach {
-        if (name == "bundleRelease" || name == "bundleReleaseStandard" || name == "bundleReleaseAab") {
-            dependsOn("incrementVersionCode")
-        }
-    }
-
 
     buildFeatures {
         compose = true

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -86,6 +86,7 @@ import io.github.jdreioe.wingmate.domain.obf.ObfButton
 import io.github.jdreioe.wingmate.domain.obf.ObfGrid
 import io.github.jdreioe.wingmate.domain.obf.ObfImage
 import io.github.jdreioe.wingmate.domain.obf.ObfLoadBoard
+import io.github.jdreioe.wingmate.domain.obf.resolveObfLocalizedString
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -892,7 +893,12 @@ private fun BoardSetWorkspaceScreen(
                                 selectedBoardId?.let { boardStack = boardStack + it }
                                 selectedBoardId = linkedBoard.id
                             } else {
-                                val spokenText = (button.vocalization ?: button.label).orEmpty().trim()
+                                val resolved = resolveObfLocalizedString(
+                                    activeBoard?.strings ?: emptyMap(),
+                                    settings.primaryLanguage,
+                                    button.vocalization ?: button.label
+                                )
+                                val spokenText = resolved?.trim().orEmpty()
                                 if (spokenText.isNotEmpty()) {
                                     selectedButtons = selectedButtons + (button to null)
                                     scope.launch(Dispatchers.IO) {
@@ -910,7 +916,12 @@ private fun BoardSetWorkspaceScreen(
                         } else null,
                         onSpeakSentence = {
                             val speechParts = selectedButtons.mapNotNull { (button, _) ->
-                                (button.vocalization ?: button.label)
+                                val resolved = resolveObfLocalizedString(
+                                    activeBoard?.strings ?: emptyMap(),
+                                    settings.primaryLanguage,
+                                    button.vocalization ?: button.label
+                                )
+                                resolved
                                     ?.trim()
                                     ?.takeIf(String::isNotEmpty)
                                     ?.let { text -> text to button.locale }

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -590,10 +590,9 @@ fun ObfButtonItem(
                 modifier = Modifier.fillMaxSize()
             ) {
                 val showImg = settings.showSymbols && (imageBitmap != null || !imageModel.isNullOrBlank())
-                    val showLbl = settings.showLabels && !(displayLabel.isNullOrBlank() && displayVocalization.isNullOrBlank())
+                val showLbl = settings.showLabels && !(displayLabel.isNullOrBlank() && displayVocalization.isNullOrBlank())
 
                 if (settings.labelAtTop && showImg && showLbl) {
-                    // Label at Top
                     val labelText = displayLabel ?: displayVocalization ?: ""
                     Text(
                         text = labelText,
@@ -608,15 +607,14 @@ fun ObfButtonItem(
                         bitmap = imageBitmap,
                         model = imageModel,
                         contentDescription = displayLabel,
-                            modifier = Modifier.weight(1f).fillMaxWidth().padding(2.dp)
-                        )
-                    } else {
-                        // Normal order (Image at Top)
-                        if (showImg) {
-                            BoardSymbolImage(
-                                bitmap = imageBitmap,
-                                model = imageModel,
-                                contentDescription = displayLabel,
+                        modifier = Modifier.weight(1f).fillMaxWidth().padding(2.dp)
+                    )
+                } else {
+                    if (showImg) {
+                        BoardSymbolImage(
+                            bitmap = imageBitmap,
+                            model = imageModel,
+                            contentDescription = displayLabel,
                             modifier = Modifier.weight(1f).fillMaxWidth().padding(2.dp)
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.sp
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
 import io.github.jdreioe.wingmate.domain.obf.ObfButton
 import io.github.jdreioe.wingmate.domain.obf.ObfImage
+import io.github.jdreioe.wingmate.domain.obf.resolveObfLocalizedString
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -146,7 +147,9 @@ fun ObfBoardView(
                                 onCellClick?.invoke(item.row, item.column, button)
                                     ?: onButtonClick(button)
                             },
-                            isEditMode = isEditMode
+                            isEditMode = isEditMode,
+                            boardStrings = board.strings,
+                            locale = settings.primaryLanguage
                         )
                     } else if (isEditMode && button == null) {
                         OutlinedCard(
@@ -187,7 +190,9 @@ fun ObfBoardView(
                                 extractedImageBytes = button.imageId?.let { 
                                     image?.path?.let { path -> extractedImages[path] }
                                 },
-                                onClick = { onButtonClick(button) }
+                                onClick = { onButtonClick(button) },
+                                boardStrings = board.strings,
+                                locale = settings.primaryLanguage
                             )
                         }
                     }
@@ -409,12 +414,16 @@ fun ObfButtonItem(
     image: ObfImage? = null,
     extractedImageBytes: ByteArray? = null,
     onClick: () -> Unit,
-    isEditMode: Boolean = false
+    isEditMode: Boolean = false,
+    boardStrings: Map<String, Map<String, String>> = emptyMap(),
+    locale: String? = null
 ) {
     val speechService: SpeechService = koinInject()
     val voiceUseCase: VoiceUseCase = koinInject()
     val aacLogger: AacLogger = koinInject()
     val settings by rememberReactiveSettings()
+    val displayLabel = resolveObfLocalizedString(boardStrings, locale, button.label)
+    val displayVocalization = resolveObfLocalizedString(boardStrings, locale, button.vocalization)
     
     // Pulse animation state
     var isSelected by remember { mutableStateOf(false) }
@@ -438,7 +447,7 @@ fun ObfButtonItem(
             
             // Auditory Fishing: Whisper label on hover start (fire-and-forget)
             if (settings.auditoryFishingEnabled) {
-                val label = button.label ?: button.vocalization ?: ""
+                val label = displayLabel ?: displayVocalization ?: ""
                 if (label.isNotBlank()) {
                     fishingScope.launch {
                         runCatching {
@@ -458,7 +467,7 @@ fun ObfButtonItem(
                 if (elapsed.toLong() >= duration.toLong()) {
                     isSelected = true
                     onClick()
-                    aacLogger.logButtonClick(button.label ?: "", phraseId = button.id)
+                    aacLogger.logButtonClick(displayLabel ?: "", phraseId = button.id)
                     dwellProgress = 0f
                     break
                 }
@@ -529,7 +538,7 @@ fun ObfButtonItem(
                 val primaryAction = { 
                     isSelected = true
                     onClick()
-                    aacLogger.logButtonClick(button.label ?: "", phraseId = button.id)
+                    aacLogger.logButtonClick(displayLabel ?: "", phraseId = button.id)
                 }
                 
                 if (settings.holdToSelectMillis > 0 && !isEditMode) {
@@ -581,11 +590,11 @@ fun ObfButtonItem(
                 modifier = Modifier.fillMaxSize()
             ) {
                 val showImg = settings.showSymbols && (imageBitmap != null || !imageModel.isNullOrBlank())
-                val showLbl = settings.showLabels && !(button.label.isNullOrBlank() && button.vocalization.isNullOrBlank())
+                    val showLbl = settings.showLabels && !(displayLabel.isNullOrBlank() && displayVocalization.isNullOrBlank())
 
                 if (settings.labelAtTop && showImg && showLbl) {
                     // Label at Top
-                    val labelText = button.label ?: button.vocalization ?: ""
+                    val labelText = displayLabel ?: displayVocalization ?: ""
                     Text(
                         text = labelText,
                         style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
@@ -598,21 +607,21 @@ fun ObfButtonItem(
                     BoardSymbolImage(
                         bitmap = imageBitmap,
                         model = imageModel,
-                        contentDescription = button.label,
-                        modifier = Modifier.weight(1f).fillMaxWidth().padding(2.dp)
-                    )
-                } else {
-                    // Normal order (Image at Top)
-                    if (showImg) {
-                        BoardSymbolImage(
-                            bitmap = imageBitmap,
-                            model = imageModel,
-                            contentDescription = button.label,
+                        contentDescription = displayLabel,
+                            modifier = Modifier.weight(1f).fillMaxWidth().padding(2.dp)
+                        )
+                    } else {
+                        // Normal order (Image at Top)
+                        if (showImg) {
+                            BoardSymbolImage(
+                                bitmap = imageBitmap,
+                                model = imageModel,
+                                contentDescription = displayLabel,
                             modifier = Modifier.weight(1f).fillMaxWidth().padding(2.dp)
                         )
                     }
                     if (showLbl) {
-                        val labelText = button.label ?: button.vocalization ?: ""
+                        val labelText = displayLabel ?: displayVocalization ?: ""
                         Text(
                             text = labelText,
                             style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -24,5 +24,10 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
             }
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfStrings.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfStrings.kt
@@ -1,0 +1,35 @@
+package io.github.jdreioe.wingmate.domain.obf
+
+/**
+ * Resolve a button label or vocalization through the board's `strings` localization table.
+ *
+ * Priority:
+ * 1. Exact locale match (`da-DK` matches `da-DK`).
+ * 2. General-locale match (`da-DK` matches `da`).
+ * 3. Raw attribute value (fallback).
+ *
+ * @param strings the board's per-locale string dictionary (`ObfBoard.strings`)
+ * @param locale the active UI language tag (e.g. `da-DK` or `da`)
+ * @param rawValue the button's `label` or `vocalization` attribute
+ * @return the localized text or [rawValue] when no match
+ */
+fun resolveObfLocalizedString(
+    strings: Map<String, Map<String, String>>,
+    locale: String?,
+    rawValue: String?
+): String? {
+    if (rawValue == null) return null
+    val normalizedLocale = locale?.trim()?.takeIf { it.isNotEmpty() } ?: return rawValue
+
+    val exact = strings[normalizedLocale]?.get(rawValue)
+    if (exact != null) return exact
+
+    val general = strings.entries.firstOrNull { (key, _) ->
+        normalizedLocale.startsWith("$key-", ignoreCase = true) ||
+            key.startsWith("$normalizedLocale-", ignoreCase = true) ||
+            key.equals(normalizedLocale, ignoreCase = true)
+    }?.value?.get(rawValue)
+    if (general != null) return general
+
+    return rawValue
+}

--- a/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfStringsTest.kt
+++ b/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfStringsTest.kt
@@ -1,0 +1,62 @@
+package io.github.jdreioe.wingmate.domain.obf
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ObfStringsTest {
+
+    private val strings = mapOf(
+        "da" to mapOf(
+            "Hello" to "Hej",
+            "Food" to "Mad"
+        ),
+        "en" to mapOf(
+            "Hello" to "Hello",
+            "Food" to "Food"
+        ),
+        "da-DK" to mapOf(
+            "Morning" to "Godmorgen"
+        )
+    )
+
+    @Test
+    fun exactLocaleMatch() {
+        assertEquals("Godmorgen", resolveObfLocalizedString(strings, "da-DK", "Morning"))
+    }
+
+    @Test
+    fun generalLocaleFallback() {
+        assertEquals("Hej", resolveObfLocalizedString(strings, "da-DK", "Hello"))
+    }
+
+    @Test
+    fun directGeneralMatch() {
+        assertEquals("Hej", resolveObfLocalizedString(strings, "da", "Hello"))
+    }
+
+    @Test
+    fun fallsBackToRawValue() {
+        assertEquals("Goodbye", resolveObfLocalizedString(strings, "da-DK", "Goodbye"))
+    }
+
+    @Test
+    fun nullLocaleReturnsRaw() {
+        assertEquals("Hello", resolveObfLocalizedString(strings, null, "Hello"))
+    }
+
+    @Test
+    fun nullRawReturnsNull() {
+        assertNull(resolveObfLocalizedString(strings, "da", null))
+    }
+
+    @Test
+    fun emptyLocaleReturnsRaw() {
+        assertEquals("Hello", resolveObfLocalizedString(strings, "  ", "Hello"))
+    }
+
+    @Test
+    fun emptyStringsMap() {
+        assertEquals("Hi", resolveObfLocalizedString(emptyMap(), "da", "Hi"))
+    }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Auto-incremented by build
-#Mon Jul 20 17:20:46 CEST 2026
-versionCode=23
+#Mon Jul 20 20:55:44 CEST 2026
+versionCode=26
 versionName=0.6


### PR DESCRIPTION
Closes #28

- Add resolveObfLocalizedString() with exact locale, general locale, and raw-value fallback in domain
- Wire into ObfButtonItem via displayLabel/displayVocalization for label rendering, vocalization, logging, and contentDescription
- Add commonTest dependencies to core/domain build.gradle.kts

All 8 unit tests pass.