### PR TITLE
feat: #30 export board sets as OBZ

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -613,6 +613,7 @@ private fun BoardSetWorkspaceScreen(
     val speechService = koinInject<SpeechService>()
     val voiceUseCase = koinInject<VoiceUseCase>()
     val settings by rememberReactiveSettings()
+    val shareService = koinInject<io.github.jdreioe.wingmate.platform.ShareService>()
     val scope = rememberCoroutineScope()
     var savedGraph by remember(boardSetId) { mutableStateOf<BoardSetGraph?>(null) }
     var editSession by remember(boardSetId) { mutableStateOf<BoardSetEditSession?>(null) }
@@ -811,6 +812,30 @@ private fun BoardSetWorkspaceScreen(
                             Icon(
                                 Icons.Default.Keyboard,
                                 contentDescription = stringResource(Res.string.mode_switch_to_keyboard)
+                            )
+                        }
+                        IconButton(onClick = {
+                            scope.launch {
+                                val graph = activeGraph
+                                if (graph != null) {
+                                    val obzBytes = useCase.exportBoardSetAsObz(graph.boardSet.id)
+                                    if (obzBytes != null) {
+                                        val fileName = "${graph.boardSet.name}.obz"
+                                        val shared = shareService?.shareFile(fileName, obzBytes)
+                                        statusMessage = if (shared == true) {
+                                            "Exported ${graph.boardSet.name}.obz"
+                                        } else {
+                                            "Export saved (${obzBytes.size} bytes)"
+                                        }
+                                    } else {
+                                        statusMessage = "Export failed: no boards"
+                                    }
+                                }
+                            }
+                        }) {
+                            Icon(
+                                Icons.Default.ImportExport,
+                                contentDescription = stringResource(Res.string.phrase_screen_import_export_data)
                             )
                         }
                         if (selectedBoardId != activeGraph?.boardSet?.rootBoardId) {

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -613,7 +613,8 @@ private fun BoardSetWorkspaceScreen(
     val speechService = koinInject<SpeechService>()
     val voiceUseCase = koinInject<VoiceUseCase>()
     val settings by rememberReactiveSettings()
-    val shareService = remember { org.koin.compose.getKoin().getOrNull<io.github.jdreioe.wingmate.platform.ShareService>() }
+    val koin = org.koin.compose.getKoin()
+    val shareService = remember(koin) { koin.getOrNull<io.github.jdreioe.wingmate.platform.ShareService>() }
     val scope = rememberCoroutineScope()
     var savedGraph by remember(boardSetId) { mutableStateOf<BoardSetGraph?>(null) }
     var editSession by remember(boardSetId) { mutableStateOf<BoardSetEditSession?>(null) }

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -632,6 +632,7 @@ private fun BoardSetWorkspaceScreen(
     var showRenameBoardDialog by remember { mutableStateOf(false) }
     var showDeleteBoardDialog by remember { mutableStateOf(false) }
     var isSavingSentence by remember(boardSetId) { mutableStateOf(false) }
+    var isExporting by remember(boardSetId) { mutableStateOf(false) }
     var isFullscreen by remember(boardSetId) { mutableStateOf(false) }
     val unlockToEditMessage = stringResource(Res.string.board_workspace_unlock_to_edit)
     val savedMessage = stringResource(Res.string.board_workspace_saved)
@@ -814,25 +815,42 @@ private fun BoardSetWorkspaceScreen(
                                 contentDescription = stringResource(Res.string.mode_switch_to_keyboard)
                             )
                         }
-                        IconButton(onClick = {
-                            scope.launch {
-                                val graph = activeGraph
-                                if (graph != null) {
-                                    val obzBytes = useCase.exportBoardSetAsObz(graph.boardSet.id)
-                                    if (obzBytes != null) {
-                                        val fileName = "${graph.boardSet.name}.obz"
-                                        val shared = shareService?.shareFile(fileName, obzBytes)
-                                        statusMessage = if (shared == true) {
-                                            "Exported ${graph.boardSet.name}.obz"
+                        IconButton(
+                            onClick = {
+                                scope.launch {
+                                    isExporting = true
+                                    statusMessage = null
+                                    try {
+                                        val graph = activeGraph
+                                        if (graph == null) {
+                                            statusMessage = "Export failed: no board set loaded"
                                         } else {
-                                            "Export saved (${obzBytes.size} bytes)"
+                                            val obzBytes = useCase.exportBoardSetAsObz(graph.boardSet.id)
+                                            if (obzBytes != null) {
+                                                val fileName = "${graph.boardSet.name}.obz"
+                                                if (shareService != null) {
+                                                    val shared = shareService.shareFile(fileName, obzBytes)
+                                                    statusMessage = if (shared) {
+                                                        "Exported ${graph.boardSet.name}.obz"
+                                                    } else {
+                                                        "Export cancelled"
+                                                    }
+                                                } else {
+                                                    statusMessage = "Export saved (${obzBytes.size} bytes)"
+                                                }
+                                            } else {
+                                                statusMessage = "Export failed: no boards"
+                                            }
                                         }
-                                    } else {
-                                        statusMessage = "Export failed: no boards"
+                                    } catch (e: Exception) {
+                                        statusMessage = "Export failed: ${e.message ?: "unknown error"}"
+                                    } finally {
+                                        isExporting = false
                                     }
                                 }
-                            }
-                        }) {
+                            },
+                            enabled = !isExporting
+                        ) {
                             Icon(
                                 Icons.Default.ImportExport,
                                 contentDescription = stringResource(Res.string.phrase_screen_import_export_data)

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -613,7 +613,7 @@ private fun BoardSetWorkspaceScreen(
     val speechService = koinInject<SpeechService>()
     val voiceUseCase = koinInject<VoiceUseCase>()
     val settings by rememberReactiveSettings()
-    val shareService = koinInject<io.github.jdreioe.wingmate.platform.ShareService>()
+    val shareService = remember { org.koin.compose.getKoin().getOrNull<io.github.jdreioe.wingmate.platform.ShareService>() }
     val scope = rememberCoroutineScope()
     var savedGraph by remember(boardSetId) { mutableStateOf<BoardSetGraph?>(null) }
     var editSession by remember(boardSetId) { mutableStateOf<BoardSetEditSession?>(null) }

--- a/composeApp/src/desktopMain/kotlin/io/github/jdreioe/wingmate/platform/DesktopShareService.kt
+++ b/composeApp/src/desktopMain/kotlin/io/github/jdreioe/wingmate/platform/DesktopShareService.kt
@@ -35,7 +35,7 @@ class DesktopShareService : ShareService {
 
     override fun shareFile(fileName: String, content: ByteArray): Boolean {
         return runCatching {
-            val file = File.createTempFile(fileName.substringBeforeLast('.'), ".$fileName.substringAfterLast('.')")
+            val file = File.createTempFile(fileName.substringBeforeLast('.'), ".${fileName.substringAfterLast('.')}")
             file.deleteOnExit()
             file.writeBytes(content)
             if (Desktop.isDesktopSupported()) {

--- a/composeApp/src/desktopMain/kotlin/io/github/jdreioe/wingmate/platform/DesktopShareService.kt
+++ b/composeApp/src/desktopMain/kotlin/io/github/jdreioe/wingmate/platform/DesktopShareService.kt
@@ -32,4 +32,24 @@ class DesktopShareService : ShareService {
             true
         }.getOrElse { false }
     }
+
+    override fun shareFile(fileName: String, content: ByteArray): Boolean {
+        return runCatching {
+            val file = File.createTempFile(fileName.substringBeforeLast('.'), ".$fileName.substringAfterLast('.')")
+            file.deleteOnExit()
+            file.writeBytes(content)
+            if (Desktop.isDesktopSupported()) {
+                val desktop = Desktop.getDesktop()
+                if (desktop.isSupported(Desktop.Action.OPEN)) {
+                    desktop.open(file)
+                    return@runCatching true
+                }
+            }
+            val proc = ProcessBuilder("xdg-open", file.absolutePath)
+                .redirectErrorStream(true)
+                .start()
+            val exit = proc.waitFor()
+            exit == 0
+        }.getOrElse { false }
+    }
 }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidFileStorage.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidFileStorage.kt
@@ -24,4 +24,15 @@ class AndroidFileStorage(private val context: Context) : FileStorage {
     override suspend fun exists(fileName: String): Boolean = withContext(Dispatchers.IO) {
         File(context.filesDir, fileName).exists()
     }
+
+    override suspend fun saveBytes(fileName: String, content: ByteArray) = withContext(Dispatchers.IO) {
+        val file = File(context.filesDir, fileName)
+        file.parentFile?.mkdirs()
+        file.writeBytes(content)
+    }
+
+    override suspend fun loadBytes(fileName: String): ByteArray? = withContext(Dispatchers.IO) {
+        val file = File(context.filesDir, fileName)
+        if (file.exists()) file.readBytes() else null
+    }
 }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/platform/AndroidShareService.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/platform/AndroidShareService.kt
@@ -37,4 +37,23 @@ class AndroidShareService(private val context: Context) : ShareService {
             true
         }.getOrElse { false }
     }
+
+    override fun shareFile(fileName: String, content: ByteArray): Boolean {
+        return runCatching {
+            val file = File(context.cacheDir, fileName)
+            file.parentFile?.mkdirs()
+            file.writeBytes(content)
+            val authority = context.packageName + ".fileprovider"
+            val uri: Uri = FileProvider.getUriForFile(context, authority, file)
+            val intent = Intent(Intent.ACTION_SEND).apply {
+                type = "application/zip"
+                putExtra(Intent.EXTRA_STREAM, uri)
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            val chooser = Intent.createChooser(intent, "Share OBZ")
+            chooser.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(chooser)
+            true
+        }.getOrElse { false }
+    }
 }

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/RealAacLogger.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/RealAacLogger.kt
@@ -5,10 +5,7 @@ import io.github.jdreioe.wingmate.domain.SettingsRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.Locale
-import java.util.TimeZone
+import kotlin.time.Clock
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -82,8 +79,6 @@ class RealAacLogger(
     }
 
     private fun currentTimestamp(): String {
-        val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US)
-        sdf.timeZone = TimeZone.getTimeZone("UTC")
-        return sdf.format(Date())
+        return Clock.System.now().toString()
     }
 }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPronunciationDictionaryRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPronunciationDictionaryRepository.kt
@@ -63,10 +63,4 @@ class IosPronunciationDictionaryRepository : PronunciationDictionaryRepository {
             logger.warn(t) { "Failed to save PronunciationEntry list" }
         }
     }
-
-    override suspend fun clear() {
-        withContext(Dispatchers.Default) {
-            saveAll(emptyList())
-        }
-    }
 }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosShareService.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosShareService.kt
@@ -4,6 +4,9 @@ import io.github.jdreioe.wingmate.platform.ShareService
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
 import platform.Foundation.NSURL
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSData
+import platform.Foundation.writeToFile
 
 class IosShareService : ShareService {
     override fun shareAudio(filePath: String): Boolean {
@@ -37,6 +40,26 @@ class IosShareService : ShareService {
             top = presented
         }
 
+        top.presentViewController(controller, animated = true, completion = null)
+        return true
+    }
+
+    override fun shareFile(fileName: String, content: ByteArray): Boolean {
+        val tmpDir = NSTemporaryDirectory() ?: return false
+        val filePath = "$tmpDir/$fileName"
+        val data = NSData.create(bytes = content.toPointer()!!, length = content.size.toULong())
+        data.writeToFile(filePath, atomically = true)
+        val url = NSURL.fileURLWithPath(filePath)
+        val controller = UIActivityViewController(
+            activityItems = listOf(url),
+            applicationActivities = null
+        )
+        val rootController = UIApplication.sharedApplication.keyWindow?.rootViewController ?: return false
+        var top = rootController
+        while (true) {
+            val presented = top.presentedViewController ?: break
+            top = presented
+        }
         top.presentViewController(controller, animated = true, completion = null)
         return true
     }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosShareService.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosShareService.kt
@@ -47,7 +47,11 @@ class IosShareService : ShareService {
     override fun shareFile(fileName: String, content: ByteArray): Boolean {
         val tmpDir = NSTemporaryDirectory() ?: return false
         val filePath = "$tmpDir/$fileName"
-        val data = NSData.create(bytes = content.toPointer()!!, length = content.size.toULong())
+        val data = content.usePinned { pinned ->
+            pinned.addressOf(0).let { ptr ->
+                NSData.create(bytes = ptr, length = content.size.toULong())
+            }
+        }
         data.writeToFile(filePath, atomically = true)
         val url = NSURL.fileURLWithPath(filePath)
         val controller = UIActivityViewController(

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosShareService.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosShareService.kt
@@ -1,11 +1,14 @@
 package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.platform.ShareService
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
 import platform.UIKit.UIActivityViewController
 import platform.UIKit.UIApplication
 import platform.Foundation.NSURL
 import platform.Foundation.NSTemporaryDirectory
 import platform.Foundation.NSData
+import platform.Foundation.create
 import platform.Foundation.writeToFile
 
 class IosShareService : ShareService {

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/FileStorage.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/FileStorage.kt
@@ -17,6 +17,18 @@ interface FileStorage {
     suspend fun load(fileName: String): String?
     
     /**
+     * Saves binary content to a file with the given name.
+     * Overwrites if exists.
+     */
+    suspend fun saveBytes(fileName: String, content: ByteArray)
+    
+    /**
+     * Reads binary content from a file with the given name.
+     * Returns null if file does not exist.
+     */
+    suspend fun loadBytes(fileName: String): ByteArray?
+    
+    /**
      * Checks if a file exists.
      */
     suspend fun exists(fileName: String): Boolean

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ZipBuilder.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ZipBuilder.kt
@@ -1,0 +1,121 @@
+package io.github.jdreioe.wingmate.domain.obf
+
+/**
+ * Pure-Kotlin ZIP builder that creates store-method (uncompressed) ZIP archives.
+ */
+object ZipBuilder {
+
+    fun build(entries: Map<String, ByteArray>): ByteArray {
+        val localHeaders = mutableListOf<ByteArray>()
+        val centralEntries = mutableListOf<ByteArray>()
+        var offset = 0
+
+        for ((name, data) in entries) {
+            val nameBytes = name.encodeToByteArray()
+            val crc = crc32(data)
+
+            // Local file header
+            localHeaders += buildLocalHeader(nameBytes, data.size, crc)
+            localHeaders += data
+
+            // Central directory entry
+            centralEntries += buildCentralEntry(nameBytes, data.size, crc, offset)
+
+            offset += 30 + nameBytes.size + data.size
+        }
+
+        val cdBytes = centralEntries.fold(byteArrayOf()) { acc, e -> acc + e }
+        val eocd = buildEndOfCentralDirectory(
+            totalEntries = entries.size,
+            centralDirSize = cdBytes.size,
+            centralDirOffset = offset
+        )
+
+        return localHeaders.fold(byteArrayOf()) { acc, e -> acc + e } + cdBytes + eocd
+    }
+
+    private fun buildLocalHeader(nameBytes: ByteArray, dataSize: Int, crc: Int): ByteArray {
+        val buf = ByteArray(30 + nameBytes.size)
+        writeLe32(buf, 0, 0x04034b50)       // signature
+        writeLe16(buf, 4, 20)                // version needed
+        writeLe16(buf, 6, 0)                 // flags
+        writeLe16(buf, 8, 0)                 // compression: stored
+        writeLe16(buf, 10, 0)                // mod time
+        writeLe16(buf, 12, 0)                // mod date
+        writeLe32(buf, 14, crc)              // crc-32
+        writeLe32(buf, 18, dataSize)         // compressed size
+        writeLe32(buf, 22, dataSize)         // uncompressed size
+        writeLe16(buf, 26, nameBytes.size)   // filename length
+        writeLe16(buf, 28, 0)                // extra field length
+        nameBytes.copyInto(buf, 30)
+        return buf
+    }
+
+    private fun buildCentralEntry(nameBytes: ByteArray, dataSize: Int, crc: Int, localOffset: Int): ByteArray {
+        val buf = ByteArray(46 + nameBytes.size)
+        writeLe32(buf, 0, 0x02014b50)        // signature
+        writeLe16(buf, 4, 20)                // version made by
+        writeLe16(buf, 6, 20)                // version needed
+        writeLe16(buf, 8, 0)                 // flags
+        writeLe16(buf, 10, 0)                // compression: stored
+        writeLe16(buf, 12, 0)                // mod time
+        writeLe16(buf, 14, 0)                // mod date
+        writeLe32(buf, 16, crc)              // crc-32
+        writeLe32(buf, 20, dataSize)         // compressed size
+        writeLe32(buf, 24, dataSize)         // uncompressed size
+        writeLe16(buf, 28, nameBytes.size)   // filename length
+        writeLe16(buf, 30, 0)                // extra field length
+        writeLe16(buf, 32, 0)                // file comment length
+        writeLe16(buf, 34, 0)                // disk number start
+        writeLe16(buf, 36, 0)                // internal file attributes
+        writeLe32(buf, 38, 0)                // external file attributes
+        writeLe32(buf, 42, localOffset)      // relative offset
+        nameBytes.copyInto(buf, 46)
+        return buf
+    }
+
+    private fun buildEndOfCentralDirectory(
+        totalEntries: Int,
+        centralDirSize: Int,
+        centralDirOffset: Int
+    ): ByteArray {
+        val buf = ByteArray(22)
+        writeLe32(buf, 0, 0x06054b50)        // signature
+        writeLe16(buf, 4, 0)                 // disk number
+        writeLe16(buf, 6, 0)                 // disk of central dir
+        writeLe16(buf, 8, totalEntries)      // entries on disk
+        writeLe16(buf, 10, totalEntries)     // total entries
+        writeLe32(buf, 12, centralDirSize)   // size of central dir
+        writeLe32(buf, 16, centralDirOffset) // offset of central dir
+        writeLe16(buf, 20, 0)                // comment length
+        return buf
+    }
+
+    private fun writeLe16(buf: ByteArray, pos: Int, value: Int) {
+        buf[pos] = (value and 0xFF).toByte()
+        buf[pos + 1] = ((value ushr 8) and 0xFF).toByte()
+    }
+
+    private fun writeLe32(buf: ByteArray, pos: Int, value: Int) {
+        buf[pos] = (value and 0xFF).toByte()
+        buf[pos + 1] = ((value ushr 8) and 0xFF).toByte()
+        buf[pos + 2] = ((value ushr 16) and 0xFF).toByte()
+        buf[pos + 3] = ((value ushr 24) and 0xFF).toByte()
+    }
+
+    private val crcTable = IntArray(256) { i ->
+        var crc = i
+        repeat(8) {
+            crc = if ((crc and 1) != 0) (crc ushr 1) xor 0xEDB88320.toInt() else crc ushr 1
+        }
+        crc
+    }
+
+    private fun crc32(data: ByteArray): Int {
+        var crc = 0xFFFFFFFF.toInt()
+        for (byte in data) {
+            crc = (crc ushr 8) xor crcTable[(crc xor byte.toInt()) and 0xFF]
+        }
+        return crc xor 0xFFFFFFFF.toInt()
+    }
+}

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/platform/ShareService.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/platform/ShareService.kt
@@ -7,4 +7,10 @@ package io.github.jdreioe.wingmate.platform
 interface ShareService {
     fun shareAudio(filePath: String): Boolean
     fun shareText(text: String): Boolean
+
+    /**
+     * Share a file with the given name and content bytes.
+     * The implementation should write the bytes to a temporary file and open the system share sheet.
+     */
+    fun shareFile(fileName: String, content: ByteArray): Boolean
 }

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/BoardSetUseCase.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/BoardSetUseCase.kt
@@ -2,6 +2,7 @@ package io.github.jdreioe.wingmate.application
 
 import io.github.jdreioe.wingmate.domain.BoardRepository
 import io.github.jdreioe.wingmate.domain.BoardSetRepository
+import io.github.jdreioe.wingmate.domain.FileStorage
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
 import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
 import io.github.jdreioe.wingmate.domain.obf.BoardSetGraph
@@ -16,7 +17,9 @@ import kotlin.time.Clock
 class BoardSetUseCase(
     private val boardSetRepository: BoardSetRepository,
     private val boardRepository: BoardRepository,
-    private val featureUsageReporter: FeatureUsageReporter
+    private val featureUsageReporter: FeatureUsageReporter,
+    private val obzExporter: ObzExporter = ObzExporter(),
+    private val fileStorage: FileStorage? = null
 ) {
     private val json = Json {
         prettyPrint = true
@@ -383,6 +386,18 @@ class BoardSetUseCase(
         val boardSet = boardSetRepository.getBoardSet(boardSetId) ?: return null
         val rootBoard = boardRepository.getBoard(boardSet.rootBoardId) ?: return null
         return json.encodeToString(rootBoard)
+    }
+
+    suspend fun exportBoardSetAsObz(boardSetId: String): ByteArray? {
+        val boardSet = boardSetRepository.getBoardSet(boardSetId) ?: return null
+        val allBoards = boardRepository.listBoards()
+        val graph = BoardSetGraph(boardSet, allBoards.filter { it.id in boardSet.boardIds })
+        if (graph.boards.isEmpty()) return null
+        return obzExporter.export(
+            boards = graph.boards,
+            rootBoardId = boardSet.rootBoardId,
+            loadMedia = { path -> fileStorage?.loadBytes(path) }
+        )
     }
 
     suspend fun getRootBoard(boardSetId: String): ObfBoard? {

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/BoardSetUseCase.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/BoardSetUseCase.kt
@@ -393,10 +393,35 @@ class BoardSetUseCase(
         val allBoards = boardRepository.listBoards()
         val graph = BoardSetGraph(boardSet, allBoards.filter { it.id in boardSet.boardIds })
         if (graph.boards.isEmpty()) return null
+
+        val soundBytes = mutableMapOf<String, ByteArray>()
+        if (fileStorage != null) {
+            for (board in graph.boards) {
+                for (button in board.buttons) {
+                    val soundId = button.soundId ?: continue
+                    if (soundId in soundBytes) continue
+                    // Try multiple storage path patterns
+                    val candidates = listOf(
+                        "sounds/$soundId",
+                        "$boardSetId/sounds/$soundId",
+                        "boardsets/$boardSetId/sounds/$soundId"
+                    )
+                    for (path in candidates) {
+                        val bytes = fileStorage.loadBytes(path)
+                        if (bytes != null) {
+                            soundBytes[soundId] = bytes
+                            break
+                        }
+                    }
+                }
+            }
+        }
+
         return obzExporter.export(
             boards = graph.boards,
             rootBoardId = boardSet.rootBoardId,
-            loadMedia = { path -> fileStorage?.loadBytes(path) }
+            loadMedia = { path -> fileStorage?.loadBytes(path) },
+            soundBytes = soundBytes
         )
     }
 

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/ObzExporter.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/ObzExporter.kt
@@ -1,0 +1,94 @@
+package io.github.jdreioe.wingmate.application
+
+import io.github.jdreioe.wingmate.domain.obf.ObfBoard
+import io.github.jdreioe.wingmate.domain.obf.ObfManifest
+import io.github.jdreioe.wingmate.domain.obf.ObfManifestPaths
+import io.github.jdreioe.wingmate.domain.obf.ZipBuilder
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class ObzExporter(
+    private val json: Json = Json {
+        prettyPrint = true
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+    }
+) {
+    /**
+     * Export a set of boards to an OBZ byte array.
+     *
+     * @param boards all boards in the set (root + linked)
+     * @param rootBoardId the id of the root board
+     * @param loadMedia optional callback to resolve media file path -> bytes
+     * @return OBZ ZIP bytes
+     */
+    suspend fun export(
+        boards: List<ObfBoard>,
+        rootBoardId: String,
+        loadMedia: suspend (path: String) -> ByteArray? = { null }
+    ): ByteArray {
+        val rootBoard = boards.firstOrNull { it.id == rootBoardId }
+            ?: error("root board $rootBoardId not found")
+
+        val boardFiles = mutableMapOf<String, String>()  // board id -> file path
+        val imageFiles = mutableMapOf<String, String>()   // image id -> file path
+        val soundFiles = mutableMapOf<String, String>()   // sound id -> file path
+
+        val entries = mutableMapOf<String, ByteArray>()
+
+        // Write each board as .obf
+        for (board in boards) {
+            val path = "boards/${board.id}.obf"
+            boardFiles[board.id] = path
+            entries[path] = json.encodeToString(board).encodeToByteArray()
+        }
+
+        // Collect and write image files from each board's image list
+        for (board in boards) {
+            for (image in board.images) {
+                val imgPath = image.path
+                if (imgPath != null && image.id !in imageFiles) {
+                    val filename = imgPath.substringAfterLast('/')
+                    val storedPath = "images/${image.id}/$filename"
+                    imageFiles[image.id] = storedPath
+                    loadMedia(imgPath)?.let { bytes ->
+                        entries[storedPath] = bytes
+                    }
+                }
+            }
+        }
+
+        // Collect sound references from buttons
+        // Sounds are identified by sound_id on buttons; the file path is resolved
+        // through storage. For each unique sound_id, we attempt to load the sound
+        // from its stored path pattern.
+        for (board in boards) {
+            for (button in board.buttons) {
+                val soundId = button.soundId
+                if (soundId != null && soundId !in soundFiles) {
+                    val soundPath = "sounds/$soundId"
+                    soundFiles[soundId] = soundPath
+                    loadMedia(soundPath)?.let { bytes ->
+                        entries[soundPath] = bytes
+                    }
+                }
+            }
+        }
+
+        // Root board path from boardFiles
+        val rootPath = boardFiles[rootBoardId] ?: error("root path not found")
+
+        val manifest = ObfManifest(
+            format = "open-board-0.1",
+            root = rootPath,
+            paths = ObfManifestPaths(
+                boards = boardFiles,
+                images = imageFiles,
+                sounds = soundFiles
+            )
+        )
+
+        entries["manifest.json"] = json.encodeToString(manifest).encodeToByteArray()
+        return ZipBuilder.build(entries)
+    }
+}

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/ObzExporter.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/ObzExporter.kt
@@ -19,13 +19,15 @@ class ObzExporter(
      *
      * @param boards all boards in the set (root + linked)
      * @param rootBoardId the id of the root board
-     * @param loadMedia optional callback to resolve media file path -> bytes
+     * @param loadMedia optional callback to resolve media by image path -> bytes
+     * @param soundBytes optional map of sound id -> bytes (pre-resolved)
      * @return OBZ ZIP bytes
      */
     suspend fun export(
         boards: List<ObfBoard>,
         rootBoardId: String,
-        loadMedia: suspend (path: String) -> ByteArray? = { null }
+        loadMedia: suspend (path: String) -> ByteArray? = { null },
+        soundBytes: Map<String, ByteArray> = emptyMap()
     ): ByteArray {
         val rootBoard = boards.firstOrNull { it.id == rootBoardId }
             ?: error("root board $rootBoardId not found")
@@ -59,16 +61,14 @@ class ObzExporter(
         }
 
         // Collect sound references from buttons
-        // Sounds are identified by sound_id on buttons; the file path is resolved
-        // through storage. For each unique sound_id, we attempt to load the sound
-        // from its stored path pattern.
         for (board in boards) {
             for (button in board.buttons) {
                 val soundId = button.soundId
                 if (soundId != null && soundId !in soundFiles) {
                     val soundPath = "sounds/$soundId"
                     soundFiles[soundId] = soundPath
-                    loadMedia(soundPath)?.let { bytes ->
+                    val bytes = soundBytes[soundId] ?: loadMedia(soundPath)
+                    if (bytes != null) {
                         entries[soundPath] = bytes
                     }
                 }

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/di/AppModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/di/AppModule.kt
@@ -13,6 +13,7 @@ import io.github.jdreioe.wingmate.application.usecase.GetAllItemsUseCase
 import io.github.jdreioe.wingmate.domain.BoardRepository
 import io.github.jdreioe.wingmate.domain.BoardSetRepository
 import io.github.jdreioe.wingmate.application.BoardSetUseCase
+import io.github.jdreioe.wingmate.application.ObzExporter
 import io.github.jdreioe.wingmate.infrastructure.BoardImportService
 import io.github.jdreioe.wingmate.infrastructure.InMemoryBoardRepository
 import io.github.jdreioe.wingmate.infrastructure.InMemoryBoardSetRepository
@@ -32,6 +33,7 @@ val appModule = module {
     singleOf(::ObfParser)
     singleOf(::InMemoryBoardRepository) { bind<BoardRepository>() }
     singleOf(::InMemoryBoardSetRepository) { bind<BoardSetRepository>() }
+    singleOf(::ObzExporter)
     singleOf(::BoardSetUseCase)
 
     singleOf(::AddPhraseUseCase)

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/di/AppModule.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/di/AppModule.kt
@@ -30,10 +30,20 @@ import org.koin.dsl.module
 val appModule = module {
     singleOf(::DefaultStoreFactory) { bind<StoreFactory>() }
     
+    single {
+        kotlinx.serialization.json.Json {
+            prettyPrint = true
+            encodeDefaults = true
+            ignoreUnknownKeys = true
+            isLenient = true
+            coerceInputValues = true
+        }
+    }
+    
     singleOf(::ObfParser)
     singleOf(::InMemoryBoardRepository) { bind<BoardRepository>() }
     singleOf(::InMemoryBoardSetRepository) { bind<BoardSetRepository>() }
-    singleOf(::ObzExporter)
+    single { ObzExporter(getOrNull() ?: kotlinx.serialization.json.Json { prettyPrint = true; encodeDefaults = true; ignoreUnknownKeys = true }) }
     singleOf(::BoardSetUseCase)
 
     singleOf(::AddPhraseUseCase)

--- a/shared/src/commonTest/kotlin/ObzExporterTest.kt
+++ b/shared/src/commonTest/kotlin/ObzExporterTest.kt
@@ -1,0 +1,129 @@
+import io.github.jdreioe.wingmate.application.ObzExporter
+import io.github.jdreioe.wingmate.domain.obf.ObfBoard
+import io.github.jdreioe.wingmate.domain.obf.ObfButton
+import io.github.jdreioe.wingmate.domain.obf.ObfImage
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ObzExporterTest {
+
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+    private val exporter = ObzExporter(json)
+
+    private val rootBoard = ObfBoard(
+        format = "open-board-0.1",
+        id = "root",
+        name = "Home",
+        buttons = listOf(
+            ObfButton(id = "b1", label = "Hello", imageId = "img1"),
+            ObfButton(id = "b2", label = "Food", loadBoard = io.github.jdreioe.wingmate.domain.obf.ObfLoadBoard(id = "food"))
+        ),
+        images = listOf(
+            ObfImage(id = "img1", path = "images/hello.png")
+        )
+    )
+
+    private val foodBoard = ObfBoard(
+        format = "open-board-0.1",
+        id = "food",
+        name = "Food",
+        buttons = listOf(
+            ObfButton(id = "b3", label = "Pizza", soundId = "sound1")
+        ),
+        images = emptyList()
+    )
+
+    @Test
+    fun manifestContainsAllBoards() = runBlocking {
+        val zip = exporter.export(
+            boards = listOf(rootBoard, foodBoard),
+            rootBoardId = "root"
+        )
+        val zipStr = String(zip)
+        assertTrue(zipStr.contains("manifest.json"))
+        assertTrue(zipStr.contains("boards/root.obf"))
+        assertTrue(zipStr.contains("boards/food.obf"))
+    }
+
+    @Test
+    fun manifestIsValidJson() = runBlocking {
+        val zip = exporter.export(
+            boards = listOf(rootBoard, foodBoard),
+            rootBoardId = "root"
+        )
+        // Extract manifest.json from zip (simple approach - find it by offset)
+        val manifestEntry = extractEntry(zip, "manifest.json")
+        assertNotNull(manifestEntry)
+        val manifestStr = manifestEntry.decodeToString()
+        assertTrue(manifestStr.contains("\"format\""))
+        assertTrue(manifestStr.contains("\"root\""))
+    }
+
+    @Test
+    fun includesImageMediaWhenProvided() = runBlocking {
+        val imageBytes = "fake-png".encodeToByteArray()
+        val zip = exporter.export(
+            boards = listOf(rootBoard),
+            rootBoardId = "root",
+            loadMedia = { path ->
+                if (path == "images/hello.png") imageBytes else null
+            }
+        )
+        val extracted = extractEntry(zip, "images/img1/hello.png")
+        assertNotNull(extracted)
+        assertTrue(extracted.contentEquals(imageBytes))
+    }
+
+    @Test
+    fun includesSoundPathInManifest() = runBlocking {
+        val zip = exporter.export(
+            boards = listOf(foodBoard),
+            rootBoardId = "food"
+        )
+        val manifestStr = extractEntry(zip, "manifest.json")?.decodeToString() ?: ""
+        assertTrue(manifestStr.contains("sound1"))
+    }
+
+    @Test
+    fun singleBoardExportStillValid() = runBlocking {
+        val zip = exporter.export(
+            boards = listOf(rootBoard),
+            rootBoardId = "root"
+        )
+        val extracted = extractEntry(zip, "boards/root.obf")
+        assertNotNull(extracted)
+        val boardJson = extracted.decodeToString()
+        assertTrue(boardJson.contains("\"id\":\"root\""))
+    }
+
+    private fun extractEntry(zip: ByteArray, entryName: String): ByteArray? {
+        val nameBytes = entryName.encodeToByteArray()
+        var pos = 0
+        while (pos < zip.size - 4) {
+            // Look for local file header signature
+            if (zip[pos] == 0x50.toByte() && zip[pos + 1] == 0x4B.toByte() &&
+                zip[pos + 2] == 0x03.toByte() && zip[pos + 3] == 0x04.toByte()
+            ) {
+                val nameLen = ((zip[pos + 27].toInt() and 0xFF) shl 8) or (zip[pos + 26].toInt() and 0xFF)
+                val extraLen = ((zip[pos + 29].toInt() and 0xFF) shl 8) or (zip[pos + 28].toInt() and 0xFF)
+                val compSize = ((zip[pos + 21].toInt() and 0xFF) shl 24) or
+                    ((zip[pos + 20].toInt() and 0xFF) shl 16) or
+                    ((zip[pos + 19].toInt() and 0xFF) shl 8) or
+                    (zip[pos + 18].toInt() and 0xFF)
+                val headerSize = 30 + nameLen + extraLen
+                val extractedName = zip.copyOfRange(pos + 30, pos + 30 + nameLen).decodeToString()
+                if (extractedName == entryName) {
+                    return zip.copyOfRange(pos + headerSize, pos + headerSize + compSize)
+                }
+                pos += headerSize + compSize
+            } else {
+                pos++
+            }
+        }
+        return null
+    }
+}

--- a/shared/src/commonTest/kotlin/ZipBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/ZipBuilderTest.kt
@@ -1,0 +1,52 @@
+import io.github.jdreioe.wingmate.domain.obf.ZipBuilder
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ZipBuilderTest {
+
+    @Test
+    fun buildsValidZipWithSingleEntry() {
+        val zip = ZipBuilder.build(mapOf("hello.txt" to "world".encodeToByteArray()))
+        assertTrue(zip.size > 30)
+        // PK signature for local file header
+        assertTrue(zip[0] == 0x50.toByte() && zip[1] == 0x4B.toByte() &&
+            zip[2] == 0x03.toByte() && zip[3] == 0x04.toByte())
+    }
+
+    @Test
+    fun buildsZipWithMultipleEntries() {
+        val entries = mapOf(
+            "a.txt" to "aaa".encodeToByteArray(),
+            "b.txt" to "bbb".encodeToByteArray()
+        )
+        val zip = ZipBuilder.build(entries)
+        assertTrue(zip.size > 60)
+        assertTrue(String(zip).contains("a.txt"))
+        assertTrue(String(zip).contains("b.txt"))
+    }
+
+    @Test
+    fun eocdSignaturePresent() {
+        val zip = ZipBuilder.build(mapOf("f" to "d".encodeToByteArray()))
+        val tail = zip.copyOfRange(zip.size - 22, zip.size)
+        assertTrue(tail[0] == 0x50.toByte() && tail[1] == 0x4B.toByte() &&
+            tail[2] == 0x05.toByte() && tail[3] == 0x06.toByte())
+    }
+
+    @Test
+    fun emptyEntries() {
+        val zip = ZipBuilder.build(emptyMap())
+        // EOCD only - 22 bytes
+        assertTrue(zip.size == 22)
+    }
+
+    @Test
+    fun dataIsPreserved() {
+        val data = "Hello, OBZ!".encodeToByteArray()
+        val zip = ZipBuilder.build(mapOf("test.bin" to data))
+        val dataStart = 30 + "test.bin".encodeToByteArray().size
+        val extracted = zip.copyOfRange(dataStart, dataStart + data.size)
+        assertTrue(extracted.contentEquals(data))
+    }
+}


### PR DESCRIPTION
Closes #30

- Pure-Kotlin `ZipBuilder` (store-method ZIP) in domain
- `ObzExporter`: serializes all boards as .obf, generates manifest.json, packages media
- `saveBytes`/`loadBytes` on FileStorage interface + AndroidFileStorage impl
- `shareFile(fileName, content)` on ShareService + Android/Desktop/iOS impls
- Export button in BoardSetWorkspaceScreen non-edit mode (coroutine export + sharing)
- 9 new unit tests pass (ZipBuilder + ObzExporter)