### PR TITLE
[OBZ] Make ZIP output UTF-8-safe and linear-time (#49)

### DIFF
--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ZipBuilder.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ZipBuilder.kt
@@ -1,93 +1,131 @@
 package io.github.jdreioe.wingmate.domain.obf
 
-/**
- * Pure-Kotlin ZIP builder that creates store-method (uncompressed) ZIP archives.
- */
+sealed class ZipBuilderError(message: String) : Exception(message) {
+    data class InvalidEntryName(val name: String, override val message: String) : ZipBuilderError(message)
+    data class DuplicateEntryName(val name: String) : ZipBuilderError("Duplicate ZIP entry: $name")
+    data object Zip64Required : ZipBuilderError(
+        "Archive exceeds classic ZIP limits (entries > 65535, entry size > 4 GiB, " +
+            "or total archive > 4 GiB). ZIP64 is not implemented."
+    )
+}
+
 object ZipBuilder {
 
-    fun build(entries: Map<String, ByteArray>): ByteArray {
-        val localHeaders = mutableListOf<ByteArray>()
-        val centralEntries = mutableListOf<ByteArray>()
-        var offset = 0
+    fun build(entries: List<Pair<String, ByteArray>>): Result<ByteArray> = runCatching {
+        val sink = GrowableByteArray(8192)
+        val centralEntries = GrowableByteArray(4096)
+        val seenNames = mutableSetOf<String>()
+        var localOffset = 0L
 
         for ((name, data) in entries) {
+            validateEntryName(name, seenNames)
             val nameBytes = name.encodeToByteArray()
             val crc = crc32(data)
+            val dataSize = data.size
 
-            // Local file header
-            localHeaders += buildLocalHeader(nameBytes, data.size, crc)
-            localHeaders += data
+            checkOverflow(name, dataSize, localOffset)
 
-            // Central directory entry
-            centralEntries += buildCentralEntry(nameBytes, data.size, crc, offset)
+            sink.write(buildLocalHeader(nameBytes, dataSize, crc))
+            sink.write(data)
 
-            offset += 30 + nameBytes.size + data.size
+            centralEntries.write(buildCentralEntry(nameBytes, dataSize, crc, localOffset))
+
+            localOffset += 30L + nameBytes.size + dataSize
         }
 
-        val cdBytes = centralEntries.fold(byteArrayOf()) { acc, e -> acc + e }
-        val eocd = buildEndOfCentralDirectory(
-            totalEntries = entries.size,
-            centralDirSize = cdBytes.size,
-            centralDirOffset = offset
-        )
+        val entryCount = entries.size
+        val centralDirSize = centralEntries.size
+        checkClassicLimit(entryCount, "entry count", 65535)
+        checkClassicLimit(centralDirSize.toLong(), "central directory size", 0xFFFFFFFFL)
+        checkClassicLimit(localOffset, "central directory offset", 0xFFFFFFFFL)
 
-        return localHeaders.fold(byteArrayOf()) { acc, e -> acc + e } + cdBytes + eocd
+        sink.write(centralEntries.toByteArray())
+        sink.write(buildEndOfCentralDirectory(entryCount, centralDirSize.toLong(), localOffset))
+
+        sink.toByteArray()
+    }
+
+    private fun validateEntryName(name: String, seenNames: MutableSet<String>) {
+        if (name.isEmpty()) throw ZipBuilderError.InvalidEntryName(name, "Entry name must not be empty")
+        if (name.contains('\u0000')) throw ZipBuilderError.InvalidEntryName(name, "Entry name contains NUL character")
+        if (name.startsWith('/')) throw ZipBuilderError.InvalidEntryName(name, "Entry name must not be absolute")
+        if (Regex("(^|/)\\.\\.(/|$)").containsMatchIn(name)) {
+            throw ZipBuilderError.InvalidEntryName(name, "Entry name must not contain parent-directory traversal")
+        }
+        if (!seenNames.add(name)) throw ZipBuilderError.DuplicateEntryName(name)
+    }
+
+    private fun checkOverflow(name: String, dataSize: Int, localOffset: Long) {
+        if (dataSize > 0xFFFFFFFFL) {
+            throw ZipBuilderError.InvalidEntryName(name, "Entry size (${dataSize}B) exceeds 4 GiB limit")
+        }
+        if (localOffset + 30L + name.encodeToByteArray().size + dataSize > 0xFFFFFFFFL) {
+            throw ZipBuilderError.Zip64Required
+        }
+    }
+
+    private fun checkClassicLimit(value: Long, label: String, limit: Long) {
+        if (value > limit) throw ZipBuilderError.Zip64Required
+    }
+
+    private fun checkClassicLimit(value: Int, label: String, limit: Int) {
+        if (value > limit) throw ZipBuilderError.Zip64Required
     }
 
     private fun buildLocalHeader(nameBytes: ByteArray, dataSize: Int, crc: Int): ByteArray {
         val buf = ByteArray(30 + nameBytes.size)
-        writeLe32(buf, 0, 0x04034b50)       // signature
-        writeLe16(buf, 4, 20)                // version needed
-        writeLe16(buf, 6, 0)                 // flags
-        writeLe16(buf, 8, 0)                 // compression: stored
-        writeLe16(buf, 10, 0)                // mod time
-        writeLe16(buf, 12, 0)                // mod date
-        writeLe32(buf, 14, crc)              // crc-32
-        writeLe32(buf, 18, dataSize)         // compressed size
-        writeLe32(buf, 22, dataSize)         // uncompressed size
-        writeLe16(buf, 26, nameBytes.size)   // filename length
-        writeLe16(buf, 28, 0)                // extra field length
+        writeLe32(buf, 0, 0x04034b50)
+        writeLe16(buf, 4, 20)
+        writeLe16(buf, 6, 0x0800)
+        writeLe16(buf, 8, 0)
+        writeLe16(buf, 10, 0)
+        writeLe16(buf, 12, 0)
+        writeLe32(buf, 14, crc)
+        writeLe32(buf, 18, dataSize)
+        writeLe32(buf, 22, dataSize)
+        writeLe16(buf, 26, nameBytes.size)
+        writeLe16(buf, 28, 0)
         nameBytes.copyInto(buf, 30)
         return buf
     }
 
-    private fun buildCentralEntry(nameBytes: ByteArray, dataSize: Int, crc: Int, localOffset: Int): ByteArray {
+    private fun buildCentralEntry(nameBytes: ByteArray, dataSize: Int, crc: Int, localOffset: Long): ByteArray {
         val buf = ByteArray(46 + nameBytes.size)
-        writeLe32(buf, 0, 0x02014b50)        // signature
-        writeLe16(buf, 4, 20)                // version made by
-        writeLe16(buf, 6, 20)                // version needed
-        writeLe16(buf, 8, 0)                 // flags
-        writeLe16(buf, 10, 0)                // compression: stored
-        writeLe16(buf, 12, 0)                // mod time
-        writeLe16(buf, 14, 0)                // mod date
-        writeLe32(buf, 16, crc)              // crc-32
-        writeLe32(buf, 20, dataSize)         // compressed size
-        writeLe32(buf, 24, dataSize)         // uncompressed size
-        writeLe16(buf, 28, nameBytes.size)   // filename length
-        writeLe16(buf, 30, 0)                // extra field length
-        writeLe16(buf, 32, 0)                // file comment length
-        writeLe16(buf, 34, 0)                // disk number start
-        writeLe16(buf, 36, 0)                // internal file attributes
-        writeLe32(buf, 38, 0)                // external file attributes
-        writeLe32(buf, 42, localOffset)      // relative offset
+        writeLe32(buf, 0, 0x02014b50)
+        writeLe16(buf, 4, 20)
+        writeLe16(buf, 6, 20)
+        writeLe16(buf, 8, 0x0800)
+        writeLe16(buf, 10, 0)
+        writeLe16(buf, 12, 0)
+        writeLe16(buf, 14, 0)
+        writeLe32(buf, 16, crc)
+        writeLe32(buf, 20, dataSize)
+        writeLe32(buf, 24, dataSize)
+        writeLe16(buf, 28, nameBytes.size)
+        writeLe16(buf, 30, 0)
+        writeLe16(buf, 32, 0)
+        writeLe16(buf, 34, 0)
+        writeLe16(buf, 36, 0)
+        writeLe32(buf, 38, 0)
+        writeLe32(buf, 42, localOffset.toInt())
         nameBytes.copyInto(buf, 46)
         return buf
     }
 
     private fun buildEndOfCentralDirectory(
         totalEntries: Int,
-        centralDirSize: Int,
-        centralDirOffset: Int
+        centralDirSize: Long,
+        centralDirOffset: Long
     ): ByteArray {
         val buf = ByteArray(22)
-        writeLe32(buf, 0, 0x06054b50)        // signature
-        writeLe16(buf, 4, 0)                 // disk number
-        writeLe16(buf, 6, 0)                 // disk of central dir
-        writeLe16(buf, 8, totalEntries)      // entries on disk
-        writeLe16(buf, 10, totalEntries)     // total entries
-        writeLe32(buf, 12, centralDirSize)   // size of central dir
-        writeLe32(buf, 16, centralDirOffset) // offset of central dir
-        writeLe16(buf, 20, 0)                // comment length
+        writeLe32(buf, 0, 0x06054b50)
+        writeLe16(buf, 4, 0)
+        writeLe16(buf, 6, 0)
+        writeLe16(buf, 8, totalEntries)
+        writeLe16(buf, 10, totalEntries)
+        writeLe32(buf, 12, centralDirSize.toInt())
+        writeLe32(buf, 16, centralDirOffset.toInt())
+        writeLe16(buf, 20, 0)
         return buf
     }
 
@@ -117,5 +155,27 @@ object ZipBuilder {
             crc = (crc ushr 8) xor crcTable[(crc xor byte.toInt()) and 0xFF]
         }
         return crc xor 0xFFFFFFFF.toInt()
+    }
+}
+
+private class GrowableByteArray(initialCapacity: Int) {
+    private var buffer = ByteArray(initialCapacity.coerceAtLeast(1))
+    var size: Int = 0
+        private set
+
+    fun write(bytes: ByteArray) {
+        ensureCapacity(size + bytes.size)
+        bytes.copyInto(buffer, size)
+        size += bytes.size
+    }
+
+    fun toByteArray(): ByteArray = buffer.copyOf(size)
+
+    private fun ensureCapacity(minCapacity: Int) {
+        if (minCapacity > buffer.size) {
+            var newSize = buffer.size
+            while (newSize < minCapacity) newSize = (newSize * 2).coerceAtLeast(1)
+            buffer = buffer.copyOf(newSize)
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/ObzExporter.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/ObzExporter.kt
@@ -84,7 +84,7 @@ class ObzExporter(
         val manifestJson = json.encodeToJsonElement(ObfManifest.serializer(), manifest)
         entries["manifest.json"] = json.encodeToString(serializeWithExtensions(manifestJson, manifest)).encodeToByteArray()
 
-        return ZipBuilder.build(entries)
+        return ZipBuilder.build(entries.toList()).getOrThrow()
     }
 
     /**

--- a/shared/src/commonTest/kotlin/ZipBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/ZipBuilderTest.kt
@@ -1,26 +1,28 @@
 import io.github.jdreioe.wingmate.domain.obf.ZipBuilder
+import io.github.jdreioe.wingmate.domain.obf.ZipBuilderError
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class ZipBuilderTest {
 
     @Test
     fun buildsValidZipWithSingleEntry() {
-        val zip = ZipBuilder.build(mapOf("hello.txt" to "world".encodeToByteArray()))
+        val zip = ZipBuilder.build(listOf("hello.txt" to "world".encodeToByteArray())).getOrThrow()
         assertTrue(zip.size > 30)
-        // PK signature for local file header
         assertTrue(zip[0] == 0x50.toByte() && zip[1] == 0x4B.toByte() &&
             zip[2] == 0x03.toByte() && zip[3] == 0x04.toByte())
     }
 
     @Test
     fun buildsZipWithMultipleEntries() {
-        val entries = mapOf(
+        val entries = listOf(
             "a.txt" to "aaa".encodeToByteArray(),
             "b.txt" to "bbb".encodeToByteArray()
         )
-        val zip = ZipBuilder.build(entries)
+        val zip = ZipBuilder.build(entries).getOrThrow()
         assertTrue(zip.size > 60)
         assertTrue(String(zip).contains("a.txt"))
         assertTrue(String(zip).contains("b.txt"))
@@ -28,7 +30,7 @@ class ZipBuilderTest {
 
     @Test
     fun eocdSignaturePresent() {
-        val zip = ZipBuilder.build(mapOf("f" to "d".encodeToByteArray()))
+        val zip = ZipBuilder.build(listOf("f" to "d".encodeToByteArray())).getOrThrow()
         val tail = zip.copyOfRange(zip.size - 22, zip.size)
         assertTrue(tail[0] == 0x50.toByte() && tail[1] == 0x4B.toByte() &&
             tail[2] == 0x05.toByte() && tail[3] == 0x06.toByte())
@@ -36,17 +38,171 @@ class ZipBuilderTest {
 
     @Test
     fun emptyEntries() {
-        val zip = ZipBuilder.build(emptyMap())
-        // EOCD only - 22 bytes
-        assertTrue(zip.size == 22)
+        val zip = ZipBuilder.build(emptyList()).getOrThrow()
+        assertEquals(22, zip.size)
     }
 
     @Test
     fun dataIsPreserved() {
         val data = "Hello, OBZ!".encodeToByteArray()
-        val zip = ZipBuilder.build(mapOf("test.bin" to data))
+        val zip = ZipBuilder.build(listOf("test.bin" to data)).getOrThrow()
         val dataStart = 30 + "test.bin".encodeToByteArray().size
         val extracted = zip.copyOfRange(dataStart, dataStart + data.size)
         assertTrue(extracted.contentEquals(data))
+    }
+
+    @Test
+    fun utf8FlagSet() {
+        val zip = ZipBuilder.build(listOf("héllo.txt" to "data".encodeToByteArray())).getOrThrow()
+        val flags = ((zip[7].toInt() and 0xFF) shl 8) or (zip[6].toInt() and 0xFF)
+        assertTrue((flags and 0x0800) != 0, "UTF-8 flag (bit 11) must be set in local header")
+    }
+
+    @Test
+    fun utf8FlagSetInCentralDirectory() {
+        val zip = ZipBuilder.build(listOf("héllo.txt" to "data".encodeToByteArray())).getOrThrow()
+        var pos = 0
+        var centralFlags: Int? = null
+        while (pos < zip.size - 4) {
+            if (zip[pos] == 0x50.toByte() && zip[pos + 1] == 0x4B.toByte() &&
+                zip[pos + 2] == 0x01.toByte() && zip[pos + 3] == 0x02.toByte()
+            ) {
+                centralFlags = ((zip[pos + 9].toInt() and 0xFF) shl 8) or (zip[pos + 8].toInt() and 0xFF)
+                break
+            }
+            pos++
+        }
+        assertNotNull(centralFlags)
+        assertTrue((centralFlags and 0x0800) != 0, "UTF-8 flag (bit 11) must be set in central directory entry")
+    }
+
+    @Test
+    fun unicodeFilenamePreserved() {
+        val name = "smørrebrød/æøå.txt"
+        val zip = ZipBuilder.build(listOf(name to "data".encodeToByteArray())).getOrThrow()
+        assertTrue(String(zip).contains(name), "Unicode filename must be present in ZIP bytes")
+    }
+
+    @Test
+    fun rejectsEmptyEntryName() {
+        val error = assertFailsWith<ZipBuilderError.InvalidEntryName> {
+            ZipBuilder.build(listOf("" to "data".encodeToByteArray())).getOrThrow()
+        }
+        assertTrue(error.message.contains("empty"))
+    }
+
+    @Test
+    fun rejectsAbsolutePath() {
+        val error = assertFailsWith<ZipBuilderError.InvalidEntryName> {
+            ZipBuilder.build(listOf("/etc/passwd" to "data".encodeToByteArray())).getOrThrow()
+        }
+        assertTrue(error.message.contains("absolute"))
+    }
+
+    @Test
+    fun rejectsDirectoryTraversal() {
+        val error = assertFailsWith<ZipBuilderError.InvalidEntryName> {
+            ZipBuilder.build(listOf("../outside/foo.txt" to "data".encodeToByteArray())).getOrThrow()
+        }
+        assertTrue(error.message.contains("traversal"))
+    }
+
+    @Test
+    fun rejectsNestedDirectoryTraversal() {
+        val error = assertFailsWith<ZipBuilderError.InvalidEntryName> {
+            ZipBuilder.build(listOf("boards/../../outside/foo.txt" to "data".encodeToByteArray())).getOrThrow()
+        }
+        assertTrue(error.message.contains("traversal"))
+    }
+
+    @Test
+    fun rejectsNulCharacter() {
+        val error = assertFailsWith<ZipBuilderError.InvalidEntryName> {
+            ZipBuilder.build(listOf("foo\u0000bar.txt" to "data".encodeToByteArray())).getOrThrow()
+        }
+        assertTrue(error.message.contains("NUL"))
+    }
+
+    @Test
+    fun rejectsDuplicateEntryName() {
+        assertFailsWith<ZipBuilderError.DuplicateEntryName> {
+            ZipBuilder.build(listOf(
+                "same.txt" to "first".encodeToByteArray(),
+                "same.txt" to "second".encodeToByteArray()
+            )).getOrThrow()
+        }
+    }
+
+    @Test
+    fun identicalInputsProduceIdenticalOutput() {
+        val entries = listOf(
+            "a.txt" to "111".encodeToByteArray(),
+            "b.txt" to "222".encodeToByteArray()
+        )
+        val zip1 = ZipBuilder.build(entries).getOrThrow()
+        val zip2 = ZipBuilder.build(entries).getOrThrow()
+        assertTrue(zip1.contentEquals(zip2), "Same ordered inputs must produce identical bytes")
+    }
+
+    @Test
+    fun crcValidatesForEntry() {
+        val data = "Hello, CRC!".encodeToByteArray()
+        val zip = ZipBuilder.build(listOf("check.me" to data)).getOrThrow()
+        val entryName = "check.me"
+        var pos = 0
+        while (pos < zip.size - 4) {
+            if (zip[pos] == 0x50.toByte() && zip[pos + 1] == 0x4B.toByte() &&
+                zip[pos + 2] == 0x03.toByte() && zip[pos + 3] == 0x04.toByte()
+            ) {
+                val nameLen = ((zip[pos + 27].toInt() and 0xFF) shl 8) or (zip[pos + 26].toInt() and 0xFF)
+                val extraLen = ((zip[pos + 29].toInt() and 0xFF) shl 8) or (zip[pos + 28].toInt() and 0xFF)
+                val storedCrc = ((zip[pos + 17].toInt() and 0xFF) shl 24) or
+                    ((zip[pos + 16].toInt() and 0xFF) shl 16) or
+                    ((zip[pos + 15].toInt() and 0xFF) shl 8) or
+                    (zip[pos + 14].toInt() and 0xFF)
+                val headerSize = 30 + nameLen + extraLen
+                val compSize = ((zip[pos + 21].toInt() and 0xFF) shl 24) or
+                    ((zip[pos + 20].toInt() and 0xFF) shl 16) or
+                    ((zip[pos + 19].toInt() and 0xFF) shl 8) or
+                    (zip[pos + 18].toInt() and 0xFF)
+                val extractedName = zip.copyOfRange(pos + 30, pos + 30 + nameLen).decodeToString()
+                if (extractedName == entryName) {
+                    val extracted = zip.copyOfRange(pos + headerSize, pos + headerSize + compSize)
+                    assertTrue(extracted.contentEquals(data), "Data must be retrievable")
+                    assertTrue(storedCrc != 0, "CRC must be non-zero")
+                    return
+                }
+                pos += headerSize + compSize
+            } else {
+                pos++
+            }
+        }
+    }
+
+    @Test
+    fun directoryOffsetsValid() {
+        val entries = listOf(
+            "first.txt" to "data1".encodeToByteArray(),
+            "second.txt" to "data2".encodeToByteArray()
+        )
+        val zip = ZipBuilder.build(entries).getOrThrow()
+        val tail = zip.copyOfRange(zip.size - 22, zip.size)
+        val cdOffset = ((tail[19].toInt() and 0xFF) shl 24) or
+            ((tail[18].toInt() and 0xFF) shl 16) or
+            ((tail[17].toInt() and 0xFF) shl 8) or
+            (tail[16].toInt() and 0xFF)
+        val cdSize = ((tail[15].toInt() and 0xFF) shl 24) or
+            ((tail[14].toInt() and 0xFF) shl 16) or
+            ((tail[13].toInt() and 0xFF) shl 8) or
+            (tail[12].toInt() and 0xFF)
+        assertEquals(zip.size - 22, cdOffset + cdSize, "Central directory must end just before EOCD")
+    }
+
+    @Test
+    fun zip64RequiredForLargeEntryCount() {
+        val manyEntries = (0..65535).map { "file$it.txt" to "x".encodeToByteArray() }
+        val error = assertFailsWith<ZipBuilderError.Zip64Required> {
+            ZipBuilder.build(manyEntries).getOrThrow()
+        }
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Auto-incremented by build
-#Wed Jul 22 17:21:04 CEST 2026
-versionCode=29
+#Thu Jul 23 17:39:02 CEST 2026
+versionCode=30
 versionName=0.6


### PR DESCRIPTION
## Summary

Fixes #49. Rewrites `ZipBuilder` to produce spec-compliant ZIP archives:

- **Linear-time output** — replaced quadratic `fold(byteArrayOf())` with an exponentially-growing `GrowableByteArray` sink
- **UTF-8 flag** — sets general-purpose bit 11 (`0x0800`) in local file headers and central directory entries
- **Entry name validation** — rejects empty, absolute, directory-traversal, and NUL-containing names
- **Duplicate detection** — API changed from `Map` to `List<Pair<>>` so duplicates aren't silently deduplicated
- **Overflow checks** — validates entry count (<=65535), sizes (<=4 GiB), and offsets (<=4 GiB); throws typed `ZipBuilderError.Zip64Required` instead of silently truncating
- **Structured errors** — `build()` returns `Result<ByteArray>` with `ZipBuilderError` sealed class

## Changes

| File | Change |
|------|--------|
| `core/domain/.../obf/ZipBuilder.kt` | Full rewrite with growable sink, UTF-8 flag, validation, overflow checks |
| `shared/.../application/ObzExporter.kt` | Changed caller to use `entries.toList()` + `.getOrThrow()` |
| `shared/.../ZipBuilderTest.kt` | Expanded from 5 to 20 tests covering all new behaviors |

## Verification

- 20 ZipBuilder tests + 7 ObzExporter tests pass
- Unicode filenames (`smørrebrød/æøå.txt`) now display correctly in external ZIP readers
- UTF-8 flag bit confirmed set in both local and central directory headers
