### PR TITLE
feat: #29 render absolute-positioned OBF buttons

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -90,11 +90,65 @@ fun ObfBoardView(
 ) {
     val settings by rememberReactiveSettings()
     val imagesById = remember(board) { board.images.associateBy { it.id } }
+    // Absolute positioning: if every button has top/left/width/height, render fractionally
+    val isAbsoluteLayout = remember(board) {
+        board.buttons.isNotEmpty() && board.buttons.all {
+            it.top != null && it.left != null && it.width != null && it.height != null
+        }
+    }
     // If grid is defined, use it. Otherwise, just listing buttons (fallback)
     val grid = board.grid
     val buttonsById = remember(board) { board.buttons.associateBy { it.id } }
 
-    if (grid != null) {
+    if (isAbsoluteLayout) {
+        Column(modifier = modifier.fillMaxSize().padding(8.dp)) {
+            if (showMessageBar) {
+                SymbolBar(
+                    selectedButtons = selectedButtons,
+                    imagesById = imagesById,
+                    extractedImages = extractedImages,
+                    onSpeak = onSpeakSentence,
+                    onSave = onSaveSentence,
+                    isSaveEnabled = isSaveSentenceEnabled,
+                    onDelete = onDeleteLast,
+                    onClear = onClearSentence,
+                    showSentenceText = showSentenceText,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(if (showSentenceText) 260.dp else 100.dp)
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+            BoxWithConstraints(modifier = Modifier.fillMaxWidth().then(if (showMessageBar) Modifier.weight(1f) else Modifier)) {
+                val containerWidth = maxWidth
+                val containerHeight = maxHeight
+                board.buttons.forEach { button ->
+                    val left = (button.left ?: 0.0) * containerWidth.value
+                    val top = (button.top ?: 0.0) * containerHeight.value
+                    val w = (button.width ?: 0.1) * containerWidth.value
+                    val h = (button.height ?: 0.1) * containerHeight.value
+                    if (!button.hidden || isEditMode) {
+                        val image = button.imageId?.let { imagesById[it] }
+                        Box(
+                            modifier = Modifier
+                                .offset(x = left.dp, y = top.dp)
+                                .size(width = w.dp, height = h.dp)
+                        ) {
+                            ObfButtonItem(
+                                button = button,
+                                image = image,
+                                extractedImageBytes = button.imageId?.let {
+                                    image?.path?.let { path -> extractedImages[path] }
+                                },
+                                onClick = { onButtonClick(button) },
+                                isEditMode = isEditMode
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    } else if (grid != null) {
         val columns = grid.columns.coerceAtLeast(1)
         val rows = grid.rows.coerceAtLeast(1)
         

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -91,18 +91,14 @@ fun ObfBoardView(
     val settings by rememberReactiveSettings()
     val imagesById = remember(board) { board.images.associateBy { it.id } }
     // Absolute positioning: if every button has top/left/width/height, render fractionally
-    val isAbsoluteLayout = remember(board) {
-        board.buttons.isNotEmpty() && board.buttons.all {
-            it.top != null && it.left != null && it.width != null && it.height != null
-        }
-    }
+    val isAbsoluteLayout = remember(board) { board.isAbsoluteLayout }
     // If grid is defined, use it. Otherwise, just listing buttons (fallback)
     val grid = board.grid
     val buttonsById = remember(board) { board.buttons.associateBy { it.id } }
 
     if (isAbsoluteLayout) {
-        Column(modifier = modifier.fillMaxSize().padding(8.dp)) {
-            if (showMessageBar) {
+        if (showMessageBar) {
+            Column(modifier = modifier.fillMaxSize().padding(8.dp)) {
                 SymbolBar(
                     selectedButtons = selectedButtons,
                     imagesById = imagesById,
@@ -118,34 +114,13 @@ fun ObfBoardView(
                         .height(if (showSentenceText) 260.dp else 100.dp)
                 )
                 Spacer(modifier = Modifier.height(8.dp))
-            }
-            BoxWithConstraints(modifier = Modifier.fillMaxWidth().then(if (showMessageBar) Modifier.weight(1f) else Modifier)) {
-                val containerWidth = maxWidth
-                val containerHeight = maxHeight
-                board.buttons.forEach { button ->
-                    val left = (button.left ?: 0.0) * containerWidth.value
-                    val top = (button.top ?: 0.0) * containerHeight.value
-                    val w = (button.width ?: 0.1) * containerWidth.value
-                    val h = (button.height ?: 0.1) * containerHeight.value
-                    if (!button.hidden || isEditMode) {
-                        val image = button.imageId?.let { imagesById[it] }
-                        Box(
-                            modifier = Modifier
-                                .offset(x = left.dp, y = top.dp)
-                                .size(width = w.dp, height = h.dp)
-                        ) {
-                            ObfButtonItem(
-                                button = button,
-                                image = image,
-                                extractedImageBytes = button.imageId?.let {
-                                    image?.path?.let { path -> extractedImages[path] }
-                                },
-                                onClick = { onButtonClick(button) },
-                                isEditMode = isEditMode
-                            )
-                        }
-                    }
+                BoxWithConstraints(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                    renderAbsoluteButtons(board, imagesById, extractedImages, isEditMode, onButtonClick)
                 }
+            }
+        } else {
+            BoxWithConstraints(modifier = modifier.fillMaxSize().padding(8.dp)) {
+                renderAbsoluteButtons(board, imagesById, extractedImages, isEditMode, onButtonClick)
             }
         }
     } else if (grid != null) {
@@ -677,6 +652,42 @@ fun ObfButtonItem(
                         )
                     }
                 }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BoxWithConstraintsScope.renderAbsoluteButtons(
+    board: ObfBoard,
+    imagesById: Map<String, ObfImage>,
+    extractedImages: Map<String, ByteArray>,
+    isEditMode: Boolean,
+    onButtonClick: (ObfButton) -> Unit
+) {
+    val containerWidth = maxWidth
+    val containerHeight = maxHeight
+    board.buttons.forEach { button ->
+        val left = (button.left ?: 0.0) * containerWidth.value
+        val top = (button.top ?: 0.0) * containerHeight.value
+        val w = (button.width ?: 0.1) * containerWidth.value
+        val h = (button.height ?: 0.1) * containerHeight.value
+        if (!button.hidden || isEditMode) {
+            val image = button.imageId?.let { imagesById[it] }
+            Box(
+                modifier = Modifier
+                    .offset(x = left.dp, y = top.dp)
+                    .size(width = w.dp, height = h.dp)
+            ) {
+                ObfButtonItem(
+                    button = button,
+                    image = image,
+                    extractedImageBytes = button.imageId?.let {
+                        image?.path?.let { path -> extractedImages[path] }
+                    },
+                    onClick = { onButtonClick(button) },
+                    isEditMode = isEditMode
+                )
             }
         }
     }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -24,5 +24,10 @@ kotlin {
                 implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
             }
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
+        }
     }
 }

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfModels.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfModels.kt
@@ -15,14 +15,18 @@ data class ObfBoard(
     @SerialName("background_color")
     val backgroundColor: String? = null,
     val buttons: List<ObfButton> = emptyList(),
-    val grid: ObfGrid? = null,
     val images: List<ObfImage> = emptyList(),
-    val sounds: List<ObfSound> = emptyList(),
-    // String lists for localization
+    val grid: ObfGrid? = null,
     val strings: Map<String, Map<String, String>> = emptyMap(),
-    // License info
+    val localeMap: Map<String, String> = emptyMap(),
     val license: ObfLicense? = null
-)
+) {
+    /** True when every button has all four absolute-positioning attributes defined. */
+    val isAbsoluteLayout: Boolean
+        get() = buttons.isNotEmpty() && buttons.all {
+            it.top != null && it.left != null && it.width != null && it.height != null
+        }
+}
 
 @Serializable
 data class ObfButton(

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfModels.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfModels.kt
@@ -17,8 +17,8 @@ data class ObfBoard(
     val buttons: List<ObfButton> = emptyList(),
     val images: List<ObfImage> = emptyList(),
     val grid: ObfGrid? = null,
+    val sounds: List<ObfSound> = emptyList(),
     val strings: Map<String, Map<String, String>> = emptyMap(),
-    val localeMap: Map<String, String> = emptyMap(),
     val license: ObfLicense? = null
 ) {
     /** True when every button has all four absolute-positioning attributes defined. */

--- a/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfBoardLayoutTest.kt
+++ b/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfBoardLayoutTest.kt
@@ -1,0 +1,57 @@
+package io.github.jdreioe.wingmate.domain.obf
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ObfBoardLayoutTest {
+
+    @Test
+    fun allButtonsHavePositionFields_returnsTrue() {
+        val board = ObfBoard(
+            format = "open-board-0.1",
+            id = "b",
+            buttons = listOf(
+                ObfButton(id = "1", top = 0.0, left = 0.0, width = 0.5, height = 0.5),
+                ObfButton(id = "2", top = 0.0, left = 0.5, width = 0.5, height = 0.5)
+            )
+        )
+        assertTrue(board.isAbsoluteLayout)
+    }
+
+    @Test
+    fun anyButtonMissingPosition_returnsFalse() {
+        val board = ObfBoard(
+            format = "open-board-0.1",
+            id = "b",
+            buttons = listOf(
+                ObfButton(id = "1", top = 0.0, left = 0.0, width = 0.5, height = 0.5),
+                ObfButton(id = "2", top = 0.0, left = 0.5, width = null, height = 0.5)
+            )
+        )
+        assertFalse(board.isAbsoluteLayout)
+    }
+
+    @Test
+    fun noButtons_returnsFalse() {
+        val board = ObfBoard(
+            format = "open-board-0.1",
+            id = "b",
+            buttons = emptyList()
+        )
+        assertFalse(board.isAbsoluteLayout)
+    }
+
+    @Test
+    fun allPositionFieldsAreNull_returnsFalse() {
+        val board = ObfBoard(
+            format = "open-board-0.1",
+            id = "b",
+            buttons = listOf(
+                ObfButton(id = "1"),
+                ObfButton(id = "2")
+            )
+        )
+        assertFalse(board.isAbsoluteLayout)
+    }
+}


### PR DESCRIPTION
Closes #29

When every button defines top/left/width/height (fractions 0.0-1.0), render using BoxWithConstraints with fractional positioning and sizing in button order instead of the grid layout.