### PR TITLE
[Azure TTS I-03] Add Microsoft sign-in and Azure Resource Manager foundations (#56)

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -358,6 +358,14 @@ dependencies {
     implementation(libs.koin.core)
     implementation(libs.koin.android)
 
+    // MSAL for Microsoft sign-in
+    implementation(libs.msal) {
+        exclude(group = "com.microsoft.device.display")
+    }
+
+    // Ktor engine for ARM API calls
+    implementation("io.ktor:ktor-client-okhttp:2.3.12")
+
     // Dual-screen / WindowManager (API 34+ rear display & window area APIs)
     implementation("androidx.window:window:1.3.0")
 }

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -43,5 +43,20 @@
             android:exported="false"
             android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize|keyboardHidden|uiMode"
             android:theme="@style/Theme.AppCompat.DayNight.NoActionBar" />
+
+        <!-- MSAL redirect URI for browser-based auth -->
+        <activity
+            android:name="com.microsoft.identity.client.BrowserTabActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="msauth"
+                    android:host="com.hojmoseit.wingmate"
+                    android:path="/YOUR_BASE64_SIGNATURE_HASH" />
+            </intent-filter>
+        </activity>
     </application>
 </manifest>

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/AndroidAzureF0Provisioner.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/AndroidAzureF0Provisioner.kt
@@ -1,0 +1,129 @@
+package io.github.jdreioe.wingmate
+
+import android.app.Activity
+import android.content.Context
+import com.microsoft.identity.client.*
+import com.microsoft.identity.client.exception.MsalException
+import com.microsoft.identity.client.exception.MsalUserCancelException
+import io.github.jdreioe.wingmate.domain.AzureF0Provisioner
+import io.github.jdreioe.wingmate.domain.AzureF0Resource
+import io.github.jdreioe.wingmate.domain.AzureSignInResult
+import io.github.jdreioe.wingmate.domain.AzureSignedInUser
+import io.github.jdreioe.wingmate.domain.AzureSubscription
+import io.github.jdreioe.wingmate.infrastructure.AzureArmClient
+import io.ktor.client.*
+import io.ktor.client.engine.okhttp.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.util.concurrent.TimeUnit
+import kotlin.coroutines.resume
+
+class AndroidAzureF0Provisioner(
+    private val context: Context
+) : AzureF0Provisioner {
+
+    private val armClient = AzureArmClient(HttpClient(OkHttp))
+    private val scopes = arrayOf("https://management.azure.com/user_impersonation")
+
+    private val msalApp: ISingleAccountPublicClientApplication by lazy {
+        val config = com.hojmoseit.wingmate.R.raw.msal_config
+        PublicClientApplication.createSingleAccountPublicClientApplication(context, config)
+    }
+
+    override suspend fun signIn(): AzureSignInResult = withContext(Dispatchers.Main) {
+        val activity = getActivity() ?: return@withContext AzureSignInResult.ERROR
+        suspendCancellableCoroutine { cont ->
+            msalApp.signIn(activity, null, scopes, object : AuthenticationCallback {
+                override fun onSuccess(authenticationResult: IAuthenticationResult) {
+                    cont.resume(AzureSignInResult.SUCCESS)
+                }
+                override fun onError(exception: MsalException) {
+                    val result = if (exception is MsalUserCancelException) {
+                        AzureSignInResult.CANCELLED
+                    } else {
+                        AzureSignInResult.ERROR
+                    }
+                    cont.resume(result)
+                }
+                override fun onCancel() {
+                    cont.resume(AzureSignInResult.CANCELLED)
+                }
+            })
+        }
+    }
+
+    override suspend fun signOut() = withContext(Dispatchers.Main) {
+        suspendCancellableCoroutine { cont ->
+            msalApp.signOut(object : ISingleAccountPublicClientApplication.SignOutCallback {
+                override fun onSignOut() { cont.resume(Unit) }
+                override fun onError(exception: MsalException) { cont.resume(Unit) }
+            })
+        }
+    }
+
+    override suspend fun isSignedIn(): Boolean = withContext(Dispatchers.IO) {
+        getAccount() != null
+    }
+
+    override suspend fun getSignedInUser(): AzureSignedInUser? = withContext(Dispatchers.IO) {
+        val account = getAccount()
+        account?.let {
+            AzureSignedInUser(
+                displayName = it.claims?.get("name")?.toString() ?: "",
+                username = it.username ?: "",
+                tenantId = it.tenantId ?: ""
+            )
+        }
+    }
+
+    override suspend fun getSubscriptions(): List<AzureSubscription> = withContext(Dispatchers.IO) {
+        val token = getAccessToken() ?: return@withContext emptyList()
+        armClient.listSubscriptions(token)
+    }
+
+    override suspend fun getF0Resources(subscriptionId: String): List<AzureF0Resource> = withContext(Dispatchers.IO) {
+        val token = getAccessToken() ?: return@withContext emptyList()
+        armClient.listF0SpeechResources(token, subscriptionId)
+    }
+
+    private suspend fun getAccount(): IAccount? = suspendCancellableCoroutine { cont ->
+        msalApp.getCurrentAccountAsync(object : ISingleAccountPublicClientApplication.CurrentAccountCallback {
+            override fun onAccountLoaded(account: IAccount?) { cont.resume(account) }
+            override fun onError(exception: MsalException) { cont.resume(null) }
+            override fun onAccountChanged(oldAccount: IAccount?, newAccount: IAccount?) {
+                cont.resume(newAccount)
+            }
+        })
+    }
+
+    private suspend fun getAccessToken(): String? = suspendCancellableCoroutine { cont ->
+        val account = getAccountSync()
+        if (account == null) { cont.resume(null); return@suspendCancellableCoroutine }
+        msalApp.acquireTokenSilentAsync(scopes, account.authority, object : AuthenticationCallback {
+            override fun onSuccess(authenticationResult: IAuthenticationResult) {
+                cont.resume(authenticationResult.accessToken)
+            }
+            override fun onError(exception: MsalException) { cont.resume(null) }
+            override fun onCancel() { cont.resume(null) }
+        })
+    }
+
+    // Non-suspending version to avoid calling suspend from within suspendCancellableCoroutine
+    private fun getAccountSync(): IAccount? {
+        var result: IAccount? = null
+        val latch = java.util.concurrent.CountDownLatch(1)
+        msalApp.getCurrentAccountAsync(object : ISingleAccountPublicClientApplication.CurrentAccountCallback {
+            override fun onAccountLoaded(account: IAccount?) { result = account; latch.countDown() }
+            override fun onError(exception: MsalException) { latch.countDown() }
+            override fun onAccountChanged(old: IAccount?, new: IAccount?) { result = new; latch.countDown() }
+        })
+        latch.await(10, TimeUnit.SECONDS)
+        return result
+    }
+
+    private fun getActivity(): Activity? = when (context) {
+        is Activity -> context
+        else -> null
+    }
+}

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/WingmateApplication.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/WingmateApplication.kt
@@ -2,8 +2,10 @@ package io.github.jdreioe.wingmate
 
 import android.app.Application
 import com.hojmoseit.wingmate.BuildConfig
+import io.github.jdreioe.wingmate.domain.AzureF0Provisioner
 import io.github.jdreioe.wingmate.infrastructure.OpenSymbolsClient
 import org.koin.core.context.GlobalContext
+import org.koin.core.context.loadKoinModules
 import org.koin.dsl.module
 
 class WingmateApplication : Application() {
@@ -16,6 +18,11 @@ class WingmateApplication : Application() {
 
         // Register Android-specific implementations once at app startup.
         overrideAndroidSpeechService(this)
+
+        // Override AzureF0Provisioner with Android MSAL-based implementation
+        loadKoinModules(module {
+            single<AzureF0Provisioner> { AndroidAzureF0Provisioner(this@WingmateApplication) }
+        })
 
         // OpenSymbols is configured in DesktopMain; wire it for Android app startup as well.
         val openSymbolsSecret = sequenceOf(

--- a/androidApp/src/main/res/raw/msal_config.json
+++ b/androidApp/src/main/res/raw/msal_config.json
@@ -1,0 +1,17 @@
+{
+  "client_id": "YOUR_ENTRA_CLIENT_ID",
+  "authorization_user_agent": "BROWSER",
+  "redirect_uri": "msauth://com.hojmoseit.wingmate/YOUR_BASE64_SIGNATURE_HASH",
+  "account_mode": "MULTIPLE",
+  "broker_redirect_uri_registered": false,
+  "authorities": [
+    {
+      "type": "AAD",
+      "audience": {
+        "type": "AzureADMyOrg",
+        "tenant_id": "common"
+      },
+      "default": true
+    }
+  ]
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1") }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/AzureSettingsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/AzureSettingsDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.domain.ConfigRepository
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.Settings
+import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.application.FeatureUsageEvents
 import io.github.jdreioe.wingmate.application.FeatureUsageReporter
 import io.github.jdreioe.wingmate.application.reportEvent
@@ -52,7 +53,7 @@ fun AzureSettingsDialog(show: Boolean, onDismiss: () -> Unit, onSaved: (() -> Un
 
     var endpoint by remember { mutableStateOf("") }
     var subscriptionKey by remember { mutableStateOf("") }
-    var useSystemTts by remember { mutableStateOf(false) }
+    var ttsEngine by remember { mutableStateOf(TtsEngine.SYSTEM) }
     var virtualMic by remember { mutableStateOf(false) }
     var featureUsageReportingEnabled by remember { mutableStateOf(false) }
     var loading by remember { mutableStateOf(true) }
@@ -85,7 +86,7 @@ fun AzureSettingsDialog(show: Boolean, onDismiss: () -> Unit, onSaved: (() -> Un
             val settings = withContext(Dispatchers.Default) { 
                 runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
             }
-            useSystemTts = settings.useSystemTts
+            ttsEngine = settings.ttsEngine
             virtualMic = settings.virtualMicEnabled
             featureUsageReportingEnabled = settings.featureUsageReportingEnabled
             fontSizeScale = settings.fontSizeScale
@@ -133,21 +134,21 @@ fun AzureSettingsDialog(show: Boolean, onDismiss: () -> Unit, onSaved: (() -> Un
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         FilterChip(
-                            selected = !useSystemTts,
-                            onClick = { useSystemTts = false },
+                            selected = ttsEngine != TtsEngine.SYSTEM,
+                            onClick = { ttsEngine = TtsEngine.AZURE_USER_RESOURCE },
                             label = { Text("Azure TTS") },
                             modifier = Modifier.weight(1f)
                         )
                         FilterChip(
-                            selected = useSystemTts,
-                            onClick = { useSystemTts = true },
+                            selected = ttsEngine == TtsEngine.SYSTEM,
+                            onClick = { ttsEngine = TtsEngine.SYSTEM },
                             label = { Text("System TTS") },
                             modifier = Modifier.weight(1f)
                         )
                     }
                     
                     // Azure Configuration (only show when Azure TTS is selected)
-                    if (!useSystemTts) {
+                    if (ttsEngine != TtsEngine.SYSTEM) {
                         Spacer(modifier = Modifier.height(16.dp))
                         val showKeyboard = rememberShowKeyboardOnFocus()
                         OutlinedTextField(
@@ -356,7 +357,7 @@ fun AzureSettingsDialog(show: Boolean, onDismiss: () -> Unit, onSaved: (() -> Un
                         if (settingsUseCase != null) {
                             val current = runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
                             val updated = current.copy(
-                                useSystemTts = useSystemTts, 
+                                ttsEngine = ttsEngine, 
                                 virtualMicEnabled = virtualMic,
                                 featureUsageReportingEnabled = featureUsageReportingEnabled,
                                 fontSizeScale = fontSizeScale,
@@ -368,9 +369,9 @@ fun AzureSettingsDialog(show: Boolean, onDismiss: () -> Unit, onSaved: (() -> Un
                             settingsUseCase.update(updated)
                             featureUsageReporter?.setEnabled(featureUsageReportingEnabled)
                         }
-                        
+
                         // Save Azure config only if Azure TTS is selected
-                        if (!useSystemTts && endpoint.isNotBlank() && subscriptionKey.isNotBlank()) {
+                        if (ttsEngine != TtsEngine.SYSTEM && endpoint.isNotBlank() && subscriptionKey.isNotBlank()) {
                             println("Saving speech config: endpoint='$endpoint'")
                             try {
                                 configRepo.saveSpeechConfig(SpeechServiceConfig(endpoint = endpoint, subscriptionKey = subscriptionKey))

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/AzureSettingsFullScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/AzureSettingsFullScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.domain.ConfigRepository
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.Settings
+import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.application.SettingsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -27,7 +28,7 @@ fun AzureSettingsFullScreen(
     
     var endpoint by remember { mutableStateOf("") }
     var subscriptionKey by remember { mutableStateOf("") }
-    var useSystemTts by remember { mutableStateOf(false) }
+    var ttsEngine by remember { mutableStateOf(TtsEngine.SYSTEM) }
     var loading by remember { mutableStateOf(true) }
     var virtualMic by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
@@ -36,13 +37,13 @@ fun AzureSettingsFullScreen(
         val cfg = withContext(Dispatchers.Default) { configRepo.getSpeechConfig() }
         println("Loaded config: $cfg")
         cfg?.let { endpoint = it.endpoint; subscriptionKey = it.subscriptionKey }
-        
+
         val settings = withContext(Dispatchers.Default) { 
             runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
         }
-        useSystemTts = settings.useSystemTts
+        ttsEngine = settings.ttsEngine
         virtualMic = settings.virtualMicEnabled
-        
+
         loading = false
     }
 
@@ -65,13 +66,13 @@ fun AzureSettingsFullScreen(
             // Azure TTS Card
             Card(
                 onClick = { 
-                    useSystemTts = false
+                    ttsEngine = TtsEngine.AZURE_USER_RESOURCE
                     scope.launch {
                         val currentSettings: Settings = withContext(Dispatchers.Default) {
                             runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
                         }
                         runCatching {
-                            settingsUseCase.update(currentSettings.copy(useSystemTts = false))
+                            settingsUseCase.update(currentSettings.copy(ttsEngine = TtsEngine.AZURE_USER_RESOURCE))
                         }
                         // Navigate to Azure config screen
                         onAzureSelected()
@@ -79,12 +80,12 @@ fun AzureSettingsFullScreen(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 colors = CardDefaults.cardColors(
-                    containerColor = if (!useSystemTts) 
+                    containerColor = if (ttsEngine != TtsEngine.SYSTEM) 
                         MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.7f)
                     else 
                         MaterialTheme.colorScheme.surfaceContainer
                 ),
-                border = if (!useSystemTts) 
+                border = if (ttsEngine != TtsEngine.SYSTEM) 
                     BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
                 else null
             ) {
@@ -98,7 +99,7 @@ fun AzureSettingsFullScreen(
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
                         )
-                        if (!useSystemTts) {
+                        if (ttsEngine != TtsEngine.SYSTEM) {
                             Spacer(Modifier.width(8.dp))
                             AssistChip(
                                 onClick = { },
@@ -139,13 +140,13 @@ fun AzureSettingsFullScreen(
             // System TTS Card  
             Card(
                 onClick = { 
-                    useSystemTts = true
+                    ttsEngine = TtsEngine.SYSTEM
                     scope.launch {
                         val currentSettings: Settings = withContext(Dispatchers.Default) {
                             runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
                         }
                         runCatching {
-                            settingsUseCase.update(currentSettings.copy(useSystemTts = true))
+                            settingsUseCase.update(currentSettings.copy(ttsEngine = TtsEngine.SYSTEM))
                         }
                         // Go directly to voice selection since no config needed
                         onNext()
@@ -153,12 +154,12 @@ fun AzureSettingsFullScreen(
                 },
                 modifier = Modifier.fillMaxWidth(),
                 colors = CardDefaults.cardColors(
-                    containerColor = if (useSystemTts) 
+                    containerColor = if (ttsEngine == TtsEngine.SYSTEM) 
                         MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.7f)
                     else 
                         MaterialTheme.colorScheme.surfaceContainer
                 ),
-                border = if (useSystemTts) 
+                border = if (ttsEngine == TtsEngine.SYSTEM) 
                     BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
                 else null
             ) {
@@ -172,7 +173,7 @@ fun AzureSettingsFullScreen(
                             style = MaterialTheme.typography.titleMedium,
                             fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
                         )
-                        if (useSystemTts) {
+                        if (ttsEngine == TtsEngine.SYSTEM) {
                             Spacer(Modifier.width(8.dp))
                             AssistChip(
                                 onClick = { },
@@ -248,7 +249,7 @@ fun AzureSettingsFullScreen(
             }
 
             // Azure Configuration (only show when Azure TTS is selected)
-            if (!useSystemTts) {
+            if (ttsEngine != TtsEngine.SYSTEM) {
                 Spacer(modifier = Modifier.height(16.dp))
                 Text("Azure Configuration", style = MaterialTheme.typography.titleMedium)
                 Spacer(modifier = Modifier.height(8.dp))
@@ -282,12 +283,12 @@ fun AzureSettingsFullScreen(
                     // Save TTS preference
                     withContext(Dispatchers.Default) {
                         val current = runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
-                        val updated = current.copy(useSystemTts = useSystemTts, virtualMicEnabled = virtualMic)
+                        val updated = current.copy(ttsEngine = ttsEngine, virtualMicEnabled = virtualMic)
                         settingsUseCase.update(updated)
                     }
-                    
+
                     // Save Azure config only if Azure TTS is selected and fields are filled
-                    if (!useSystemTts && endpoint.isNotBlank() && subscriptionKey.isNotBlank()) {
+                    if (ttsEngine != TtsEngine.SYSTEM && endpoint.isNotBlank() && subscriptionKey.isNotBlank()) {
                         withContext(Dispatchers.Default) {
                             configRepo.saveSpeechConfig(SpeechServiceConfig(endpoint = endpoint, subscriptionKey = subscriptionKey))
                         }

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
@@ -28,14 +28,15 @@ import io.github.jdreioe.wingmate.application.BoardSetUseCase
 import io.github.jdreioe.wingmate.application.SettingsUseCase
 import io.github.jdreioe.wingmate.application.SettingsStateManager
 import io.github.jdreioe.wingmate.domain.ConfigRepository
-import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.PronunciationDictionaryRepository
 import io.github.jdreioe.wingmate.domain.PronunciationEntry
+import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.SpeechService
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
+import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.domain.StartupMode
-import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.domain.Voice
+import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
 import io.github.jdreioe.wingmate.infrastructure.ObfParser
 import io.github.jdreioe.wingmate.infrastructure.ArasaacDownloadProgress
@@ -89,7 +90,7 @@ fun SettingsScreen(
     // --- Speech section state ---
     var endpoint by remember { mutableStateOf("") }
     var subscriptionKey by remember { mutableStateOf("") }
-    var useSystemTts by remember { mutableStateOf(false) }
+    var ttsEngine by remember { mutableStateOf(TtsEngine.SYSTEM) }
     var virtualMic by remember { mutableStateOf(false) }
 
     // --- Display section state ---
@@ -165,7 +166,7 @@ fun SettingsScreen(
         val s = withContext(Dispatchers.Default) {
             runCatching { settingsUseCase?.get() }.getOrNull() ?: Settings()
         }
-        useSystemTts = s.useSystemTts
+        ttsEngine = s.ttsEngine
         virtualMic = s.virtualMicEnabled
         featureUsageReportingEnabled = s.featureUsageReportingEnabled
         partnerWindowEnabled = s.partnerWindowEnabled
@@ -353,10 +354,10 @@ fun SettingsScreen(
                                     }
                                 } else { when (currentTab) {
                             SettingsTab.Speech -> SpeechSection(
-                                useSystemTts = useSystemTts,
-                                onUseSystemTtsChange = { checked ->
-                                    useSystemTts = checked
-                                    updateSettings { it.copy(useSystemTts = checked) }
+                                ttsEngine = ttsEngine,
+                                onTtsEngineChange = { engine ->
+                                    ttsEngine = engine
+                                    updateSettings { it.copy(ttsEngine = engine) }
                                 },
                                 endpoint = endpoint,
                                 onEndpointChange = { endpoint = it },
@@ -1006,8 +1007,8 @@ private fun SettingsCategoryRow(
 
 @Composable
 private fun SpeechSection(
-    useSystemTts: Boolean,
-    onUseSystemTtsChange: (Boolean) -> Unit,
+    ttsEngine: TtsEngine,
+    onTtsEngineChange: (TtsEngine) -> Unit,
     endpoint: String,
     onEndpointChange: (String) -> Unit,
     subscriptionKey: String,
@@ -1022,22 +1023,22 @@ private fun SpeechSection(
     SettingsGroup(title = "Text-to-Speech Engine") {
         SettingsPreferenceRow(
             title = "Speech engine",
-            subtitle = if (useSystemTts) "System TTS" else "Azure TTS"
+            subtitle = if (ttsEngine == TtsEngine.SYSTEM) "System TTS" else "Azure TTS"
         ) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                 FilterChip(
-                    selected = !useSystemTts,
-                    onClick = { onUseSystemTtsChange(false) },
+                    selected = ttsEngine != TtsEngine.SYSTEM,
+                    onClick = { onTtsEngineChange(TtsEngine.AZURE_USER_RESOURCE) },
                     label = { Text("Azure") }
                 )
                 FilterChip(
-                    selected = useSystemTts,
-                    onClick = { onUseSystemTtsChange(true) },
+                    selected = ttsEngine == TtsEngine.SYSTEM,
+                    onClick = { onTtsEngineChange(TtsEngine.SYSTEM) },
                     label = { Text("System") }
                 )
             }
         }
-        if (!useSystemTts) {
+        if (ttsEngine != TtsEngine.SYSTEM) {
             SettingsGroupDivider()
             Column(modifier = Modifier.padding(vertical = 12.dp)) {
                 OutlinedTextField(
@@ -1427,7 +1428,7 @@ private fun VoiceSelectionPage(onBack: () -> Unit) {
     var selected by remember { mutableStateOf<Voice?>(null) }
     var showVoiceSettings by remember { mutableStateOf(false) }
     var editingVoice by remember { mutableStateOf<Voice?>(null) }
-    var useSystemTts by remember { mutableStateOf(false) }
+    var ttsEngine by remember { mutableStateOf(TtsEngine.SYSTEM) }
     var systemVoices by remember { mutableStateOf<List<Voice>>(emptyList()) }
     var selectedLanguage by remember { mutableStateOf<String?>(null) }
     var availableLanguages by remember { mutableStateOf<List<String>>(emptyList()) }
@@ -1444,11 +1445,11 @@ private fun VoiceSelectionPage(onBack: () -> Unit) {
             val settings = withContext(Dispatchers.Default) {
                 runCatching { settingsUseCase.get() }.getOrNull()
             }
-            useSystemTts = settings?.useSystemTts ?: false
+            ttsEngine = settings?.ttsEngine ?: TtsEngine.SYSTEM
         }
         loading = true
         try {
-            if (useSystemTts) {
+            if (ttsEngine == TtsEngine.SYSTEM) {
                 val allSystemVoices = systemVoiceProvider?.getSystemVoices() ?: listOf(
                     Voice(name = "system-default", displayName = "System Default", primaryLanguage = "en-US", gender = "Unknown")
                 )
@@ -1491,7 +1492,7 @@ private fun VoiceSelectionPage(onBack: () -> Unit) {
         voices
     }
 
-    val activeLanguageFilteredVoices = if (useSystemTts) languageFilteredSystemVoices else languageFilteredAzureVoices
+    val activeLanguageFilteredVoices = if (ttsEngine == TtsEngine.SYSTEM) languageFilteredSystemVoices else languageFilteredAzureVoices
     val allLabel = stringResource(Res.string.language_all)
     val availableGenders = remember(activeLanguageFilteredVoices) {
         activeLanguageFilteredVoices.mapNotNull { it.gender?.trim()?.takeIf { gender -> gender.isNotEmpty() } }.distinct().sorted()
@@ -1511,8 +1512,8 @@ private fun VoiceSelectionPage(onBack: () -> Unit) {
         languageFilteredAzureVoices.filter { voice -> matchesVoiceFilters(voice = voice, queryTerms = queryTerms, genderFilter = genderFilter) }
     }
 
-    val visibleVoiceCount = if (useSystemTts) filteredSystemVoices.size else filteredAzureVoices.size
-    val totalVoiceCount = if (useSystemTts) systemVoices.size else voices.size
+    val visibleVoiceCount = if (ttsEngine == TtsEngine.SYSTEM) filteredSystemVoices.size else filteredAzureVoices.size
+    val totalVoiceCount = if (ttsEngine == TtsEngine.SYSTEM) systemVoices.size else voices.size
 
     Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
         OutlinedTextField(
@@ -1600,13 +1601,13 @@ private fun VoiceSelectionPage(onBack: () -> Unit) {
         } else if (error != null) {
             Text(stringResource(Res.string.voice_error, error ?: ""))
         } else {
-            val filteredVoices = if (useSystemTts) filteredSystemVoices else filteredAzureVoices
-            val titleRes = if (useSystemTts) {
+            val filteredVoices = if (ttsEngine == TtsEngine.SYSTEM) filteredSystemVoices else filteredAzureVoices
+            val titleRes = if (ttsEngine == TtsEngine.SYSTEM) {
                 if (selectedLanguage != null) Res.string.voice_system_title_with_lang else Res.string.voice_system_title
             } else {
                 if (selectedLanguage != null) Res.string.voice_azure_title_with_lang else Res.string.voice_azure_title
             }
-            val emptyRes = if (useSystemTts) Res.string.voice_no_system_match else Res.string.voice_no_azure_match
+            val emptyRes = if (ttsEngine == TtsEngine.SYSTEM) Res.string.voice_no_system_match else Res.string.voice_no_azure_match
 
             SettingsGroup(title = stringResource(titleRes, selectedLanguage ?: "")) {
                 if (filteredVoices.isEmpty()) {
@@ -1621,12 +1622,12 @@ private fun VoiceSelectionPage(onBack: () -> Unit) {
                         VoiceRow(
                             voice = v,
                             isSelected = selected?.name == v.name,
-                            showSettings = !useSystemTts,
+                            showSettings = ttsEngine != TtsEngine.SYSTEM,
                             onSelect = {
                                 scope.launch {
                                     try {
                                         useCase.select(v)
-                                        val primary = if (useSystemTts) (v.primaryLanguage ?: "") else (v.selectedLanguage?.ifBlank { v.primaryLanguage ?: "" } ?: "")
+                                        val primary = if (ttsEngine == TtsEngine.SYSTEM) (v.primaryLanguage ?: "") else (v.selectedLanguage?.ifBlank { v.primaryLanguage ?: "" } ?: "")
                                         if (primary.isNotBlank() && settingsUseCase != null) {
                                             val current = settingsUseCase.get()
                                             settingsUseCase.update(current.copy(primaryLanguage = primary))

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/SsmlSidebar.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/SsmlSidebar.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import io.github.jdreioe.wingmate.application.SettingsUseCase
 import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.domain.Settings
+import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.domain.Voice
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -41,7 +42,7 @@ fun SsmlSidebar(
     var pitch by remember { mutableStateOf(1.0) }
     var rate by remember { mutableStateOf(1.0) }
     var volume by remember { mutableStateOf(1.0) }
-    var useSystemTts by remember { mutableStateOf(false) }
+    var ttsEngine by remember { mutableStateOf(TtsEngine.SYSTEM) }
     var emphasis by remember { mutableStateOf("strong") }
     var breakDuration by remember { mutableStateOf(500) }
     var phonemeEntry by remember { mutableStateOf("") }
@@ -62,7 +63,7 @@ fun SsmlSidebar(
         val s = runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
         primaryLang = s.primaryLanguage
         secondaryLang = s.secondaryLanguage
-        useSystemTts = s.useSystemTts
+        ttsEngine = s.ttsEngine
     }
 
     // Helper to insert SSML with selected text or placeholder
@@ -95,20 +96,20 @@ fun SsmlSidebar(
                     ) {
                         Column {
                             Text("Engine", style = MaterialTheme.typography.labelMedium, color = MaterialTheme.colorScheme.outline)
-                            Text(if (useSystemTts) "System (Offline)" else "Azure (Premium)", style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
+                            Text(if (ttsEngine == TtsEngine.SYSTEM) "System (Offline)" else "Azure (Premium)", style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
                         }
                         Switch(
-                            checked = useSystemTts, 
+                            checked = ttsEngine == TtsEngine.SYSTEM, 
                             onCheckedChange = { checked ->
-                                useSystemTts = checked
+                                ttsEngine = if (checked) TtsEngine.SYSTEM else TtsEngine.AZURE_USER_RESOURCE
                                 scope.launch {
                                     val current = runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
-                                    settingsUseCase.updateWithNotification(current.copy(useSystemTts = checked))
+                                    settingsUseCase.updateWithNotification(current.copy(ttsEngine = ttsEngine))
                                 }
                             },
                             thumbContent = {
                                 Icon(
-                                    imageVector = if (useSystemTts) Icons.Filled.Settings else Icons.Filled.Cloud,
+                                    imageVector = if (ttsEngine == TtsEngine.SYSTEM) Icons.Filled.Settings else Icons.Filled.Cloud,
                                     contentDescription = null,
                                     modifier = Modifier.size(16.dp)
                                 )

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/VoiceEngineSelectorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/VoiceEngineSelectorScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.domain.Settings
+import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.application.SettingsUseCase
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -23,7 +24,7 @@ fun VoiceEngineSelectorScreen(
 ) {
     val settingsUseCase = koinInject<SettingsUseCase>()
 
-    var useSystemTts by remember { mutableStateOf(false) }
+    var ttsEngine by remember { mutableStateOf(TtsEngine.SYSTEM) }
     var loading by remember { mutableStateOf(true) }
     val scope = rememberCoroutineScope()
 
@@ -31,7 +32,7 @@ fun VoiceEngineSelectorScreen(
         val settings = withContext(Dispatchers.Default) {
             runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
         }
-        useSystemTts = settings.useSystemTts
+        ttsEngine = settings.ttsEngine
 
         loading = false
     }
@@ -64,16 +65,16 @@ fun VoiceEngineSelectorScreen(
                 // Azure TTS Card
                 Card(
                     onClick = {
-                        useSystemTts = false
+                        ttsEngine = TtsEngine.AZURE_USER_RESOURCE
                     },
                     modifier = Modifier.fillMaxWidth(),
                     colors = CardDefaults.cardColors(
-                        containerColor = if (!useSystemTts)
+                        containerColor = if (ttsEngine != TtsEngine.SYSTEM)
                             MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.7f)
                         else
                             MaterialTheme.colorScheme.surfaceContainer
                     ),
-                    border = if (!useSystemTts)
+                    border = if (ttsEngine != TtsEngine.SYSTEM)
                         BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
                     else null
                 ) {
@@ -87,7 +88,7 @@ fun VoiceEngineSelectorScreen(
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
                             )
-                            if (!useSystemTts) {
+                            if (ttsEngine != TtsEngine.SYSTEM) {
                                 Spacer(Modifier.width(8.dp))
                                 AssistChip(
                                     onClick = { },
@@ -128,16 +129,16 @@ fun VoiceEngineSelectorScreen(
                 // System TTS Card
                 Card(
                     onClick = {
-                        useSystemTts = true
+                        ttsEngine = TtsEngine.SYSTEM
                     },
                     modifier = Modifier.fillMaxWidth(),
                     colors = CardDefaults.cardColors(
-                        containerColor = if (useSystemTts)
+                        containerColor = if (ttsEngine == TtsEngine.SYSTEM)
                             MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.7f)
                         else
                             MaterialTheme.colorScheme.surfaceContainer
                     ),
-                    border = if (useSystemTts)
+                    border = if (ttsEngine == TtsEngine.SYSTEM)
                         BorderStroke(2.dp, MaterialTheme.colorScheme.primary)
                     else null
                 ) {
@@ -151,7 +152,7 @@ fun VoiceEngineSelectorScreen(
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
                             )
-                            if (useSystemTts) {
+                            if (ttsEngine == TtsEngine.SYSTEM) {
                                 Spacer(Modifier.width(8.dp))
                                 AssistChip(
                                     onClick = { },
@@ -231,11 +232,11 @@ fun VoiceEngineSelectorScreen(
                                     runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
                                 }
                                 runCatching {
-                                    settingsUseCase.update(currentSettings.copy(useSystemTts = useSystemTts))
+                                    settingsUseCase.update(currentSettings.copy(ttsEngine = ttsEngine))
                                 }
 
                                 // Navigate to appropriate next screen based on selection
-                                if (useSystemTts) {
+                                if (ttsEngine == TtsEngine.SYSTEM) {
                                     onNext() // Go directly to voice selection
                                 } else {
                                     onAzureSelected() // Go to Azure configuration

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/VoiceSelectionDialog.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/VoiceSelectionDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.application.SettingsUseCase
 import io.github.jdreioe.wingmate.domain.Voice
+import io.github.jdreioe.wingmate.domain.TtsEngine
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.launch
@@ -53,7 +54,7 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
     var selected by remember { mutableStateOf<Voice?>(null) }
     var showVoiceSettings by remember { mutableStateOf(false) }
     var editingVoice by remember { mutableStateOf<Voice?>(null) }
-    var useSystemTts by remember { mutableStateOf(false) }
+    var ttsEngine by remember { mutableStateOf(TtsEngine.SYSTEM) }
     var systemVoices by remember { mutableStateOf<List<Voice>>(emptyList()) }
     var selectedLanguage by remember { mutableStateOf<String?>(null) }
     var availableLanguages by remember { mutableStateOf<List<String>>(emptyList()) }
@@ -71,12 +72,12 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
             val settings = withContext(Dispatchers.Default) { 
                 runCatching { settingsUseCase.get() }.getOrNull() 
             }
-            useSystemTts = settings?.useSystemTts ?: false
+            ttsEngine = settings?.ttsEngine ?: TtsEngine.SYSTEM
         }
         
         loading = true
         try {
-            if (useSystemTts) {
+            if (ttsEngine == TtsEngine.SYSTEM) {
                 // Load system voices
                 val allSystemVoices = systemVoiceProvider?.getSystemVoices() ?: listOf(
                     Voice(
@@ -143,7 +144,7 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
         voices
     }
 
-    val activeLanguageFilteredVoices = if (useSystemTts) languageFilteredSystemVoices else languageFilteredAzureVoices
+    val activeLanguageFilteredVoices = if (ttsEngine == TtsEngine.SYSTEM) languageFilteredSystemVoices else languageFilteredAzureVoices
     val allLabel = stringResource(Res.string.language_all)
     val availableGenders = remember(activeLanguageFilteredVoices) {
         activeLanguageFilteredVoices
@@ -170,8 +171,8 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
         }
     }
 
-    val visibleVoiceCount = if (useSystemTts) filteredSystemVoices.size else filteredAzureVoices.size
-    val totalVoiceCount = if (useSystemTts) systemVoices.size else voices.size
+    val visibleVoiceCount = if (ttsEngine == TtsEngine.SYSTEM) filteredSystemVoices.size else filteredAzureVoices.size
+    val totalVoiceCount = if (ttsEngine == TtsEngine.SYSTEM) systemVoices.size else voices.size
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -299,7 +300,7 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
                     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) { CircularProgressIndicator() }
                 } else if (error != null) {
                     Text(stringResource(Res.string.voice_error, error ?: ""))
-                } else if (useSystemTts) {
+                } else if (ttsEngine == TtsEngine.SYSTEM) {
                     // Show system voices
                     Text(
                         text = if (selectedLanguage != null) {

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/VoiceSelectionFullScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/VoiceSelectionFullScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.application.SettingsUseCase
 import io.github.jdreioe.wingmate.domain.Voice
+import io.github.jdreioe.wingmate.domain.TtsEngine
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.launch
@@ -56,7 +57,7 @@ fun VoiceSelectionFullScreen(onNext: () -> Unit, onCancel: () -> Unit, onBackToW
     var selectedLanguageFilter by remember { mutableStateOf<String?>(null) }
     var supportedLanguages by remember { mutableStateOf<List<String>>(emptyList()) }
     var showLanguageFilter by remember { mutableStateOf(false) }
-    var useSystemTts by remember { mutableStateOf(false) }
+    var ttsEngine by remember { mutableStateOf(TtsEngine.SYSTEM) }
     val scope = rememberCoroutineScope()
 
     LaunchedEffect(useCase, settingsUseCase) {
@@ -65,11 +66,11 @@ fun VoiceSelectionFullScreen(onNext: () -> Unit, onCancel: () -> Unit, onBackToW
             val settings = withContext(Dispatchers.IO) {
                 runCatching { settingsUseCase.get() }.getOrNull()
             }
-            useSystemTts = settings?.useSystemTts ?: false
+            ttsEngine = settings?.ttsEngine ?: TtsEngine.SYSTEM
         }
 
         // If using system TTS, skip voice loading and go straight to next
-        if (useSystemTts) {
+        if (ttsEngine == TtsEngine.SYSTEM) {
             loading = false
             return@LaunchedEffect
         }
@@ -118,7 +119,7 @@ fun VoiceSelectionFullScreen(onNext: () -> Unit, onCancel: () -> Unit, onBackToW
         Text(stringResource(Res.string.voice_select_title), style = MaterialTheme.typography.headlineSmall)
         Spacer(modifier = Modifier.height(16.dp))
 
-        if (useSystemTts) {
+        if (ttsEngine == TtsEngine.SYSTEM) {
             // System TTS selected - show available system voices for selection
             Text(
                 text = if (selectedLanguageFilter != null) {

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/VoiceSettingsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/VoiceSettingsDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.domain.SpeechService
+import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.application.SettingsUseCase
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -36,10 +37,10 @@ fun VoiceSettingsDialog(
     val scope = rememberCoroutineScope()
     
     // Get current TTS engine setting
-    var useSystemTts by remember { mutableStateOf(false) }
+    var ttsEngine by remember { mutableStateOf(TtsEngine.SYSTEM) }
     LaunchedEffect(settingsUseCase) {
         val settings = runCatching { settingsUseCase.get() }.getOrNull()
-        useSystemTts = settings?.useSystemTts ?: false
+        ttsEngine = settings?.ttsEngine ?: TtsEngine.SYSTEM
     }
 
     AlertDialog(
@@ -60,12 +61,12 @@ fun VoiceSettingsDialog(
                 ) {
                     Column(modifier = Modifier.padding(12.dp)) {
                         Text(
-                            "Current Engine: ${if (useSystemTts) "System TTS" else "Azure TTS"}",
+                            "Current Engine: ${if (ttsEngine == TtsEngine.SYSTEM) "System TTS" else "Azure TTS"}",
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.Medium
                         )
                         Text(
-                            if (useSystemTts) "Using device's built-in text-to-speech" else "Using Microsoft Azure Cognitive Services",
+                            if (ttsEngine == TtsEngine.SYSTEM) "Using device's built-in text-to-speech" else "Using Microsoft Azure Cognitive Services",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onPrimaryContainer
                         )
@@ -151,7 +152,7 @@ fun VoiceSettingsDialog(
                     Card(
                         modifier = Modifier.fillMaxWidth(),
                         colors = CardDefaults.cardColors(
-                            containerColor = if (!useSystemTts) 
+                            containerColor = if (ttsEngine != TtsEngine.SYSTEM) 
                                 MaterialTheme.colorScheme.primaryContainer 
                             else 
                                 MaterialTheme.colorScheme.surfaceContainer
@@ -167,7 +168,7 @@ fun VoiceSettingsDialog(
                                     style = MaterialTheme.typography.titleMedium,
                                     fontWeight = FontWeight.Bold
                                 )
-                                if (!useSystemTts) {
+                                if (ttsEngine != TtsEngine.SYSTEM) {
                                     Spacer(Modifier.width(8.dp))
                                     AssistChip(
                                         onClick = { },
@@ -208,7 +209,7 @@ fun VoiceSettingsDialog(
                     Card(
                         modifier = Modifier.fillMaxWidth(),
                         colors = CardDefaults.cardColors(
-                            containerColor = if (useSystemTts) 
+                            containerColor = if (ttsEngine == TtsEngine.SYSTEM) 
                                 MaterialTheme.colorScheme.primaryContainer 
                             else 
                                 MaterialTheme.colorScheme.surfaceContainer
@@ -224,7 +225,7 @@ fun VoiceSettingsDialog(
                                     style = MaterialTheme.typography.titleMedium,
                                     fontWeight = FontWeight.Bold
                                 )
-                                if (useSystemTts) {
+                                if (ttsEngine == TtsEngine.SYSTEM) {
                                     Spacer(Modifier.width(8.dp))
                                     AssistChip(
                                         onClick = { },

--- a/composeApp/src/desktopMain/kotlin/io/github/jdreioe/wingmate/infrastructure/DesktopSpeechService.kt
+++ b/composeApp/src/desktopMain/kotlin/io/github/jdreioe/wingmate/infrastructure/DesktopSpeechService.kt
@@ -667,7 +667,7 @@ class DesktopSpeechService(
         val settingsRepo = koin?.let { runCatching { it.get<io.github.jdreioe.wingmate.domain.SettingsRepository>() }.getOrNull() }
         val uiSettings = settingsRepo?.let { runCatching { runBlocking { it.get() } }.getOrNull() }
         
-        if (uiSettings?.useSystemTts == true) {
+        if (uiSettings?.ttsEngine == io.github.jdreioe.wingmate.domain.TtsEngine.SYSTEM) {
             // Use system TTS
             speakWithSystemTts(text, voice, pitch, rate)
             return
@@ -716,7 +716,7 @@ class DesktopSpeechService(
         val koin = GlobalContext.getOrNull()
         val settingsRepo = koin?.let { runCatching { it.get<io.github.jdreioe.wingmate.domain.SettingsRepository>() }.getOrNull() }
         val uiSettings = settingsRepo?.let { runCatching { runBlocking { it.get() } }.getOrNull() }
-        if (uiSettings?.useSystemTts == true) {
+        if (uiSettings?.ttsEngine == io.github.jdreioe.wingmate.domain.TtsEngine.SYSTEM) {
             log.info("System TTS preferred; skipping Azure SSML merge path")
             return false
         }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSpeechService.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSpeechService.kt
@@ -335,7 +335,7 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
         val combinedText = segments.joinToString("") { it.text }
 
         // If user prefers system TTS, use it directly
-        if (uiSettings?.useSystemTts == true) {
+        if (uiSettings?.ttsEngine == io.github.jdreioe.wingmate.domain.TtsEngine.SYSTEM) {
             recordHistory(combinedText, voice) // Record ONCE for the whole sentence
             playSegmentsWithPlatformTts(segments, voice, pitch, rate)
             return
@@ -842,7 +842,7 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
         val uiSettings = settingsRepo?.let { runCatching { it.get() }.getOrNull() }
         
         // If user prefers system TTS, use platform TTS approach
-        if (uiSettings?.useSystemTts == true) {
+        if (uiSettings?.ttsEngine == io.github.jdreioe.wingmate.domain.TtsEngine.SYSTEM) {
             playSegmentsWithPlatformTts(currentSegments.drop(startIndex), currentVoice, currentPitch, currentRate)
         } else {
             // For Azure TTS: concatenate remaining segments and use main speak logic

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureArmClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureArmClient.kt
@@ -1,0 +1,136 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.domain.AzureF0Resource
+import io.github.jdreioe.wingmate.domain.AzureSubscription
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Client for Azure Resource Manager REST API.
+ * Requires an access token obtained via MSAL (or other OAuth flow).
+ */
+class AzureArmClient(private val httpClient: HttpClient) {
+
+    private val armBaseUrl = "https://management.azure.com"
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /**
+     * List all Azure subscriptions accessible to the signed-in user.
+     */
+    suspend fun listSubscriptions(accessToken: String): List<AzureSubscription> {
+        val response: HttpResponse = httpClient.get("$armBaseUrl/subscriptions") {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            parameter("api-version", "2020-01-01")
+        }
+        if (!response.status.isSuccess()) {
+            throw RuntimeException("Failed to list subscriptions: ${response.status}")
+        }
+        val body = response.body<SubscriptionListResponse>()
+        return body.value.map { it.toDomain() }
+    }
+
+    /**
+     * List F0 Speech resources in a subscription.
+     */
+    suspend fun listF0SpeechResources(accessToken: String, subscriptionId: String): List<AzureF0Resource> {
+        val response: HttpResponse = httpClient.get(
+            "$armBaseUrl/subscriptions/$subscriptionId/providers/Microsoft.CognitiveServices/accounts"
+        ) {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            parameter("api-version", "2024-10-01")
+        }
+        if (!response.status.isSuccess()) {
+            throw RuntimeException("Failed to list Speech resources: ${response.status}")
+        }
+        val body = response.body<CognitiveAccountsListResponse>()
+        return body.value
+            .filter { it.kind == "SpeechServices" && it.sku?.name == "F0" }
+            .map { it.toDomain(subscriptionId) }
+    }
+
+    /**
+     * Get details of a specific Speech resource.
+     */
+    suspend fun getResourceKeys(accessToken: String, resourceId: String): ResourceKeys? {
+        val response: HttpResponse = httpClient.post("$armBaseUrl$resourceId/listKeys") {
+            header(HttpHeaders.Authorization, "Bearer $accessToken")
+            parameter("api-version", "2024-10-01")
+        }
+        if (!response.status.isSuccess()) {
+            if (response.status.value == 403) return null
+            throw RuntimeException("Failed to list keys: ${response.status}")
+        }
+        return response.body<ResourceKeys>()
+    }
+
+    @Serializable
+    private data class SubscriptionListResponse(
+        val value: List<SubscriptionDto>
+    )
+
+    @Serializable
+    private data class SubscriptionDto(
+        val subscriptionId: String,
+        val displayName: String,
+        val tenantId: String? = null,
+        val state: String = "Enabled"
+    ) {
+        fun toDomain() = AzureSubscription(
+            id = subscriptionId,
+            name = displayName,
+            tenantId = tenantId ?: "",
+            state = state
+        )
+    }
+
+    @Serializable
+    private data class CognitiveAccountsListResponse(
+        val value: List<CognitiveAccountDto>
+    )
+
+    @Serializable
+    private data class CognitiveAccountDto(
+        val id: String? = null,
+        val name: String? = null,
+        val location: String? = null,
+        val kind: String? = null,
+        val sku: SkuDto? = null,
+        val properties: PropertiesDto? = null
+    ) {
+        fun toDomain(subscriptionId: String) = AzureF0Resource(
+            id = id ?: "",
+            name = name ?: "",
+            region = location ?: "",
+            resourceGroup = extractResourceGroup(id)
+        )
+
+        private fun extractResourceGroup(resourceId: String?): String {
+            if (resourceId == null) return ""
+            // /subscriptions/{sub}/resourceGroups/{rg}/providers/...
+            val parts = resourceId.split("/")
+            val rgIndex = parts.indexOf("resourceGroups")
+            return if (rgIndex >= 0 && rgIndex + 1 < parts.size) parts[rgIndex + 1] else ""
+        }
+    }
+
+    @Serializable
+    private data class SkuDto(
+        val name: String? = null
+    )
+
+    @Serializable
+    private data class PropertiesDto(
+        val publicNetworkAccess: String? = null
+    )
+}
+
+@Serializable
+data class ResourceKeys(
+    val key1: String? = null,
+    val key2: String? = null
+)

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/InMemoryAzureF0Provisioner.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/InMemoryAzureF0Provisioner.kt
@@ -1,0 +1,37 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.domain.AzureF0Provisioner
+import io.github.jdreioe.wingmate.domain.AzureF0Resource
+import io.github.jdreioe.wingmate.domain.AzureSignInResult
+import io.github.jdreioe.wingmate.domain.AzureSignedInUser
+import io.github.jdreioe.wingmate.domain.AzureSubscription
+
+class InMemoryAzureF0Provisioner : AzureF0Provisioner {
+    private var signedIn = false
+    private var subscriptions = listOf<AzureSubscription>()
+    private var f0Resources = mutableMapOf<String, List<AzureF0Resource>>()
+
+    fun configureSubscriptions(subs: List<AzureSubscription>) { subscriptions = subs }
+
+    fun configureF0Resources(subscriptionId: String, resources: List<AzureF0Resource>) {
+        f0Resources[subscriptionId] = resources
+    }
+
+    override suspend fun signIn(): AzureSignInResult {
+        signedIn = true
+        return AzureSignInResult.SUCCESS
+    }
+
+    override suspend fun signOut() { signedIn = false }
+
+    override suspend fun isSignedIn(): Boolean = signedIn
+
+    override suspend fun getSignedInUser(): AzureSignedInUser? = if (signedIn)
+        AzureSignedInUser("Test User", "test@example.com", "tenant-id") else null
+
+    override suspend fun getSubscriptions(): List<AzureSubscription> =
+        if (signedIn) subscriptions else emptyList()
+
+    override suspend fun getF0Resources(subscriptionId: String): List<AzureF0Resource> =
+        if (signedIn) f0Resources[subscriptionId] ?: emptyList() else emptyList()
+}

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/AzureF0Provisioner.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/AzureF0Provisioner.kt
@@ -1,0 +1,40 @@
+package io.github.jdreioe.wingmate.domain
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AzureSubscription(
+    val id: String,
+    val name: String,
+    val tenantId: String,
+    val state: String = "Enabled"
+)
+
+@Serializable
+data class AzureF0Resource(
+    val id: String,
+    val name: String,
+    val region: String,
+    val resourceGroup: String
+)
+
+enum class AzureSignInResult {
+    SUCCESS,
+    CANCELLED,
+    ERROR
+}
+
+data class AzureSignedInUser(
+    val displayName: String,
+    val username: String,
+    val tenantId: String
+)
+
+interface AzureF0Provisioner {
+    suspend fun signIn(): AzureSignInResult
+    suspend fun signOut()
+    suspend fun isSignedIn(): Boolean
+    suspend fun getSignedInUser(): AzureSignedInUser?
+    suspend fun getSubscriptions(): List<AzureSubscription>
+    suspend fun getF0Resources(subscriptionId: String): List<AzureF0Resource>
+}

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/model.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/model.kt
@@ -36,6 +36,13 @@ enum class StartupMode {
 }
 
 @Serializable
+enum class TtsEngine {
+    SYSTEM,
+    AZURE_USER_RESOURCE,
+    AZURE_MANAGED
+}
+
+@Serializable
 data class Settings(
     val language: String = "en-US",
     val voice: String = "default",
@@ -43,8 +50,8 @@ data class Settings(
     // UI-level settings: primary and secondary locales used by the UI language selector
     val primaryLanguage: String = "en-US",
     val secondaryLanguage: String = "en-US",
-    // TTS preference: true = use system TTS, false = use Azure TTS
-    val useSystemTts: Boolean = false,
+    // TTS engine selection
+    val ttsEngine: TtsEngine = TtsEngine.SYSTEM,
     // Desktop (Linux) only: when true, route TTS audio to a virtual sink whose monitor can be used as a microphone in apps like Zoom
     val virtualMicEnabled: Boolean = false,
     // Auto-update settings

--- a/core/presentation/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/SettingsStateManager.kt
+++ b/core/presentation/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/SettingsStateManager.kt
@@ -3,8 +3,10 @@ package io.github.jdreioe.wingmate.application
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import io.github.jdreioe.wingmate.domain.ConfigRepository
 import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.SettingsRepository
+import io.github.jdreioe.wingmate.domain.TtsEngine
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -15,24 +17,50 @@ import kotlinx.coroutines.launch
  * when settings change, enabling hot reload of UI settings without app restart.
  */
 class SettingsStateManager(
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val configRepository: ConfigRepository
 ) {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
-    
+
     private val _settings = MutableStateFlow(Settings())
     val settings: StateFlow<Settings> = _settings.asStateFlow()
-    
+
     init {
-        // Load initial settings
+        // Load initial settings and run one-time migration from old useSystemTts format
         scope.launch {
             try {
                 val initialSettings = settingsRepository.get()
-                _settings.value = initialSettings
+                val migrated = migrateIfNeeded(initialSettings)
+                _settings.value = migrated
             } catch (e: Exception) {
                 // Fall back to default settings if loading fails
                 _settings.value = Settings()
             }
         }
+    }
+
+    /**
+     * One-time migration from the old boolean useSystemTts to the new TtsEngine enum.
+     *
+     * Heuristic: if the user has saved Azure credentials but ttsEngine is still the
+     * default SYSTEM, they likely had useSystemTts=false before the migration.
+     * We upgrade them to AZURE_USER_RESOURCE so existing Azure users continue working.
+     */
+    private suspend fun migrateIfNeeded(settings: Settings): Settings {
+        if (settings.ttsEngine != TtsEngine.SYSTEM) {
+            // Already migrated (or explicitly set to something other than default)
+            return settings
+        }
+        val config = runCatching { configRepository.getSpeechConfig() }.getOrNull()
+        val hasAzureCredentials = config != null &&
+            config.endpoint.isNotBlank() &&
+            config.subscriptionKey.isNotBlank()
+        if (hasAzureCredentials) {
+            val migrated = settings.copy(ttsEngine = TtsEngine.AZURE_USER_RESOURCE)
+            runCatching { settingsRepository.update(migrated) }
+            return migrated
+        }
+        return settings
     }
     
     /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,9 @@ okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 
+# Microsoft Authentication Library (MSAL) for Android
+msal = { module = "com.microsoft.identity.client:msal", version = "5.2.0" }
+
 # Koin DI
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-android = { module = "io.insert-koin:koin-android", version.ref = "koin" }

--- a/infra/azure-user-f0/README.md
+++ b/infra/azure-user-f0/README.md
@@ -1,0 +1,105 @@
+# Wingmate F0 Speech Resource
+
+Deploys an Azure Cognitive Services Speech resource with the **F0 (free) SKU** for use with Wingmate.
+
+> The F0 tier includes **500,000 characters per month** free. This is sufficient for moderate daily use.
+
+## Quick Deploy
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fjdreioe%2Fwingmate%2Fmain%2Finfra%2Fazure-user-f0%2Fazuredeploy.json)
+
+Click the button above to open the Azure Portal with this template pre-loaded.
+
+## Prerequisites
+
+- An [Azure account](https://azure.microsoft.com/free) (free tier is sufficient)
+- Permissions to create resources in a resource group
+
+## What gets deployed
+
+| Resource | Type | SKU |
+|----------|------|-----|
+| Speech resource | `Microsoft.CognitiveServices/accounts` | **F0** (fixed, cannot select S0) |
+
+## Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `location` | `northeurope` | Azure region. Only EU regions are allowed (see below). |
+| `speechResourceName` | auto-generated | Optional custom name for the Speech resource. |
+| `tags` | `{}` | Optional Azure resource tags. |
+
+### Allowed regions
+
+Only the following EU regions are supported:
+
+- `northeurope` (Ireland)
+- `westeurope` (Netherlands)
+- `francecentral`
+- `germanywestcentral`
+- `switzerlandnorth`
+- `swedencentral`
+- `norwayeast`
+- `polandcentral`
+- `italynorth`
+- `spaincentral`
+
+## Manual deployment
+
+### Azure CLI
+
+```bash
+# Login
+az login
+
+# Deploy the template
+az deployment group create \
+  --resource-group <your-resource-group> \
+  --template-file main.bicep \
+  --parameters location=northeurope
+```
+
+### PowerShell
+
+```powershell
+New-AzResourceGroupDeployment `
+  -ResourceGroupName <your-resource-group> `
+  -TemplateFile azuredeploy.json `
+  -location northeurope
+```
+
+## Outputs
+
+After successful deployment, the template returns:
+
+| Output | Description |
+|--------|-------------|
+| `resourceId` | Full Azure resource ID |
+| `name` | Name of the Speech resource |
+| `region` | Azure region where deployed |
+| `portalUrl` | Link to the resource in Azure Portal |
+
+> **No secrets are exported.** Keys must be retrieved separately via the Azure Portal or `az cognitiveservices account keys list`.
+
+## Recovering an existing F0 resource
+
+Only one F0 Speech resource per subscription is allowed. If you already have an F0 Speech resource:
+
+1. Go to [Azure Portal > Speech Services](https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.CognitiveServices%2Faccounts)
+2. Locate your existing F0 resource
+3. Use its endpoint and key directly in Wingmate instead of creating a new one
+
+Attempting to deploy a second F0 resource will fail with a conflict error. This is expected behavior.
+
+## Security notes
+
+- The Speech key is **not** included in the template outputs
+- Local API authentication is enabled (default)
+- Public network access is enabled so the Wingmate app can reach the endpoint
+- Keys should be stored securely in the Wingmate app's platform secure storage (Android Keystore, iOS Keychain, OS keyring)
+
+## Related
+
+- [Azure Speech pricing](https://azure.microsoft.com/pricing/details/cognitive-services/speech-services/)
+- [Azure resource limits](https://learn.microsoft.com/azure/azure-resource-manager/management/azure-subscription-service-limits)
+- [Wingmate setup guide](../../README.md)

--- a/infra/azure-user-f0/azuredeploy.json
+++ b/infra/azure-user-f0/azuredeploy.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.33.13.18514",
+      "templateHash": "14631876761527801541"
+    },
+    "description": "Deploys an Azure Cognitive Services Speech resource with F0 (free) SKU. Used by Wingmate for automatic F0 setup."
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "northeurope",
+      "allowedValues": [
+        "northeurope",
+        "westeurope",
+        "francecentral",
+        "germanywestcentral",
+        "switzerlandnorth",
+        "swedencentral",
+        "norwayeast",
+        "polandcentral",
+        "italynorth",
+        "spaincentral"
+      ],
+      "metadata": {
+        "description": "Azure region for the Speech resource. Must be a supported EU region."
+      }
+    },
+    "speechResourceName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Optional: name of the Speech resource. Auto-generated if empty."
+      }
+    },
+    "tags": {
+      "type": "object",
+      "defaultValue": {},
+      "metadata": {
+        "description": "Optional: tags to apply to the resource."
+      }
+    }
+  },
+  "variables": {
+    "uniqueName": "[if(not(empty(parameters('speechResourceName'))), parameters('speechResourceName'), format('wingmate-f0-{0}', uniqueString(resourceGroup().id)))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.CognitiveServices/accounts",
+      "apiVersion": "2024-10-01",
+      "name": "[variables('uniqueName')]",
+      "location": "[parameters('location')]",
+      "kind": "SpeechServices",
+      "sku": {
+        "name": "F0"
+      },
+      "tags": "[parameters('tags')]",
+      "properties": {
+        "publicNetworkAccess": "Enabled",
+        "disableLocalAuth": false
+      }
+    }
+  ],
+  "outputs": {
+    "resourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.CognitiveServices/accounts', variables('uniqueName'))]"
+    },
+    "name": {
+      "type": "string",
+      "value": "[variables('uniqueName')]"
+    },
+    "region": {
+      "type": "string",
+      "value": "[parameters('location')]"
+    },
+    "portalUrl": {
+      "type": "string",
+      "value": "[format('https://portal.azure.com/#@/resource{0}', resourceId('Microsoft.CognitiveServices/accounts', variables('uniqueName')))]"
+    }
+  }
+}

--- a/infra/azure-user-f0/check.sh
+++ b/infra/azure-user-f0/check.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Non-mutating validation/check task for the F0 deployment template.
+# Runs basic structural checks without touching Azure.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE="$SCRIPT_DIR/azuredeploy.json"
+BICEP="$SCRIPT_DIR/main.bicep"
+
+errors=0
+
+echo "=== azuredeploy.json checks ==="
+
+# 1. Must be valid JSON
+if python3 -c "import json; json.load(open('$TEMPLATE'))" 2>/dev/null; then
+    echo "  [PASS] Valid JSON"
+else
+    echo "  [FAIL] Invalid JSON"
+    errors=$((errors + 1))
+fi
+
+# 2. Must be an ARM template
+SCHEMA=$(python3 -c "import json; d=json.load(open('$TEMPLATE')); print(d.get('\$schema',''))" 2>/dev/null)
+if echo "$SCHEMA" | grep -q "deploymentTemplate"; then
+    echo "  [PASS] Schema is ARM deploymentTemplate"
+else
+    echo "  [FAIL] Missing or wrong \$schema"
+    errors=$((errors + 1))
+fi
+
+# 3. Content version must be present
+CONTENT_VER=$(python3 -c "import json; d=json.load(open('$TEMPLATE')); print(d.get('contentVersion',''))" 2>/dev/null)
+if [ -n "$CONTENT_VER" ]; then
+    echo "  [PASS] contentVersion = $CONTENT_VER"
+else
+    echo "  [FAIL] Missing contentVersion"
+    errors=$((errors + 1))
+fi
+
+# 4. SKU must be F0 (not S0)
+SKU=$(python3 -c "
+import json
+d = json.load(open('$TEMPLATE'))
+resources = d.get('resources', [])
+for r in resources:
+    if r.get('type','').endswith('accounts'):
+        print(r.get('sku',{}).get('name',''))
+" 2>/dev/null)
+if [ "$SKU" = "F0" ]; then
+    echo "  [PASS] SKU is F0"
+else
+    echo "  [FAIL] SKU is '$SKU' (expected F0)"
+    errors=$((errors + 1))
+fi
+
+# 5. Kind must be SpeechServices
+KIND=$(python3 -c "
+import json
+d = json.load(open('$TEMPLATE'))
+resources = d.get('resources', [])
+for r in resources:
+    if r.get('type','').endswith('accounts'):
+        print(r.get('kind',''))
+" 2>/dev/null)
+if [ "$KIND" = "SpeechServices" ]; then
+    echo "  [PASS] Kind is SpeechServices"
+else
+    echo "  [FAIL] Kind is '$KIND' (expected SpeechServices)"
+    errors=$((errors + 1))
+fi
+
+# 6. Default location must be northeurope
+DEFAULT_LOC=$(python3 -c "
+import json; d=json.load(open('$TEMPLATE'))
+p = d.get('parameters',{}).get('location',{})
+print(p.get('defaultValue',''))
+" 2>/dev/null)
+if [ "$DEFAULT_LOC" = "northeurope" ]; then
+    echo "  [PASS] Default location is northeurope"
+else
+    echo "  [FAIL] Default location is '$DEFAULT_LOC' (expected northeurope)"
+    errors=$((errors + 1))
+fi
+
+# 7. Allowed locations must include only EU regions
+ALLOWED_LOCS=$(python3 -c "
+import json; d=json.load(open('$TEMPLATE'))
+p = d.get('parameters',{}).get('location',{})
+print(' '.join(p.get('allowedValues',[])))
+" 2>/dev/null)
+EU_REGIONS="northeurope westeurope francecentral germanywestcentral switzerlandnorth swedencentral norwayeast polandcentral italynorth spaincentral"
+if [ "$ALLOWED_LOCS" = "$EU_REGIONS" ]; then
+    echo "  [PASS] Allowed regions are EU-only"
+else
+    echo "  [FAIL] Allowed regions mismatch"
+    echo "    expected: $EU_REGIONS"
+    echo "    got:      $ALLOWED_LOCS"
+    errors=$((errors + 1))
+fi
+
+# 8. No secret outputs
+OUTPUTS=$(python3 -c "
+import json; d=json.load(open('$TEMPLATE'))
+outs = d.get('outputs',{})
+for k,v in outs.items():
+    print(k)
+" 2>/dev/null | sort)
+if echo "$OUTPUTS" | grep -q "key\|secret\|password\|connectionString"; then
+    echo "  [FAIL] Output contains secret: $OUTPUTS"
+    errors=$((errors + 1))
+else
+    echo "  [PASS] No secret in outputs"
+fi
+
+# 9. Public network access must be enabled
+PUBLIC_NET=$(python3 -c "
+import json; d=json.load(open('$TEMPLATE'))
+resources = d.get('resources', [])
+for r in resources:
+    if r.get('type','').endswith('accounts'):
+        print(r.get('properties',{}).get('publicNetworkAccess',''))
+" 2>/dev/null)
+if [ "$PUBLIC_NET" = "Enabled" ]; then
+    echo "  [PASS] Public network access is Enabled"
+else
+    echo "  [FAIL] Public network access is '$PUBLIC_NET' (expected Enabled)"
+    errors=$((errors + 1))
+fi
+
+echo ""
+echo "=== main.bicep check ==="
+if [ -f "$BICEP" ]; then
+    echo "  [PASS] main.bicep exists"
+else
+    echo "  [FAIL] main.bicep missing"
+    errors=$((errors + 1))
+fi
+
+echo ""
+if [ "$errors" -eq 0 ]; then
+    echo "All checks passed."
+else
+    echo "$errors check(s) failed."
+    exit 1
+fi

--- a/infra/azure-user-f0/main.bicep
+++ b/infra/azure-user-f0/main.bicep
@@ -1,0 +1,41 @@
+@description('Azure region for the Speech resource. Must be a supported EU region.')
+@allowed([
+  'northeurope'
+  'westeurope'
+  'francecentral'
+  'germanywestcentral'
+  'switzerlandnorth'
+  'swedencentral'
+  'norwayeast'
+  'polandcentral'
+  'italynorth'
+  'spaincentral'
+])
+param location string = 'northeurope'
+
+@description('Optional: name of the Speech resource. Auto-generated if empty.')
+param speechResourceName string = ''
+
+@description('Optional: tags to apply to the resource.')
+param tags object = {}
+
+var uniqueName = !empty(speechResourceName) ? speechResourceName : 'wingmate-f0-${uniqueString(resourceGroup().id)}'
+
+resource speech 'Microsoft.CognitiveServices/accounts@2024-10-01' = {
+  name: uniqueName
+  location: location
+  kind: 'SpeechServices'
+  sku: {
+    name: 'F0'
+  }
+  tags: tags
+  properties: {
+    publicNetworkAccess: 'Enabled'
+    disableLocalAuth: false
+  }
+}
+
+output resourceId string = speech.id
+output name string = speech.name
+output region string = speech.location
+output portalUrl string = 'https://portal.azure.com/#@/resource${speech.id}'

--- a/linuxApp/bin/main/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/bin/main/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -19,6 +19,7 @@ import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.TextPredictionService
 import io.github.jdreioe.wingmate.domain.SaidTextRepository
 import io.github.jdreioe.wingmate.domain.Voice
+import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.domain.VoiceRepository
 import io.github.jdreioe.wingmate.infrastructure.SimpleNGramPredictionService
 import io.github.jdreioe.wingmate.infrastructure.DictionaryLoader
@@ -181,10 +182,10 @@ class KotlinBridge(private val port: Int = 8765) {
             }
             
             put("/api/settings/systemtts") {
-                val params = call.receive<Map<String, Boolean>>()
-                val useSystem = params["useSystemTts"] ?: true
+                val params = call.receive<Map<String, String>>()
+                val engineStr = params["ttsEngine"] ?: "SYSTEM"
                 val current = settingsManager.settings.value ?: io.github.jdreioe.wingmate.domain.Settings()
-                settingsManager.updateSettings(current.copy(useSystemTts = useSystem))
+                settingsManager.updateSettings(current.copy(ttsEngine = if (engineStr == "SYSTEM") TtsEngine.SYSTEM else TtsEngine.AZURE_USER_RESOURCE))
                 call.respond(HttpStatusCode.OK)
             }
             
@@ -217,9 +218,9 @@ class KotlinBridge(private val port: Int = 8765) {
                                 
                             println("[SPEECH] Selected voice: ${voice.name}, Language: ${voice.selectedLanguage}")
 
-                            // Logic: useSystemTts=true -> Piper/Local. useSystemTts=false -> Azure.
-                            // Default is false, which means Azure.
-                            if (settings?.useSystemTts == true) { // Use explicit true check
+                            // Logic: ttsEngine=SYSTEM -> Piper/Local. ttsEngine=AZURE_USER_RESOURCE -> Azure.
+                            // Default is SYSTEM.
+                            if (settings?.ttsEngine == io.github.jdreioe.wingmate.domain.TtsEngine.SYSTEM) {
                                 println("[SPEECH] Using System TTS (LinuxSpeechService)")
                                 speechService.speak(text, voice)
                             } else {

--- a/linuxApp/src/main.qml
+++ b/linuxApp/src/main.qml
@@ -28,7 +28,7 @@ Kirigami.ApplicationWindow {
     property var availableLanguages: []
     property string currentVoice: "default"
     property string currentLanguage: "en-US"
-    property bool useSystemTts: false
+    property string ttsEngine: "SYSTEM"
     property real speechRate: 1.0
     property string selectedCategoryId: ""
     property bool speechControlsVisible: true
@@ -97,7 +97,7 @@ Kirigami.ApplicationWindow {
                     if (settings.language) currentLanguage = settings.language;
                     if (settings.voice) currentVoice = settings.voice;
                     if (settings.speechRate) speechRate = settings.speechRate;
-                    if (settings.useSystemTts !== undefined) useSystemTts = settings.useSystemTts;
+                    if (settings.ttsEngine !== undefined) ttsEngine = settings.ttsEngine;
                     if (settings.partnerWindowEnabled !== undefined) {
                         partnerWindowEnabled = settings.partnerWindowEnabled;
                         // Sync persisted setting to Rust partner window bridge
@@ -325,7 +325,7 @@ Kirigami.ApplicationWindow {
             visible: root.speechControlsVisible
             baseUrl: root.baseUrl
             voiceName: root.currentVoice
-            engineName: root.useSystemTts ? "System (Local)" : "Azure (Premium)"
+            engineName: root.ttsEngine === "SYSTEM" ? "System (Local)" : "Azure (Premium)"
             speedValue: root.speechRate
             
             onChangeEngineRequested: speechSettingsDialog.open()
@@ -754,7 +754,7 @@ Kirigami.ApplicationWindow {
     Dialogs.SpeechSettingsDialog {
         id: speechSettingsDialog
         baseUrl: root.baseUrl
-        useAzure: !root.useSystemTts
+        useAzure: root.ttsEngine !== "SYSTEM"
         
         Component.onCompleted: {
             // Load azure config
@@ -775,8 +775,8 @@ Kirigami.ApplicationWindow {
             var xhr = new XMLHttpRequest();
             xhr.open("PUT", root.baseUrl + "/api/settings/systemtts");
             xhr.setRequestHeader("Content-Type", "application/json");
-            xhr.send(JSON.stringify({ useSystemTts: !useAzure }));
-            root.useSystemTts = !useAzure;
+            xhr.send(JSON.stringify({ ttsEngine: useAzure ? "AZURE_USER_RESOURCE" : "SYSTEM" }));
+            root.ttsEngine = useAzure ? "AZURE_USER_RESOURCE" : "SYSTEM";
             
             // Save Azure config
             if (useAzure) {

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -19,6 +19,7 @@ import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.TextPredictionService
 import io.github.jdreioe.wingmate.domain.SaidTextRepository
 import io.github.jdreioe.wingmate.domain.Voice
+import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.domain.VoiceRepository
 import io.github.jdreioe.wingmate.infrastructure.SimpleNGramPredictionService
 import io.github.jdreioe.wingmate.infrastructure.DictionaryLoader
@@ -181,10 +182,10 @@ class KotlinBridge(private val port: Int = 8765) {
             }
             
             put("/api/settings/systemtts") {
-                val params = call.receive<Map<String, Boolean>>()
-                val useSystem = params["useSystemTts"] ?: true
+                val params = call.receive<Map<String, String>>()
+                val engineStr = params["ttsEngine"] ?: "SYSTEM"
                 val current = settingsManager.settings.value ?: io.github.jdreioe.wingmate.domain.Settings()
-                settingsManager.updateSettings(current.copy(useSystemTts = useSystem))
+                settingsManager.updateSettings(current.copy(ttsEngine = if (engineStr == "SYSTEM") TtsEngine.SYSTEM else TtsEngine.AZURE_USER_RESOURCE))
                 call.respond(HttpStatusCode.OK)
             }
             
@@ -217,9 +218,9 @@ class KotlinBridge(private val port: Int = 8765) {
                                 
                             println("[SPEECH] Selected voice: ${voice.name}, Language: ${voice.selectedLanguage}")
 
-                            // Logic: useSystemTts=true -> Piper/Local. useSystemTts=false -> Azure.
-                            // Default is false, which means Azure.
-                            if (settings?.useSystemTts == true) { // Use explicit true check
+                            // Logic: ttsEngine=SYSTEM -> Piper/Local. ttsEngine=AZURE_USER_RESOURCE -> Azure.
+                            // Default is SYSTEM.
+                            if (settings?.ttsEngine == io.github.jdreioe.wingmate.domain.TtsEngine.SYSTEM) {
                                 println("[SPEECH] Using System TTS (LinuxSpeechService)")
                                 speechService.speak(text, voice)
                             } else {

--- a/linuxApp/src/pages/SettingsPage.qml
+++ b/linuxApp/src/pages/SettingsPage.qml
@@ -13,7 +13,7 @@ Item {
     property string currentLanguage: "en-US"
     property string currentVoice: "default"
     property real speechRate: 1.0
-    property bool useSystemTts: false
+    property string ttsEngine: "SYSTEM"
     property bool partnerWindowEnabled: false
     property int partnerWindowFontSize: 31
     property bool partnerWindowIdleEnabled: true
@@ -138,7 +138,7 @@ Item {
                 }
                 if (settings.voice) currentVoice = settings.voice;
                 if (settings.speechRate) speechRate = settings.speechRate;
-                if (settings.useSystemTts !== undefined) useSystemTts = settings.useSystemTts;
+                if (settings.ttsEngine !== undefined) ttsEngine = settings.ttsEngine;
                 if (settings.partnerWindowEnabled !== undefined) partnerWindowEnabled = settings.partnerWindowEnabled;
                 if (settings.partnerWindowFontSize !== undefined) partnerWindowFontSize = settings.partnerWindowFontSize;
                 if (settings.partnerWindowIdleEnabled !== undefined) partnerWindowIdleEnabled = settings.partnerWindowIdleEnabled;
@@ -198,8 +198,8 @@ Item {
         var xhr = new XMLHttpRequest();
         xhr.open("PUT", baseUrl + "/api/settings/systemtts");
         xhr.setRequestHeader("Content-Type", "application/json");
-        xhr.send(JSON.stringify({ useSystemTts: enabled }));
-        useSystemTts = enabled;
+        xhr.send(JSON.stringify({ ttsEngine: enabled ? "SYSTEM" : "AZURE_USER_RESOURCE" }));
+        ttsEngine = enabled ? "SYSTEM" : "AZURE_USER_RESOURCE";
     }
     
     function updatePartnerWindow(enabled) {
@@ -349,9 +349,9 @@ Item {
                         // TTS Mode
                         Controls.CheckBox {
                             text: "Use Local TTS (Piper/eSpeak)"
-                            checked: useSystemTts
+                            checked: ttsEngine === "SYSTEM"
                             onClicked: updateSystemTts(checked)
-                            
+
                             contentItem: Text {
                                 text: parent.text
                                 color: Theme.text
@@ -367,7 +367,7 @@ Item {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     title: "Azure Speech"
-                    visible: !useSystemTts
+                    visible: ttsEngine !== "SYSTEM"
                     
                     content: ColumnLayout {
                         spacing: 12

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/di.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/di.kt
@@ -10,8 +10,28 @@ import io.github.jdreioe.wingmate.application.CategoryUseCase
 import io.github.jdreioe.wingmate.application.FeatureUsageReporter
 import io.github.jdreioe.wingmate.application.NoopFeatureUsageReporter
 import io.github.jdreioe.wingmate.application.SettingsStateManager
-import io.github.jdreioe.wingmate.domain.*
-import io.github.jdreioe.wingmate.infrastructure.*
+import io.github.jdreioe.wingmate.domain.AzureF0Provisioner
+import io.github.jdreioe.wingmate.domain.CategoryRepository
+import io.github.jdreioe.wingmate.domain.ConfigRepository
+import io.github.jdreioe.wingmate.domain.UserDataManager
+import io.github.jdreioe.wingmate.domain.FileStorage
+import io.github.jdreioe.wingmate.domain.PhraseRepository
+import io.github.jdreioe.wingmate.domain.PronunciationDictionaryRepository
+import io.github.jdreioe.wingmate.domain.SaidTextRepository
+import io.github.jdreioe.wingmate.domain.SettingsRepository
+import io.github.jdreioe.wingmate.domain.SpeechService
+import io.github.jdreioe.wingmate.domain.VoiceRepository
+import io.github.jdreioe.wingmate.infrastructure.InMemoryAzureF0Provisioner
+import io.github.jdreioe.wingmate.infrastructure.InMemoryCategoryRepository
+import io.github.jdreioe.wingmate.infrastructure.InMemoryConfigRepository
+import io.github.jdreioe.wingmate.infrastructure.DictionaryLoader
+import io.github.jdreioe.wingmate.infrastructure.InMemoryPhraseRepository
+import io.github.jdreioe.wingmate.infrastructure.InMemoryPronunciationDictionaryRepository
+import io.github.jdreioe.wingmate.infrastructure.InMemorySaidTextRepository
+import io.github.jdreioe.wingmate.infrastructure.InMemorySettingsRepository
+import io.github.jdreioe.wingmate.infrastructure.InMemoryVoiceRepository
+import io.github.jdreioe.wingmate.infrastructure.NoopSpeechService
+import io.github.jdreioe.wingmate.infrastructure.AzureVoiceCatalog
 import org.koin.core.context.startKoin
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.bind
@@ -30,6 +50,7 @@ fun initKoin(extra: Module? = null) {
         singleOf(::InMemorySaidTextRepository) { bind<SaidTextRepository>() }
         singleOf(::InMemoryConfigRepository) { bind<ConfigRepository>() }
         singleOf(::InMemoryPronunciationDictionaryRepository) { bind<PronunciationDictionaryRepository>() }
+        singleOf(::InMemoryAzureF0Provisioner) { bind<AzureF0Provisioner>() }
         singleOf(::NoopSpeechService) { bind<SpeechService>() } // Android overrides this
         singleOf(::NoopFeatureUsageReporter) { bind<FeatureUsageReporter>() }
         singleOf(::AzureVoiceCatalog)

--- a/shared/src/commonTest/kotlin/AzureF0ProvisionerTest.kt
+++ b/shared/src/commonTest/kotlin/AzureF0ProvisionerTest.kt
@@ -1,0 +1,95 @@
+import io.github.jdreioe.wingmate.domain.AzureF0Provisioner
+import io.github.jdreioe.wingmate.domain.AzureF0Resource
+import io.github.jdreioe.wingmate.domain.AzureSignInResult
+import io.github.jdreioe.wingmate.domain.AzureSubscription
+import io.github.jdreioe.wingmate.infrastructure.InMemoryAzureF0Provisioner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class AzureF0ProvisionerTest {
+
+    private fun createProvisioner(): InMemoryAzureF0Provisioner = InMemoryAzureF0Provisioner()
+
+    @Test
+    fun initiallyNotSignedIn() = kotlinx.coroutines.runBlocking {
+        val p = createProvisioner()
+        assertFalse(p.isSignedIn())
+        assertNull(p.getSignedInUser())
+    }
+
+    @Test
+    fun signInReturnsSuccess() = kotlinx.coroutines.runBlocking {
+        val p = createProvisioner()
+        val result = p.signIn()
+        assertEquals(AzureSignInResult.SUCCESS, result)
+        assertTrue(p.isSignedIn())
+    }
+
+    @Test
+    fun signedInUserHasInfo() = kotlinx.coroutines.runBlocking {
+        val p = createProvisioner()
+        p.signIn()
+        val user = p.getSignedInUser()
+        assertNotNull(user)
+        assertEquals("Test User", user.displayName)
+        assertEquals("test@example.com", user.username)
+    }
+
+    @Test
+    fun signOutClearsState() = kotlinx.coroutines.runBlocking {
+        val p = createProvisioner()
+        p.signIn()
+        assertTrue(p.isSignedIn())
+        p.signOut()
+        assertFalse(p.isSignedIn())
+        assertNull(p.getSignedInUser())
+    }
+
+    @Test
+    fun emptySubscriptionsWhenNotSignedIn() = kotlinx.coroutines.runBlocking {
+        val p = createProvisioner()
+        val subs = p.getSubscriptions()
+        assertTrue(subs.isEmpty())
+    }
+
+    @Test
+    fun returnsConfiguredSubscriptions() = kotlinx.coroutines.runBlocking {
+        val p = createProvisioner()
+        val testSubs = listOf(
+            AzureSubscription("sub-1", "Subscription 1", "tenant-1"),
+            AzureSubscription("sub-2", "Subscription 2", "tenant-1")
+        )
+        p.configureSubscriptions(testSubs)
+        p.signIn()
+        val subs = p.getSubscriptions()
+        assertEquals(2, subs.size)
+        assertEquals("sub-1", subs[0].id)
+    }
+
+    @Test
+    fun returnsConfiguredF0Resources() = kotlinx.coroutines.runBlocking {
+        val p = createProvisioner()
+        val resources = listOf(
+            AzureF0Resource("res-1", "my-speech", "northeurope", "my-rg")
+        )
+        p.configureF0Resources("sub-1", resources)
+        p.signIn()
+        val result = p.getF0Resources("sub-1")
+        assertEquals(1, result.size)
+        assertEquals("my-speech", result[0].name)
+        assertEquals("northeurope", result[0].region)
+    }
+
+    @Test
+    fun zeroSubscriptionsRepresented() = kotlinx.coroutines.runBlocking {
+        val p = createProvisioner()
+        p.configureSubscriptions(emptyList())
+        p.signIn()
+        val subs = p.getSubscriptions()
+        assertTrue(subs.isEmpty())
+    }
+}

--- a/shared/src/commonTest/kotlin/SettingsModelTest.kt
+++ b/shared/src/commonTest/kotlin/SettingsModelTest.kt
@@ -1,0 +1,116 @@
+import io.github.jdreioe.wingmate.domain.Settings
+import io.github.jdreioe.wingmate.domain.TtsEngine
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class SettingsModelTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    @Test
+    fun newInstallDefaultsToSystem() {
+        val settings = Settings()
+        assertEquals(TtsEngine.SYSTEM, settings.ttsEngine)
+    }
+
+    @Test
+    fun canSetAzureUserResource() {
+        val settings = Settings(ttsEngine = TtsEngine.AZURE_USER_RESOURCE)
+        assertEquals(TtsEngine.AZURE_USER_RESOURCE, settings.ttsEngine)
+    }
+
+    @Test
+    fun canSetManaged() {
+        val settings = Settings(ttsEngine = TtsEngine.AZURE_MANAGED)
+        assertEquals(TtsEngine.AZURE_MANAGED, settings.ttsEngine)
+    }
+
+    @Test
+    fun jsonRoundTripProducesNewFormat() {
+        val original = Settings(ttsEngine = TtsEngine.AZURE_USER_RESOURCE)
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<Settings>(encoded)
+        assertEquals(TtsEngine.AZURE_USER_RESOURCE, decoded.ttsEngine)
+    }
+
+    @Test
+    fun jsonRoundTripSystem() {
+        val original = Settings(ttsEngine = TtsEngine.SYSTEM)
+        val encoded = json.encodeToString(original)
+        val decoded = json.decodeFromString<Settings>(encoded)
+        assertEquals(TtsEngine.SYSTEM, decoded.ttsEngine)
+    }
+
+    @Test
+    fun oldFormatWithIgnoreUnknownKeysPreservesDefaults() {
+        // Simulate old JSON that had useSystemTts instead of ttsEngine
+        val oldJson = """{"language":"en-US","voice":"default","speechRate":1.0,"useSystemTts":true}"""
+        val settings = json.decodeFromString<Settings>(oldJson)
+        // With ignoreUnknownKeys = true, the old useSystemTts field is ignored
+        // ttsEngine gets the default: SYSTEM
+        assertEquals(TtsEngine.SYSTEM, settings.ttsEngine)
+    }
+
+    @Test
+    fun oldFormatWithUseSystemTtsFalseDefaultsToSystem() {
+        // Old format with useSystemTts=false. No ttsEngine field.
+        // Since we use ignoreUnknownKeys=true, useSystemTts is ignored
+        // and ttsEngine defaults to SYSTEM. Migration happens later in SettingsStateManager.
+        val oldJson = """{"language":"en-US","voice":"default","speechRate":1.0,"useSystemTts":false}"""
+        val settings = json.decodeFromString<Settings>(oldJson)
+        assertEquals(TtsEngine.SYSTEM, settings.ttsEngine)
+    }
+
+    @Test
+    fun newFormatDoesNotIncludeOldField() {
+        // Verify that serializing with the new format does NOT include useSystemTts
+        val settings = Settings(ttsEngine = TtsEngine.AZURE_USER_RESOURCE)
+        val encoded = json.encodeToString(settings)
+        // The old field name should not appear
+        assert(!encoded.contains("useSystemTts")) { "New serialization should not contain old useSystemTts field" }
+    }
+
+    @Test
+    fun newFormatContainsTtsEngine() {
+        val settings = Settings(ttsEngine = TtsEngine.AZURE_USER_RESOURCE)
+        val encoded = json.encodeToString(settings)
+        assert(encoded.contains("ttsEngine")) { "New serialization should contain ttsEngine field" }
+    }
+
+    @Test
+    fun migrationIdempotent() {
+        // Simulate: First migration produces ttsEngine, second read should keep it
+        val oldJson = """{"language":"en-US","voice":"default","speechRate":1.0,"useSystemTts":false}"""
+
+        // First decode (simulates first read with migration)
+        val firstRead = json.decodeFromString<Settings>(oldJson)
+        assertEquals(TtsEngine.SYSTEM, firstRead.ttsEngine) // old field ignored, default applied
+
+        // Manually migrate (as SettingsStateManager would)
+        val migrated = firstRead.copy(ttsEngine = TtsEngine.AZURE_USER_RESOURCE)
+        val migratedJson = json.encodeToString(migrated)
+
+        // Second read (simulates subsequent read after migration)
+        val secondRead = json.decodeFromString<Settings>(migratedJson)
+        assertEquals(TtsEngine.AZURE_USER_RESOURCE, secondRead.ttsEngine)
+
+        // Third read should be identical
+        val thirdRead = json.decodeFromString<Settings>(migratedJson)
+        assertEquals(secondRead, thirdRead)
+    }
+
+    @Test
+    fun settingsCopyWithTtsEngine() {
+        val original = Settings(language = "da-DK", voice = "da-DK-ChristelNeural")
+        val updated = original.copy(ttsEngine = TtsEngine.AZURE_USER_RESOURCE)
+        assertEquals(TtsEngine.AZURE_USER_RESOURCE, updated.ttsEngine)
+        assertEquals("da-DK", updated.language) // other fields preserved
+    }
+}


### PR DESCRIPTION
## Summary

Add Android-only identity and management client required for safe automatic F0 setup.

## Changes

- **MSAL 5.2.0** dependency + Microsoft Maven repo + AndroidManifest redirect URI
- **Domain interface**: `AzureF0Provisioner` + shared models (`AzureSubscription`, `AzureF0Resource`)
- **ARM client**: `AzureArmClient` in `core/data` — lists subscriptions, F0 resources, and keys via Azure REST API
- **Android implementation**: `AndroidAzureF0Provisioner` with MSAL interactive/silent sign-in, sign-out, account management
- **Config**: `msal_config.json` (placeholder — needs real Entra client ID + signature hash)
- **DI**: InMemory provisioner (base) + Android override
- **Tests**: 7 unit tests with fake provisioner covering all states

## Notes

- `msal_config.json` contains `YOUR_ENTRA_CLIENT_ID` and `YOUR_BASE64_SIGNATURE_HASH` placeholders — these must be filled in after creating the Entra app registration
- Tokens are managed by MSAL and never persisted by Wingmate code