### PR TITLE
Fix #51: show more sentence text in SymbolBar

### DIFF
--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -800,7 +800,11 @@ private fun BoardSetWorkspaceScreen(
                         board = activeBoard,
                         isEditMode = mode == BoardWorkspaceMode.Edit,
                         showMessageBar = mode == BoardWorkspaceMode.Run,
-                        showSentenceText = isFullscreen,
+                        sentenceText = selectedButtons.joinToString(" ") { (button, _) ->
+                            (button.label ?: button.vocalization).orEmpty()
+                        },
+                        presentationMode = if (isFullscreen) SentencePresentationMode.Fullscreen
+                            else SentencePresentationMode.Normal,
                         selectedButtons = selectedButtons,
                         onButtonClick = { button ->
                             val actions = parseObfButtonActions(button)

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -570,7 +570,6 @@ private fun BoardSetWorkspaceScreen(
             statusMessage = unlockToEditMessage
             return
         }
-        selectedButtons = emptyList()
         boardStack = emptyList()
         editSession = BoardSetEditSession(graph, graph)
         mode = BoardWorkspaceMode.Edit
@@ -799,7 +798,7 @@ private fun BoardSetWorkspaceScreen(
                     ObfBoardView(
                         board = activeBoard,
                         isEditMode = mode == BoardWorkspaceMode.Edit,
-                        showMessageBar = mode == BoardWorkspaceMode.Run,
+                        showActions = mode == BoardWorkspaceMode.Run,
                         sentenceText = selectedButtons.joinToString(" ") { (button, _) ->
                             (button.label ?: button.vocalization).orEmpty()
                         },

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -570,6 +570,7 @@ private fun BoardSetWorkspaceScreen(
             statusMessage = unlockToEditMessage
             return
         }
+        selectedButtons = emptyList()
         boardStack = emptyList()
         editSession = BoardSetEditSession(graph, graph)
         mode = BoardWorkspaceMode.Edit
@@ -798,7 +799,7 @@ private fun BoardSetWorkspaceScreen(
                     ObfBoardView(
                         board = activeBoard,
                         isEditMode = mode == BoardWorkspaceMode.Edit,
-                        showActions = mode == BoardWorkspaceMode.Run,
+                        showMessageBar = mode == BoardWorkspaceMode.Run,
                         sentenceText = selectedButtons.joinToString(" ") { (button, _) ->
                             (button.label ?: button.vocalization).orEmpty()
                         },

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -800,11 +800,7 @@ private fun BoardSetWorkspaceScreen(
                         board = activeBoard,
                         isEditMode = mode == BoardWorkspaceMode.Edit,
                         showMessageBar = mode == BoardWorkspaceMode.Run,
-                        sentenceText = selectedButtons.joinToString(" ") { (button, _) ->
-                            (button.label ?: button.vocalization).orEmpty()
-                        },
-                        presentationMode = if (isFullscreen) SentencePresentationMode.Fullscreen
-                            else SentencePresentationMode.Normal,
+                        showSentenceText = isFullscreen,
                         selectedButtons = selectedButtons,
                         onButtonClick = { button ->
                             val actions = parseObfButtonActions(button)

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -71,11 +71,9 @@ import io.github.jdreioe.wingmate.application.BoardSetSpeechCacheUseCase
 import io.github.jdreioe.wingmate.infrastructure.BoardImportService
 import io.github.jdreioe.wingmate.application.FeatureUsageEvents
 import io.github.jdreioe.wingmate.application.reportEvent
-import io.github.jdreioe.wingmate.application.PhraseUseCase
 import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.domain.Base64Decoder
 import io.github.jdreioe.wingmate.domain.FileStorage
-import io.github.jdreioe.wingmate.domain.Phrase
 import io.github.jdreioe.wingmate.domain.SoundPlayer
 import io.github.jdreioe.wingmate.domain.SpeechService
 import io.github.jdreioe.wingmate.domain.SpeechSegment
@@ -478,7 +476,6 @@ private fun BoardSetWorkspaceScreen(
     onExitToLibrary: () -> Unit
 ) {
     val useCase = koinInject<BoardSetUseCase>()
-    val phraseUseCase = koinInject<PhraseUseCase>()
     val speechService = koinInject<SpeechService>()
     val voiceUseCase = koinInject<VoiceUseCase>()
     val soundPlayer = koinInject<SoundPlayer>()
@@ -504,14 +501,11 @@ private fun BoardSetWorkspaceScreen(
     var showRenameBoardSetDialog by remember { mutableStateOf(false) }
     var showResizeBoardDialog by remember { mutableStateOf(false) }
     var showDeleteBoardDialog by remember { mutableStateOf(false) }
-    var isSavingSentence by remember(boardSetId) { mutableStateOf(false) }
     var isExporting by remember(boardSetId) { mutableStateOf(false) }
     var isFullscreen by remember(boardSetId) { mutableStateOf(false) }
     val unlockToEditMessage = stringResource(Res.string.board_workspace_unlock_to_edit)
     val savedMessage = stringResource(Res.string.board_workspace_saved)
     val saveErrorMessage = stringResource(Res.string.board_workspace_save_error)
-    val phraseSavedMessage = stringResource(Res.string.board_workspace_phrase_saved)
-    val phraseSaveErrorMessage = stringResource(Res.string.board_workspace_phrase_save_error)
     // Placeholder substituted in click handler (stringResource formatting is composition-only).
     val unsupportedActionTemplate = stringResource(Res.string.board_workspace_unsupported_action, "%ACTION%")
 
@@ -563,6 +557,32 @@ private fun BoardSetWorkspaceScreen(
 
     val activeGraph = editSession?.draft ?: savedGraph
     val activeBoard = activeGraph?.boardsById?.get(selectedBoardId)
+    val sentenceText = remember(selectedButtons, activeBoard?.strings, settings.primaryLanguage) {
+        buildResolvedSentence(
+            selected = selectedButtons,
+            board = activeBoard,
+            primaryLanguage = settings.primaryLanguage
+        )
+    }
+    val availableBoardActions = remember(activeBoard) {
+        val visibleGridButtonIds = activeBoard?.grid
+            ?.order
+            ?.flatten()
+            ?.filterNotNull()
+            ?.toSet()
+        activeBoard?.buttons
+            ?.asSequence()
+            ?.filter { button ->
+                !button.hidden &&
+                    (visibleGridButtonIds == null || button.id in visibleGridButtonIds)
+            }
+            ?.flatMap { parseObfButtonActions(it).asSequence() }
+            ?.toList()
+            .orEmpty()
+    }
+    val boardHasSpeakField = availableBoardActions.any { it == ObfButtonActionEffect.Speak }
+    val boardHasDeleteField = availableBoardActions.any { it == ObfButtonActionEffect.Backspace }
+    val boardHasClearField = availableBoardActions.any { it == ObfButtonActionEffect.Clear }
 
     fun startEditing() {
         val graph = savedGraph ?: return
@@ -800,7 +820,15 @@ private fun BoardSetWorkspaceScreen(
                         board = activeBoard,
                         isEditMode = mode == BoardWorkspaceMode.Edit,
                         showMessageBar = mode == BoardWorkspaceMode.Run,
-                        showSentenceText = isFullscreen,
+                        sentenceText = sentenceText,
+                        symbolBarPresentation = if (isFullscreen) {
+                            SymbolBarPresentation.Fullscreen
+                        } else {
+                            SymbolBarPresentation.Normal
+                        },
+                        showSpeakControl = !boardHasSpeakField,
+                        showDeleteControl = !boardHasDeleteField,
+                        showClearControl = !boardHasClearField,
                         selectedButtons = selectedButtons,
                         onButtonClick = { button ->
                             val actions = parseObfButtonActions(button)
@@ -933,39 +961,6 @@ private fun BoardSetWorkspaceScreen(
                                 scope = scope
                             )
                         },
-                        onSaveSentence = {
-                            val allSingleChars = selectedButtons.all {
-                                val text = (it.first.vocalization ?: it.first.label).orEmpty()
-                                text.length <= 1
-                            }
-                            val separator = if (allSingleChars) "" else " "
-                            val sentence = selectedButtons.joinToString(separator) {
-                                (it.first.vocalization ?: it.first.label).orEmpty()
-                            }.trim()
-                            if (sentence.isNotEmpty() && !isSavingSentence) {
-                                isSavingSentence = true
-                                scope.launch {
-                                    runCatching {
-                                        phraseUseCase.add(
-                                            Phrase(
-                                                id = workspaceId("phrase"),
-                                                text = sentence,
-                                                name = null,
-                                                backgroundColor = null,
-                                                parentId = null,
-                                                createdAt = Clock.System.now().toEpochMilliseconds()
-                                            )
-                                        )
-                                    }.onSuccess {
-                                        statusMessage = phraseSavedMessage
-                                    }.onFailure {
-                                        statusMessage = phraseSaveErrorMessage
-                                    }
-                                    isSavingSentence = false
-                                }
-                            }
-                        },
-                        isSaveSentenceEnabled = selectedButtons.isNotEmpty() && !isSavingSentence,
                         onDeleteLast = {
                             if (selectedButtons.isNotEmpty()) selectedButtons = selectedButtons.dropLast(1)
                         },
@@ -1824,6 +1819,22 @@ internal fun backspaceSentenceSelection(
     )
 }
 
+internal fun buildResolvedSentence(
+    selected: List<Pair<ObfButton, ImageBitmap?>>,
+    board: ObfBoard?,
+    primaryLanguage: String
+): String {
+    val tokens = selected.mapNotNull { (button, _) ->
+        resolveObfLocalizedString(
+            strings = board?.strings.orEmpty(),
+            locale = primaryLanguage,
+            rawValue = button.vocalization ?: button.label
+        )?.trim()?.takeIf { it.isNotEmpty() }
+    }
+    val separator = if (tokens.all { it.length <= 1 }) "" else " "
+    return tokens.joinToString(separator)
+}
+
 private fun speakSelectedButtons(
     selected: List<Pair<ObfButton, ImageBitmap?>>,
     board: ObfBoard,
@@ -1841,7 +1852,11 @@ private fun speakSelectedButtons(
     )
 
     val speechParts = selected.mapNotNull { (button, _) ->
-        val text = (button.vocalization ?: button.label)?.takeIf { it.isNotEmpty() }
+        val text = resolveObfLocalizedString(
+            strings = board.strings,
+            locale = primaryLanguage,
+            rawValue = button.vocalization ?: button.label
+        )?.trim()?.takeIf { it.isNotEmpty() }
             ?: return@mapNotNull null
         val recordingPath = button.soundId
             ?.let { soundId -> board.sounds.firstOrNull { it.id == soundId } }

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -103,7 +103,7 @@ fun ObfBoardView(
     isSaveSentenceEnabled: Boolean = selectedButtons.isNotEmpty(),
     onDeleteLast: () -> Unit = {},
     onClearSentence: () -> Unit = {},
-    showMessageBar: Boolean = !isEditMode,
+    showActions: Boolean = true,
     sentenceText: String = "",
     presentationMode: SentencePresentationMode = SentencePresentationMode.Normal,
     onCellClick: ((row: Int, column: Int, button: ObfButton?) -> Unit)? = null,
@@ -119,28 +119,23 @@ fun ObfBoardView(
     val buttonsById = remember(board) { board.buttons.associateBy { it.id } }
 
     if (isAbsoluteLayout) {
-        if (showMessageBar) {
-            Column(modifier = modifier.fillMaxSize().padding(8.dp)) {
-                SymbolBar(
-                    selectedButtons = selectedButtons,
-                    imagesById = imagesById,
-                    extractedImages = extractedImages,
-                    sentenceText = sentenceText,
-                    presentationMode = presentationMode,
-                    onSpeak = onSpeakSentence,
-                    onSave = onSaveSentence,
-                    isSaveEnabled = isSaveSentenceEnabled,
-                    onDelete = onDeleteLast,
-                    onClear = onClearSentence,
-                    modifier = Modifier.fillMaxWidth()
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                BoxWithConstraints(modifier = Modifier.fillMaxWidth().weight(1f)) {
-                    renderAbsoluteButtons(board, imagesById, extractedImages, isEditMode, onButtonClick, homeBoardId)
-                }
-            }
-        } else {
-            BoxWithConstraints(modifier = modifier.fillMaxSize().padding(8.dp)) {
+        Column(modifier = modifier.fillMaxSize().padding(8.dp)) {
+            SymbolBar(
+                selectedButtons = selectedButtons,
+                imagesById = imagesById,
+                extractedImages = extractedImages,
+                showActions = showActions,
+                sentenceText = sentenceText,
+                presentationMode = presentationMode,
+                onSpeak = onSpeakSentence,
+                onSave = onSaveSentence,
+                isSaveEnabled = isSaveSentenceEnabled,
+                onDelete = onDeleteLast,
+                onClear = onClearSentence,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            BoxWithConstraints(modifier = Modifier.fillMaxWidth().weight(1f)) {
                 renderAbsoluteButtons(board, imagesById, extractedImages, isEditMode, onButtonClick, homeBoardId)
             }
         }
@@ -153,23 +148,22 @@ fun ObfBoardView(
             modifier = modifier.padding(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            if (showMessageBar) {
-                SymbolBar(
-                    selectedButtons = selectedButtons,
-                    imagesById = imagesById,
-                    extractedImages = extractedImages,
-                    sentenceText = sentenceText,
-                    presentationMode = presentationMode,
-                    onSpeak = onSpeakSentence,
-                    onSave = onSaveSentence,
-                    isSaveEnabled = isSaveSentenceEnabled,
-                    onDelete = onDeleteLast,
-                    onClear = onClearSentence,
-                    modifier = Modifier.fillMaxWidth()
-                )
+            SymbolBar(
+                selectedButtons = selectedButtons,
+                imagesById = imagesById,
+                extractedImages = extractedImages,
+                showActions = showActions,
+                sentenceText = sentenceText,
+                presentationMode = presentationMode,
+                onSpeak = onSpeakSentence,
+                onSave = onSaveSentence,
+                isSaveEnabled = isSaveSentenceEnabled,
+                onDelete = onDeleteLast,
+                onClear = onClearSentence,
+                modifier = Modifier.fillMaxWidth()
+            )
 
-                Spacer(modifier = Modifier.height(8.dp))
-            }
+            Spacer(modifier = Modifier.height(8.dp))
 
             val gridItems = remember(grid, buttonsById) {
                 buildBoardGridItems(grid, buttonsById)
@@ -439,6 +433,7 @@ fun SymbolBar(
     selectedButtons: List<Pair<ObfButton, ImageBitmap?>>,
     imagesById: Map<String, io.github.jdreioe.wingmate.domain.obf.ObfImage>,
     extractedImages: Map<String, ByteArray>,
+    showActions: Boolean = true,
     sentenceText: String = "",
     presentationMode: SentencePresentationMode = SentencePresentationMode.Normal,
     onSpeak: () -> Unit,
@@ -449,8 +444,8 @@ fun SymbolBar(
     modifier: Modifier = Modifier
 ) {
     val maxTextLines = when (presentationMode) {
-        SentencePresentationMode.Normal -> 4
-        SentencePresentationMode.Fullscreen -> 6
+        SentencePresentationMode.Normal -> 2
+        SentencePresentationMode.Fullscreen -> 4
     }
     val textScrollState = rememberScrollState()
     val symbolsScrollState = rememberLazyListState()
@@ -550,23 +545,25 @@ fun SymbolBar(
                     }
                 }
 
-                VerticalDivider(modifier = Modifier.padding(horizontal = 8.dp).height(40.dp))
+                if (showActions) {
+                    VerticalDivider(modifier = Modifier.padding(horizontal = 8.dp).height(40.dp))
 
-                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                    FilledIconButton(
-                        onClick = onSpeak,
-                        colors = IconButtonDefaults.filledIconButtonColors(containerColor = MaterialTheme.colorScheme.primary)
-                    ) {
-                        Icon(Icons.Default.PlayArrow, contentDescription = stringResource(Res.string.board_workspace_speak_sentence))
-                    }
-                    IconButton(onClick = onSave, enabled = isSaveEnabled) {
-                        Icon(Icons.Default.Save, contentDescription = stringResource(Res.string.board_workspace_save_phrase))
-                    }
-                    IconButton(onClick = onDelete) {
-                        Icon(Icons.Default.Delete, contentDescription = stringResource(Res.string.board_workspace_delete_last))
-                    }
-                    IconButton(onClick = onClear) {
-                        Icon(Icons.Default.Clear, contentDescription = stringResource(Res.string.board_workspace_clear_sentence))
+                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                        FilledIconButton(
+                            onClick = onSpeak,
+                            colors = IconButtonDefaults.filledIconButtonColors(containerColor = MaterialTheme.colorScheme.primary)
+                        ) {
+                            Icon(Icons.Default.PlayArrow, contentDescription = stringResource(Res.string.board_workspace_speak_sentence))
+                        }
+                        IconButton(onClick = onSave, enabled = isSaveEnabled) {
+                            Icon(Icons.Default.Save, contentDescription = stringResource(Res.string.board_workspace_save_phrase))
+                        }
+                        IconButton(onClick = onDelete) {
+                            Icon(Icons.Default.Delete, contentDescription = stringResource(Res.string.board_workspace_delete_last))
+                        }
+                        IconButton(onClick = onClear) {
+                            Icon(Icons.Default.Clear, contentDescription = stringResource(Res.string.board_workspace_clear_sentence))
+                        }
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -36,6 +36,9 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import kotlinx.coroutines.withTimeoutOrNull
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Home
@@ -77,6 +80,8 @@ import wingmatekmp.composeapp.generated.resources.board_workspace_speak_sentence
 import wingmatekmp.composeapp.generated.resources.board_workspace_home
 import wingmatekmp.composeapp.generated.resources.board_cell_opens_board
 
+enum class SentencePresentationMode { Normal, Fullscreen }
+
 private data class BoardGridItem(
     val row: Int,
     val column: Int,
@@ -99,7 +104,8 @@ fun ObfBoardView(
     onDeleteLast: () -> Unit = {},
     onClearSentence: () -> Unit = {},
     showMessageBar: Boolean = !isEditMode,
-    showSentenceText: Boolean = false,
+    sentenceText: String = "",
+    presentationMode: SentencePresentationMode = SentencePresentationMode.Normal,
     onCellClick: ((row: Int, column: Int, button: ObfButton?) -> Unit)? = null,
     onCellMove: ((fromRow: Int, fromColumn: Int, toRow: Int, toColumn: Int) -> Unit)? = null,
     homeBoardId: String? = null
@@ -119,15 +125,14 @@ fun ObfBoardView(
                     selectedButtons = selectedButtons,
                     imagesById = imagesById,
                     extractedImages = extractedImages,
+                    sentenceText = sentenceText,
+                    presentationMode = presentationMode,
                     onSpeak = onSpeakSentence,
                     onSave = onSaveSentence,
                     isSaveEnabled = isSaveSentenceEnabled,
                     onDelete = onDeleteLast,
                     onClear = onClearSentence,
-                    showSentenceText = showSentenceText,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(if (showSentenceText) 260.dp else 100.dp)
+                    modifier = Modifier.fillMaxWidth()
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 BoxWithConstraints(modifier = Modifier.fillMaxWidth().weight(1f)) {
@@ -153,15 +158,14 @@ fun ObfBoardView(
                     selectedButtons = selectedButtons,
                     imagesById = imagesById,
                     extractedImages = extractedImages,
+                    sentenceText = sentenceText,
+                    presentationMode = presentationMode,
                     onSpeak = onSpeakSentence,
                     onSave = onSaveSentence,
                     isSaveEnabled = isSaveSentenceEnabled,
                     onDelete = onDeleteLast,
                     onClear = onClearSentence,
-                    showSentenceText = showSentenceText,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(if (showSentenceText) 260.dp else 100.dp)
+                    modifier = Modifier.fillMaxWidth()
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -435,32 +439,69 @@ fun SymbolBar(
     selectedButtons: List<Pair<ObfButton, ImageBitmap?>>,
     imagesById: Map<String, io.github.jdreioe.wingmate.domain.obf.ObfImage>,
     extractedImages: Map<String, ByteArray>,
+    sentenceText: String = "",
+    presentationMode: SentencePresentationMode = SentencePresentationMode.Normal,
     onSpeak: () -> Unit,
     onSave: () -> Unit,
     isSaveEnabled: Boolean,
     onDelete: () -> Unit,
     onClear: () -> Unit,
-    showSentenceText: Boolean = false,
     modifier: Modifier = Modifier
 ) {
+    val maxTextLines = when (presentationMode) {
+        SentencePresentationMode.Normal -> 4
+        SentencePresentationMode.Fullscreen -> 6
+    }
+    val textScrollState = rememberScrollState()
+    val symbolsScrollState = rememberLazyListState()
+
+    val hasContent = selectedButtons.isNotEmpty()
+    val effectiveSentenceText = if (hasContent && sentenceText.isBlank()) {
+        selectedButtons.joinToString(" ") { (button, _) ->
+            (button.label ?: button.vocalization).orEmpty()
+        }
+    } else sentenceText
+
+    val currentSentenceLength = effectiveSentenceText.length
+    var previousLength by remember { mutableStateOf(currentSentenceLength) }
+    LaunchedEffect(currentSentenceLength) {
+        if (currentSentenceLength > previousLength) {
+            val isNearBottom = textScrollState.value >= textScrollState.maxValue - 32
+            if (isNearBottom) {
+                textScrollState.animateScrollTo(textScrollState.maxValue)
+            }
+        }
+        previousLength = currentSentenceLength
+    }
+
+    LaunchedEffect(selectedButtons.size) {
+        if (selectedButtons.isNotEmpty()) {
+            symbolsScrollState.animateScrollToItem(selectedButtons.size - 1)
+        }
+    }
+
     Surface(
         modifier = modifier.shadow(2.dp, RoundedCornerShape(16.dp)),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
         shape = RoundedCornerShape(16.dp)
     ) {
-        Column(modifier = Modifier.fillMaxSize().padding(8.dp)) {
-            if (showSentenceText) {
+        Column(modifier = Modifier.widthIn(max = 1200.dp).padding(8.dp)) {
+            if (effectiveSentenceText.isNotEmpty()) {
                 Box(
-                    modifier = Modifier.weight(1f).fillMaxWidth(),
-                    contentAlignment = Alignment.CenterStart
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = (maxTextLines * 28).dp)
+                        .verticalScroll(textScrollState)
+                        .semantics {
+                            contentDescription = effectiveSentenceText
+                        },
+                    contentAlignment = Alignment.TopStart
                 ) {
                     Text(
-                        text = selectedButtons.joinToString(" ") { (button, _) ->
-                            (button.label ?: button.vocalization).orEmpty()
-                        },
+                        text = effectiveSentenceText,
                         fontSize = 48.sp,
                         lineHeight = 56.sp,
-                        maxLines = 2,
+                        maxLines = maxTextLines,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
                             .fillMaxWidth()
@@ -470,20 +511,17 @@ fun SymbolBar(
             }
 
             Row(
-                modifier = if (showSentenceText) {
-                    Modifier.fillMaxWidth().height(80.dp)
-                } else {
-                    Modifier.weight(1f).fillMaxWidth()
-                },
+                modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 LazyRow(
                     modifier = Modifier.weight(1f).fillMaxHeight(),
+                    state = symbolsScrollState,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(horizontal = 4.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    items(selectedButtons) { (button, bitmap) ->
+                    items(selectedButtons, key = { it.first.id }) { (button, bitmap) ->
                         val resolvedBitmap = remember(button, bitmap) {
                             bitmap ?: button.imageId?.let { id ->
                                 imagesById[id]?.path?.let { path ->

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -36,13 +36,13 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import kotlinx.coroutines.withTimeoutOrNull
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Clear
-import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.*
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.draw.clip
@@ -57,6 +57,9 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import io.github.jdreioe.wingmate.domain.AacLogger
 import io.github.jdreioe.wingmate.domain.Base64Decoder
 import io.github.jdreioe.wingmate.domain.SpeechService
@@ -72,7 +75,6 @@ import wingmatekmp.composeapp.generated.resources.board_symbol_unavailable
 import wingmatekmp.composeapp.generated.resources.board_symbol_unavailable_set
 import wingmatekmp.composeapp.generated.resources.board_workspace_clear_sentence
 import wingmatekmp.composeapp.generated.resources.board_workspace_delete_last
-import wingmatekmp.composeapp.generated.resources.board_workspace_save_phrase
 import wingmatekmp.composeapp.generated.resources.board_workspace_speak_sentence
 import wingmatekmp.composeapp.generated.resources.board_workspace_home
 import wingmatekmp.composeapp.generated.resources.board_cell_opens_board
@@ -85,6 +87,11 @@ private data class BoardGridItem(
     val button: ObfButton?
 )
 
+enum class SymbolBarPresentation(val maxTextLines: Int, val maximumViewportFraction: Float) {
+    Normal(maxTextLines = 4, maximumViewportFraction = 0.5f),
+    Fullscreen(maxTextLines = 6, maximumViewportFraction = 0.6f)
+}
+
 @Composable
 fun ObfBoardView(
     board: ObfBoard,
@@ -94,12 +101,14 @@ fun ObfBoardView(
     isEditMode: Boolean = false,
     selectedButtons: List<Pair<ObfButton, ImageBitmap?>> = emptyList(),
     onSpeakSentence: () -> Unit = {},
-    onSaveSentence: () -> Unit = {},
-    isSaveSentenceEnabled: Boolean = selectedButtons.isNotEmpty(),
     onDeleteLast: () -> Unit = {},
     onClearSentence: () -> Unit = {},
+    showSpeakControl: Boolean = true,
+    showDeleteControl: Boolean = true,
+    showClearControl: Boolean = true,
     showMessageBar: Boolean = !isEditMode,
-    showSentenceText: Boolean = false,
+    sentenceText: String = "",
+    symbolBarPresentation: SymbolBarPresentation = SymbolBarPresentation.Normal,
     onCellClick: ((row: Int, column: Int, button: ObfButton?) -> Unit)? = null,
     onCellMove: ((fromRow: Int, fromColumn: Int, toRow: Int, toColumn: Int) -> Unit)? = null,
     homeBoardId: String? = null
@@ -114,24 +123,29 @@ fun ObfBoardView(
 
     if (isAbsoluteLayout) {
         if (showMessageBar) {
-            Column(modifier = modifier.fillMaxSize().padding(8.dp)) {
-                SymbolBar(
-                    selectedButtons = selectedButtons,
-                    imagesById = imagesById,
-                    extractedImages = extractedImages,
-                    onSpeak = onSpeakSentence,
-                    onSave = onSaveSentence,
-                    isSaveEnabled = isSaveSentenceEnabled,
-                    onDelete = onDeleteLast,
-                    onClear = onClearSentence,
-                    showSentenceText = showSentenceText,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(if (showSentenceText) 260.dp else 100.dp)
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-                BoxWithConstraints(modifier = Modifier.fillMaxWidth().weight(1f)) {
-                    renderAbsoluteButtons(board, imagesById, extractedImages, isEditMode, onButtonClick, homeBoardId)
+            BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+                val symbolBarMaxHeight = maxHeight * symbolBarPresentation.maximumViewportFraction
+                Column(modifier = Modifier.fillMaxSize().padding(8.dp)) {
+                    SymbolBar(
+                        selectedButtons = selectedButtons,
+                        sentenceText = sentenceText,
+                        imagesById = imagesById,
+                        extractedImages = extractedImages,
+                        onSpeak = onSpeakSentence,
+                        onDelete = onDeleteLast,
+                        onClear = onClearSentence,
+                        showSpeak = showSpeakControl,
+                        showDelete = showDeleteControl,
+                        showClear = showClearControl,
+                        presentation = symbolBarPresentation,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = symbolBarMaxHeight)
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    BoxWithConstraints(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                        renderAbsoluteButtons(board, imagesById, extractedImages, isEditMode, onButtonClick, homeBoardId)
+                    }
                 }
             }
         } else {
@@ -144,80 +158,83 @@ fun ObfBoardView(
         val rows = grid.rows.coerceAtLeast(1)
         
         // Use Column/Row for fixed grid that fills the space
-        Column(
-            modifier = modifier.padding(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            if (showMessageBar) {
-                SymbolBar(
-                    selectedButtons = selectedButtons,
-                    imagesById = imagesById,
-                    extractedImages = extractedImages,
-                    onSpeak = onSpeakSentence,
-                    onSave = onSaveSentence,
-                    isSaveEnabled = isSaveSentenceEnabled,
-                    onDelete = onDeleteLast,
-                    onClear = onClearSentence,
-                    showSentenceText = showSentenceText,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(if (showSentenceText) 260.dp else 100.dp)
-                )
+        BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+            val symbolBarMaxHeight = maxHeight * symbolBarPresentation.maximumViewportFraction
+            Column(
+                modifier = Modifier.fillMaxSize().padding(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                if (showMessageBar) {
+                    SymbolBar(
+                        selectedButtons = selectedButtons,
+                        sentenceText = sentenceText,
+                        imagesById = imagesById,
+                        extractedImages = extractedImages,
+                        onSpeak = onSpeakSentence,
+                        onDelete = onDeleteLast,
+                        onClear = onClearSentence,
+                        showSpeak = showSpeakControl,
+                        showDelete = showDeleteControl,
+                        showClear = showClearControl,
+                        presentation = symbolBarPresentation,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = symbolBarMaxHeight)
+                    )
+                }
 
-                Spacer(modifier = Modifier.height(8.dp))
-            }
-
-            val gridItems = remember(grid, buttonsById) {
-                buildBoardGridItems(grid, buttonsById)
-            }
-            val pageScrollState = rememberScrollState()
-            BoxWithConstraints(modifier = Modifier.weight(1f).fillMaxWidth()) {
-                val minimumCellHeight = 96.dp * settings.inputFieldScale.coerceIn(0.5f, 2f)
-                val minimumContentHeight = minimumCellHeight * rows + 8.dp * (rows - 1)
-                val contentHeight = maxOf(maxHeight, minimumContentHeight)
-                Box(modifier = Modifier.fillMaxSize().verticalScroll(pageScrollState)) {
-                    SpanningBoardGrid(
-                        rows = rows,
-                        columns = columns,
-                        items = gridItems,
-                        modifier = Modifier.fillMaxWidth().height(contentHeight),
-                        onMove = onCellMove
-                    ) { item ->
-                        val button = item.button
-                        val isVisible = button != null && (!button.hidden || isEditMode)
-                        Box(modifier = Modifier.fillMaxSize()) {
-                            if (button != null && isVisible) {
-                                val image = button.imageId?.let { imagesById[it] }
-                                ObfButtonItem(
-                                    button = button,
-                                    image = image,
-                                    extractedImageBytes = button.imageId?.let {
-                                        image?.path?.let { path -> extractedImages[path] }
-                                    },
-                                    onClick = {
-                                        onCellClick?.invoke(item.row, item.column, button)
-                                            ?: onButtonClick(button)
-                                    },
-                                    isEditMode = isEditMode,
-                                    isHomeLink = button.isHomeNavigation(homeBoardId),
-                                    boardStrings = board.strings,
-                                    locale = settings.primaryLanguage
-                                )
-                            } else if (isEditMode && button == null) {
-                                OutlinedCard(
-                                    modifier = Modifier.fillMaxSize(),
-                                    onClick = { onCellClick?.invoke(item.row, item.column, null) }
-                                ) {
-                                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                                        Text(
-                                            text = "+",
-                                            style = MaterialTheme.typography.headlineMedium,
-                                            color = MaterialTheme.colorScheme.primary
-                                        )
+                val gridItems = remember(grid, buttonsById) {
+                    buildBoardGridItems(grid, buttonsById)
+                }
+                val pageScrollState = rememberScrollState()
+                BoxWithConstraints(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                    val minimumCellHeight = 96.dp * settings.inputFieldScale.coerceIn(0.5f, 2f)
+                    val minimumContentHeight = minimumCellHeight * rows + 8.dp * (rows - 1)
+                    val contentHeight = maxOf(maxHeight, minimumContentHeight)
+                    Box(modifier = Modifier.fillMaxSize().verticalScroll(pageScrollState)) {
+                        SpanningBoardGrid(
+                            rows = rows,
+                            columns = columns,
+                            items = gridItems,
+                            modifier = Modifier.fillMaxWidth().height(contentHeight),
+                            onMove = onCellMove
+                        ) { item ->
+                            val button = item.button
+                            val isVisible = button != null && (!button.hidden || isEditMode)
+                            Box(modifier = Modifier.fillMaxSize()) {
+                                if (button != null && isVisible) {
+                                    val image = button.imageId?.let { imagesById[it] }
+                                    ObfButtonItem(
+                                        button = button,
+                                        image = image,
+                                        extractedImageBytes = button.imageId?.let {
+                                            image?.path?.let { path -> extractedImages[path] }
+                                        },
+                                        onClick = {
+                                            onCellClick?.invoke(item.row, item.column, button)
+                                                ?: onButtonClick(button)
+                                        },
+                                        isEditMode = isEditMode,
+                                        isHomeLink = button.isHomeNavigation(homeBoardId),
+                                        boardStrings = board.strings,
+                                        locale = settings.primaryLanguage
+                                    )
+                                } else if (isEditMode && button == null) {
+                                    OutlinedCard(
+                                        modifier = Modifier.fillMaxSize(),
+                                        onClick = { onCellClick?.invoke(item.row, item.column, null) }
+                                    ) {
+                                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                            Text(
+                                                text = "+",
+                                                style = MaterialTheme.typography.headlineMedium,
+                                                color = MaterialTheme.colorScheme.primary
+                                            )
+                                        }
                                     }
+                                } else {
+                                    Spacer(modifier = Modifier.fillMaxSize())
                                 }
-                            } else {
-                                Spacer(modifier = Modifier.fillMaxSize())
                             }
                         }
                     }
@@ -226,34 +243,60 @@ fun ObfBoardView(
         }
     } else {
         // Fallback: scrollable grid for boards without explicit grid
-        Column(
-            modifier = modifier.padding(4.dp).verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(4.dp)
-        ) {
-            board.buttons.chunked(4).forEach { rowButtons ->
-                Row(
-                    modifier = Modifier.fillMaxWidth().height(100.dp),
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+        BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+            val symbolBarMaxHeight = maxHeight * symbolBarPresentation.maximumViewportFraction
+            Column(
+                modifier = Modifier.fillMaxSize().padding(4.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                if (showMessageBar) {
+                    SymbolBar(
+                        selectedButtons = selectedButtons,
+                        sentenceText = sentenceText,
+                        imagesById = imagesById,
+                        extractedImages = extractedImages,
+                        onSpeak = onSpeakSentence,
+                        onDelete = onDeleteLast,
+                        onClear = onClearSentence,
+                        showSpeak = showSpeakControl,
+                        showDelete = showDeleteControl,
+                        showClear = showClearControl,
+                        presentation = symbolBarPresentation,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = symbolBarMaxHeight)
+                    )
+                }
+                Column(
+                    modifier = Modifier.weight(1f).fillMaxWidth().verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    rowButtons.forEach { button ->
-                        val image = button.imageId?.let { imagesById[it] }
-                        Box(modifier = Modifier.weight(1f).fillMaxHeight()) {
-                            ObfButtonItem(
-                                button = button,
-                                image = image,
-                                extractedImageBytes = button.imageId?.let { 
-                                    image?.path?.let { path -> extractedImages[path] }
-                                },
-                                onClick = { onButtonClick(button) },
-                                isHomeLink = button.isHomeNavigation(homeBoardId),
-                                boardStrings = board.strings,
-                                locale = settings.primaryLanguage
-                            )
+                    board.buttons.chunked(4).forEach { rowButtons ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth().height(100.dp),
+                            horizontalArrangement = Arrangement.spacedBy(4.dp)
+                        ) {
+                            rowButtons.forEach { button ->
+                                val image = button.imageId?.let { imagesById[it] }
+                                Box(modifier = Modifier.weight(1f).fillMaxHeight()) {
+                                    ObfButtonItem(
+                                        button = button,
+                                        image = image,
+                                        extractedImageBytes = button.imageId?.let {
+                                            image?.path?.let { path -> extractedImages[path] }
+                                        },
+                                        onClick = { onButtonClick(button) },
+                                        isHomeLink = button.isHomeNavigation(homeBoardId),
+                                        boardStrings = board.strings,
+                                        locale = settings.primaryLanguage
+                                    )
+                                }
+                            }
+                            // Fill remaining space if row is not complete
+                            repeat(4 - rowButtons.size) {
+                                Spacer(modifier = Modifier.weight(1f))
+                            }
                         }
-                    }
-                    // Fill remaining space if row is not complete
-                    repeat(4 - rowButtons.size) {
-                        Spacer(modifier = Modifier.weight(1f))
                     }
                 }
             }
@@ -433,51 +476,78 @@ private fun SpanningBoardGrid(
 @Composable
 fun SymbolBar(
     selectedButtons: List<Pair<ObfButton, ImageBitmap?>>,
+    sentenceText: String,
     imagesById: Map<String, io.github.jdreioe.wingmate.domain.obf.ObfImage>,
     extractedImages: Map<String, ByteArray>,
     onSpeak: () -> Unit,
-    onSave: () -> Unit,
-    isSaveEnabled: Boolean,
     onDelete: () -> Unit,
     onClear: () -> Unit,
-    showSentenceText: Boolean = false,
+    showSpeak: Boolean = true,
+    showDelete: Boolean = true,
+    showClear: Boolean = true,
+    presentation: SymbolBarPresentation = SymbolBarPresentation.Normal,
     modifier: Modifier = Modifier
 ) {
+    val textScrollState = rememberScrollState()
+    val symbolListState = rememberLazyListState()
+    var previousItemCount by remember { mutableIntStateOf(0) }
+    val textStyle = when (presentation) {
+        SymbolBarPresentation.Normal -> MaterialTheme.typography.titleMedium
+        SymbolBarPresentation.Fullscreen -> MaterialTheme.typography.headlineSmall
+    }
+    val maximumTextHeight = with(LocalDensity.current) {
+        textStyle.lineHeight.toDp() * presentation.maxTextLines + 8.dp
+    }
+
+    LaunchedEffect(selectedButtons.size) {
+        val appended = selectedButtons.size > previousItemCount
+        previousItemCount = selectedButtons.size
+        if (appended) {
+            withFrameNanos { }
+            launch { textScrollState.animateScrollTo(textScrollState.maxValue) }
+            launch { symbolListState.animateScrollToItem(selectedButtons.lastIndex) }
+        }
+    }
+
     Surface(
         modifier = modifier.shadow(2.dp, RoundedCornerShape(16.dp)),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
         shape = RoundedCornerShape(16.dp)
     ) {
-        Column(modifier = Modifier.fillMaxSize().padding(8.dp)) {
-            if (showSentenceText) {
+        Column(modifier = Modifier.fillMaxWidth().padding(8.dp)) {
+            if (sentenceText.isNotEmpty()) {
                 Box(
-                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                    modifier = Modifier
+                        .weight(1f, fill = false)
+                        .fillMaxWidth()
+                        .heightIn(max = maximumTextHeight)
+                        .verticalScroll(textScrollState)
+                        .clearAndSetSemantics {
+                            contentDescription = sentenceText
+                        },
                     contentAlignment = Alignment.CenterStart
                 ) {
                     Text(
-                        text = selectedButtons.joinToString(" ") { (button, _) ->
-                            (button.label ?: button.vocalization).orEmpty()
-                        },
-                        fontSize = 48.sp,
-                        lineHeight = 56.sp,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
+                        text = sentenceText,
+                        style = textStyle,
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(start = 12.dp, end = 64.dp, top = 4.dp, bottom = 4.dp)
+                            .padding(
+                                start = 8.dp,
+                                end = if (presentation == SymbolBarPresentation.Fullscreen) 64.dp else 8.dp,
+                                top = 4.dp,
+                                bottom = 4.dp
+                            )
                     )
                 }
             }
 
             Row(
-                modifier = if (showSentenceText) {
-                    Modifier.fillMaxWidth().height(80.dp)
-                } else {
-                    Modifier.weight(1f).fillMaxWidth()
-                },
+                modifier = Modifier.fillMaxWidth().height(64.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 LazyRow(
+                    state = symbolListState,
                     modifier = Modifier.weight(1f).fillMaxHeight(),
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(horizontal = 4.dp),
@@ -512,23 +582,28 @@ fun SymbolBar(
                     }
                 }
 
-                VerticalDivider(modifier = Modifier.padding(horizontal = 8.dp).height(40.dp))
+                if (showSpeak || showDelete || showClear) {
+                    VerticalDivider(modifier = Modifier.padding(horizontal = 8.dp).height(40.dp))
+                }
 
                 Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                    FilledIconButton(
-                        onClick = onSpeak,
-                        colors = IconButtonDefaults.filledIconButtonColors(containerColor = MaterialTheme.colorScheme.primary)
-                    ) {
-                        Icon(Icons.Default.PlayArrow, contentDescription = stringResource(Res.string.board_workspace_speak_sentence))
+                    if (showSpeak) {
+                        FilledIconButton(
+                            onClick = onSpeak,
+                            colors = IconButtonDefaults.filledIconButtonColors(containerColor = MaterialTheme.colorScheme.primary)
+                        ) {
+                            Icon(Icons.Default.PlayArrow, contentDescription = stringResource(Res.string.board_workspace_speak_sentence))
+                        }
                     }
-                    IconButton(onClick = onSave, enabled = isSaveEnabled) {
-                        Icon(Icons.Default.Save, contentDescription = stringResource(Res.string.board_workspace_save_phrase))
+                    if (showDelete) {
+                        IconButton(onClick = onDelete) {
+                            Icon(Icons.Default.Delete, contentDescription = stringResource(Res.string.board_workspace_delete_last))
+                        }
                     }
-                    IconButton(onClick = onDelete) {
-                        Icon(Icons.Default.Delete, contentDescription = stringResource(Res.string.board_workspace_delete_last))
-                    }
-                    IconButton(onClick = onClear) {
-                        Icon(Icons.Default.Clear, contentDescription = stringResource(Res.string.board_workspace_clear_sentence))
+                    if (showClear) {
+                        IconButton(onClick = onClear) {
+                            Icon(Icons.Default.Clear, contentDescription = stringResource(Res.string.board_workspace_clear_sentence))
+                        }
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -36,9 +36,6 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import kotlinx.coroutines.withTimeoutOrNull
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Home
@@ -80,8 +77,6 @@ import wingmatekmp.composeapp.generated.resources.board_workspace_speak_sentence
 import wingmatekmp.composeapp.generated.resources.board_workspace_home
 import wingmatekmp.composeapp.generated.resources.board_cell_opens_board
 
-enum class SentencePresentationMode { Normal, Fullscreen }
-
 private data class BoardGridItem(
     val row: Int,
     val column: Int,
@@ -104,8 +99,7 @@ fun ObfBoardView(
     onDeleteLast: () -> Unit = {},
     onClearSentence: () -> Unit = {},
     showMessageBar: Boolean = !isEditMode,
-    sentenceText: String = "",
-    presentationMode: SentencePresentationMode = SentencePresentationMode.Normal,
+    showSentenceText: Boolean = false,
     onCellClick: ((row: Int, column: Int, button: ObfButton?) -> Unit)? = null,
     onCellMove: ((fromRow: Int, fromColumn: Int, toRow: Int, toColumn: Int) -> Unit)? = null,
     homeBoardId: String? = null
@@ -125,14 +119,15 @@ fun ObfBoardView(
                     selectedButtons = selectedButtons,
                     imagesById = imagesById,
                     extractedImages = extractedImages,
-                    sentenceText = sentenceText,
-                    presentationMode = presentationMode,
                     onSpeak = onSpeakSentence,
                     onSave = onSaveSentence,
                     isSaveEnabled = isSaveSentenceEnabled,
                     onDelete = onDeleteLast,
                     onClear = onClearSentence,
-                    modifier = Modifier.fillMaxWidth()
+                    showSentenceText = showSentenceText,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(if (showSentenceText) 260.dp else 100.dp)
                 )
                 Spacer(modifier = Modifier.height(8.dp))
                 BoxWithConstraints(modifier = Modifier.fillMaxWidth().weight(1f)) {
@@ -158,14 +153,15 @@ fun ObfBoardView(
                     selectedButtons = selectedButtons,
                     imagesById = imagesById,
                     extractedImages = extractedImages,
-                    sentenceText = sentenceText,
-                    presentationMode = presentationMode,
                     onSpeak = onSpeakSentence,
                     onSave = onSaveSentence,
                     isSaveEnabled = isSaveSentenceEnabled,
                     onDelete = onDeleteLast,
                     onClear = onClearSentence,
-                    modifier = Modifier.fillMaxWidth()
+                    showSentenceText = showSentenceText,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(if (showSentenceText) 260.dp else 100.dp)
                 )
 
                 Spacer(modifier = Modifier.height(8.dp))
@@ -439,69 +435,32 @@ fun SymbolBar(
     selectedButtons: List<Pair<ObfButton, ImageBitmap?>>,
     imagesById: Map<String, io.github.jdreioe.wingmate.domain.obf.ObfImage>,
     extractedImages: Map<String, ByteArray>,
-    sentenceText: String = "",
-    presentationMode: SentencePresentationMode = SentencePresentationMode.Normal,
     onSpeak: () -> Unit,
     onSave: () -> Unit,
     isSaveEnabled: Boolean,
     onDelete: () -> Unit,
     onClear: () -> Unit,
+    showSentenceText: Boolean = false,
     modifier: Modifier = Modifier
 ) {
-    val maxTextLines = when (presentationMode) {
-        SentencePresentationMode.Normal -> 4
-        SentencePresentationMode.Fullscreen -> 6
-    }
-    val textScrollState = rememberScrollState()
-    val symbolsScrollState = rememberLazyListState()
-
-    val hasContent = selectedButtons.isNotEmpty()
-    val effectiveSentenceText = if (hasContent && sentenceText.isBlank()) {
-        selectedButtons.joinToString(" ") { (button, _) ->
-            (button.label ?: button.vocalization).orEmpty()
-        }
-    } else sentenceText
-
-    val currentSentenceLength = effectiveSentenceText.length
-    var previousLength by remember { mutableStateOf(currentSentenceLength) }
-    LaunchedEffect(currentSentenceLength) {
-        if (currentSentenceLength > previousLength) {
-            val isNearBottom = textScrollState.value >= textScrollState.maxValue - 32
-            if (isNearBottom) {
-                textScrollState.animateScrollTo(textScrollState.maxValue)
-            }
-        }
-        previousLength = currentSentenceLength
-    }
-
-    LaunchedEffect(selectedButtons.size) {
-        if (selectedButtons.isNotEmpty()) {
-            symbolsScrollState.animateScrollToItem(selectedButtons.size - 1)
-        }
-    }
-
     Surface(
         modifier = modifier.shadow(2.dp, RoundedCornerShape(16.dp)),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
         shape = RoundedCornerShape(16.dp)
     ) {
-        Column(modifier = Modifier.widthIn(max = 1200.dp).padding(8.dp)) {
-            if (effectiveSentenceText.isNotEmpty()) {
+        Column(modifier = Modifier.fillMaxSize().padding(8.dp)) {
+            if (showSentenceText) {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = (maxTextLines * 28).dp)
-                        .verticalScroll(textScrollState)
-                        .semantics {
-                            contentDescription = effectiveSentenceText
-                        },
-                    contentAlignment = Alignment.TopStart
+                    modifier = Modifier.weight(1f).fillMaxWidth(),
+                    contentAlignment = Alignment.CenterStart
                 ) {
                     Text(
-                        text = effectiveSentenceText,
+                        text = selectedButtons.joinToString(" ") { (button, _) ->
+                            (button.label ?: button.vocalization).orEmpty()
+                        },
                         fontSize = 48.sp,
                         lineHeight = 56.sp,
-                        maxLines = maxTextLines,
+                        maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier
                             .fillMaxWidth()
@@ -511,17 +470,20 @@ fun SymbolBar(
             }
 
             Row(
-                modifier = Modifier.fillMaxWidth().heightIn(min = 56.dp),
+                modifier = if (showSentenceText) {
+                    Modifier.fillMaxWidth().height(80.dp)
+                } else {
+                    Modifier.weight(1f).fillMaxWidth()
+                },
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 LazyRow(
                     modifier = Modifier.weight(1f).fillMaxHeight(),
-                    state = symbolsScrollState,
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(horizontal = 4.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    items(selectedButtons, key = { it.first.id }) { (button, bitmap) ->
+                    items(selectedButtons) { (button, bitmap) ->
                         val resolvedBitmap = remember(button, bitmap) {
                             bitmap ?: button.imageId?.let { id ->
                                 imagesById[id]?.path?.let { path ->

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -103,7 +103,7 @@ fun ObfBoardView(
     isSaveSentenceEnabled: Boolean = selectedButtons.isNotEmpty(),
     onDeleteLast: () -> Unit = {},
     onClearSentence: () -> Unit = {},
-    showActions: Boolean = true,
+    showMessageBar: Boolean = !isEditMode,
     sentenceText: String = "",
     presentationMode: SentencePresentationMode = SentencePresentationMode.Normal,
     onCellClick: ((row: Int, column: Int, button: ObfButton?) -> Unit)? = null,
@@ -119,23 +119,28 @@ fun ObfBoardView(
     val buttonsById = remember(board) { board.buttons.associateBy { it.id } }
 
     if (isAbsoluteLayout) {
-        Column(modifier = modifier.fillMaxSize().padding(8.dp)) {
-            SymbolBar(
-                selectedButtons = selectedButtons,
-                imagesById = imagesById,
-                extractedImages = extractedImages,
-                showActions = showActions,
-                sentenceText = sentenceText,
-                presentationMode = presentationMode,
-                onSpeak = onSpeakSentence,
-                onSave = onSaveSentence,
-                isSaveEnabled = isSaveSentenceEnabled,
-                onDelete = onDeleteLast,
-                onClear = onClearSentence,
-                modifier = Modifier.fillMaxWidth()
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-            BoxWithConstraints(modifier = Modifier.fillMaxWidth().weight(1f)) {
+        if (showMessageBar) {
+            Column(modifier = modifier.fillMaxSize().padding(8.dp)) {
+                SymbolBar(
+                    selectedButtons = selectedButtons,
+                    imagesById = imagesById,
+                    extractedImages = extractedImages,
+                    sentenceText = sentenceText,
+                    presentationMode = presentationMode,
+                    onSpeak = onSpeakSentence,
+                    onSave = onSaveSentence,
+                    isSaveEnabled = isSaveSentenceEnabled,
+                    onDelete = onDeleteLast,
+                    onClear = onClearSentence,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                BoxWithConstraints(modifier = Modifier.fillMaxWidth().weight(1f)) {
+                    renderAbsoluteButtons(board, imagesById, extractedImages, isEditMode, onButtonClick, homeBoardId)
+                }
+            }
+        } else {
+            BoxWithConstraints(modifier = modifier.fillMaxSize().padding(8.dp)) {
                 renderAbsoluteButtons(board, imagesById, extractedImages, isEditMode, onButtonClick, homeBoardId)
             }
         }
@@ -148,22 +153,23 @@ fun ObfBoardView(
             modifier = modifier.padding(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            SymbolBar(
-                selectedButtons = selectedButtons,
-                imagesById = imagesById,
-                extractedImages = extractedImages,
-                showActions = showActions,
-                sentenceText = sentenceText,
-                presentationMode = presentationMode,
-                onSpeak = onSpeakSentence,
-                onSave = onSaveSentence,
-                isSaveEnabled = isSaveSentenceEnabled,
-                onDelete = onDeleteLast,
-                onClear = onClearSentence,
-                modifier = Modifier.fillMaxWidth()
-            )
+            if (showMessageBar) {
+                SymbolBar(
+                    selectedButtons = selectedButtons,
+                    imagesById = imagesById,
+                    extractedImages = extractedImages,
+                    sentenceText = sentenceText,
+                    presentationMode = presentationMode,
+                    onSpeak = onSpeakSentence,
+                    onSave = onSaveSentence,
+                    isSaveEnabled = isSaveSentenceEnabled,
+                    onDelete = onDeleteLast,
+                    onClear = onClearSentence,
+                    modifier = Modifier.fillMaxWidth()
+                )
 
-            Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(8.dp))
+            }
 
             val gridItems = remember(grid, buttonsById) {
                 buildBoardGridItems(grid, buttonsById)
@@ -433,7 +439,6 @@ fun SymbolBar(
     selectedButtons: List<Pair<ObfButton, ImageBitmap?>>,
     imagesById: Map<String, io.github.jdreioe.wingmate.domain.obf.ObfImage>,
     extractedImages: Map<String, ByteArray>,
-    showActions: Boolean = true,
     sentenceText: String = "",
     presentationMode: SentencePresentationMode = SentencePresentationMode.Normal,
     onSpeak: () -> Unit,
@@ -444,8 +449,8 @@ fun SymbolBar(
     modifier: Modifier = Modifier
 ) {
     val maxTextLines = when (presentationMode) {
-        SentencePresentationMode.Normal -> 2
-        SentencePresentationMode.Fullscreen -> 4
+        SentencePresentationMode.Normal -> 4
+        SentencePresentationMode.Fullscreen -> 6
     }
     val textScrollState = rememberScrollState()
     val symbolsScrollState = rememberLazyListState()
@@ -545,25 +550,23 @@ fun SymbolBar(
                     }
                 }
 
-                if (showActions) {
-                    VerticalDivider(modifier = Modifier.padding(horizontal = 8.dp).height(40.dp))
+                VerticalDivider(modifier = Modifier.padding(horizontal = 8.dp).height(40.dp))
 
-                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                        FilledIconButton(
-                            onClick = onSpeak,
-                            colors = IconButtonDefaults.filledIconButtonColors(containerColor = MaterialTheme.colorScheme.primary)
-                        ) {
-                            Icon(Icons.Default.PlayArrow, contentDescription = stringResource(Res.string.board_workspace_speak_sentence))
-                        }
-                        IconButton(onClick = onSave, enabled = isSaveEnabled) {
-                            Icon(Icons.Default.Save, contentDescription = stringResource(Res.string.board_workspace_save_phrase))
-                        }
-                        IconButton(onClick = onDelete) {
-                            Icon(Icons.Default.Delete, contentDescription = stringResource(Res.string.board_workspace_delete_last))
-                        }
-                        IconButton(onClick = onClear) {
-                            Icon(Icons.Default.Clear, contentDescription = stringResource(Res.string.board_workspace_clear_sentence))
-                        }
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    FilledIconButton(
+                        onClick = onSpeak,
+                        colors = IconButtonDefaults.filledIconButtonColors(containerColor = MaterialTheme.colorScheme.primary)
+                    ) {
+                        Icon(Icons.Default.PlayArrow, contentDescription = stringResource(Res.string.board_workspace_speak_sentence))
+                    }
+                    IconButton(onClick = onSave, enabled = isSaveEnabled) {
+                        Icon(Icons.Default.Save, contentDescription = stringResource(Res.string.board_workspace_save_phrase))
+                    }
+                    IconButton(onClick = onDelete) {
+                        Icon(Icons.Default.Delete, contentDescription = stringResource(Res.string.board_workspace_delete_last))
+                    }
+                    IconButton(onClick = onClear) {
+                        Icon(Icons.Default.Clear, contentDescription = stringResource(Res.string.board_workspace_clear_sentence))
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/PhraseScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/PhraseScreen.kt
@@ -1215,6 +1215,7 @@ fun PhraseScreen(
                                 board = currentBoard!!,
                                 extractedImages = extractedImages,
                                 selectedButtons = selectedObfButtons,
+                                sentenceText = input.text,
                                 onButtonClick = { button ->
                                     // Check if this is a linking button
                                     val loadBoard = button.loadBoard

--- a/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/BoardSentenceTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/BoardSentenceTest.kt
@@ -1,0 +1,70 @@
+package io.github.jdreioe.wingmate.ui
+
+import androidx.compose.ui.graphics.ImageBitmap
+import io.github.jdreioe.wingmate.domain.obf.ObfBoard
+import io.github.jdreioe.wingmate.domain.obf.ObfButton
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BoardSentenceTest {
+    @Test
+    fun emptySelectionHasNoSentence() {
+        assertEquals("", buildResolvedSentence(emptyList(), board(), "en"))
+    }
+
+    @Test
+    fun vocalizationTakesPriorityAndUsesBoardLocalization() {
+        val selected = listOf(
+            selectedButton(label = "Hello", vocalization = "Hello spoken"),
+            selectedButton(label = "world")
+        )
+        val board = board(
+            strings = mapOf(
+                "da" to mapOf(
+                    "Hello spoken" to "Hej",
+                    "world" to "verden"
+                )
+            )
+        )
+
+        assertEquals("Hej verden", buildResolvedSentence(selected, board, "da-DK"))
+    }
+
+    @Test
+    fun singleCharacterTokensAreJoinedForSpelling() {
+        val selected = listOf(
+            selectedButton(label = "H"),
+            selectedButton(label = "i")
+        )
+
+        assertEquals("Hi", buildResolvedSentence(selected, board(), "en"))
+    }
+
+    @Test
+    fun blankTokensAreIgnored() {
+        val selected = listOf(
+            selectedButton(label = "Hello"),
+            selectedButton(label = " "),
+            selectedButton(label = "there")
+        )
+
+        assertEquals("Hello there", buildResolvedSentence(selected, board(), "en"))
+    }
+
+    private fun board(
+        strings: Map<String, Map<String, String>> = emptyMap()
+    ) = ObfBoard(
+        format = "open-board-0.1",
+        id = "board",
+        strings = strings
+    )
+
+    private fun selectedButton(
+        label: String,
+        vocalization: String? = null
+    ): Pair<ObfButton, ImageBitmap?> = ObfButton(
+        id = "button-$label",
+        label = label,
+        vocalization = vocalization
+    ) to null
+}

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ZipBuilder.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ZipBuilder.kt
@@ -1,93 +1,131 @@
 package io.github.jdreioe.wingmate.domain.obf
 
-/**
- * Pure-Kotlin ZIP builder that creates store-method (uncompressed) ZIP archives.
- */
+sealed class ZipBuilderError(message: String) : Exception(message) {
+    data class InvalidEntryName(val name: String, override val message: String) : ZipBuilderError(message)
+    data class DuplicateEntryName(val name: String) : ZipBuilderError("Duplicate ZIP entry: $name")
+    data object Zip64Required : ZipBuilderError(
+        "Archive exceeds classic ZIP limits (entries > 65535, entry size > 4 GiB, " +
+            "or total archive > 4 GiB). ZIP64 is not implemented."
+    )
+}
+
 object ZipBuilder {
 
-    fun build(entries: Map<String, ByteArray>): ByteArray {
-        val localHeaders = mutableListOf<ByteArray>()
-        val centralEntries = mutableListOf<ByteArray>()
-        var offset = 0
+    fun build(entries: List<Pair<String, ByteArray>>): Result<ByteArray> = runCatching {
+        val sink = GrowableByteArray(8192)
+        val centralEntries = GrowableByteArray(4096)
+        val seenNames = mutableSetOf<String>()
+        var localOffset = 0L
 
         for ((name, data) in entries) {
+            validateEntryName(name, seenNames)
             val nameBytes = name.encodeToByteArray()
             val crc = crc32(data)
+            val dataSize = data.size
 
-            // Local file header
-            localHeaders += buildLocalHeader(nameBytes, data.size, crc)
-            localHeaders += data
+            checkOverflow(name, dataSize, localOffset)
 
-            // Central directory entry
-            centralEntries += buildCentralEntry(nameBytes, data.size, crc, offset)
+            sink.write(buildLocalHeader(nameBytes, dataSize, crc))
+            sink.write(data)
 
-            offset += 30 + nameBytes.size + data.size
+            centralEntries.write(buildCentralEntry(nameBytes, dataSize, crc, localOffset))
+
+            localOffset += 30L + nameBytes.size + dataSize
         }
 
-        val cdBytes = centralEntries.fold(byteArrayOf()) { acc, e -> acc + e }
-        val eocd = buildEndOfCentralDirectory(
-            totalEntries = entries.size,
-            centralDirSize = cdBytes.size,
-            centralDirOffset = offset
-        )
+        val entryCount = entries.size
+        val centralDirSize = centralEntries.size
+        checkClassicLimit(entryCount, "entry count", 65535)
+        checkClassicLimit(centralDirSize.toLong(), "central directory size", 0xFFFFFFFFL)
+        checkClassicLimit(localOffset, "central directory offset", 0xFFFFFFFFL)
 
-        return localHeaders.fold(byteArrayOf()) { acc, e -> acc + e } + cdBytes + eocd
+        sink.write(centralEntries.toByteArray())
+        sink.write(buildEndOfCentralDirectory(entryCount, centralDirSize.toLong(), localOffset))
+
+        sink.toByteArray()
+    }
+
+    private fun validateEntryName(name: String, seenNames: MutableSet<String>) {
+        if (name.isEmpty()) throw ZipBuilderError.InvalidEntryName(name, "Entry name must not be empty")
+        if (name.contains('\u0000')) throw ZipBuilderError.InvalidEntryName(name, "Entry name contains NUL character")
+        if (name.startsWith('/')) throw ZipBuilderError.InvalidEntryName(name, "Entry name must not be absolute")
+        if (Regex("(^|/)\\.\\.(/|$)").containsMatchIn(name)) {
+            throw ZipBuilderError.InvalidEntryName(name, "Entry name must not contain parent-directory traversal")
+        }
+        if (!seenNames.add(name)) throw ZipBuilderError.DuplicateEntryName(name)
+    }
+
+    private fun checkOverflow(name: String, dataSize: Int, localOffset: Long) {
+        if (dataSize > 0xFFFFFFFFL) {
+            throw ZipBuilderError.InvalidEntryName(name, "Entry size (${dataSize}B) exceeds 4 GiB limit")
+        }
+        if (localOffset + 30L + name.encodeToByteArray().size + dataSize > 0xFFFFFFFFL) {
+            throw ZipBuilderError.Zip64Required
+        }
+    }
+
+    private fun checkClassicLimit(value: Long, label: String, limit: Long) {
+        if (value > limit) throw ZipBuilderError.Zip64Required
+    }
+
+    private fun checkClassicLimit(value: Int, label: String, limit: Int) {
+        if (value > limit) throw ZipBuilderError.Zip64Required
     }
 
     private fun buildLocalHeader(nameBytes: ByteArray, dataSize: Int, crc: Int): ByteArray {
         val buf = ByteArray(30 + nameBytes.size)
-        writeLe32(buf, 0, 0x04034b50)       // signature
-        writeLe16(buf, 4, 20)                // version needed
-        writeLe16(buf, 6, 0)                 // flags
-        writeLe16(buf, 8, 0)                 // compression: stored
-        writeLe16(buf, 10, 0)                // mod time
-        writeLe16(buf, 12, 0)                // mod date
-        writeLe32(buf, 14, crc)              // crc-32
-        writeLe32(buf, 18, dataSize)         // compressed size
-        writeLe32(buf, 22, dataSize)         // uncompressed size
-        writeLe16(buf, 26, nameBytes.size)   // filename length
-        writeLe16(buf, 28, 0)                // extra field length
+        writeLe32(buf, 0, 0x04034b50)
+        writeLe16(buf, 4, 20)
+        writeLe16(buf, 6, 0x0800)
+        writeLe16(buf, 8, 0)
+        writeLe16(buf, 10, 0)
+        writeLe16(buf, 12, 0)
+        writeLe32(buf, 14, crc)
+        writeLe32(buf, 18, dataSize)
+        writeLe32(buf, 22, dataSize)
+        writeLe16(buf, 26, nameBytes.size)
+        writeLe16(buf, 28, 0)
         nameBytes.copyInto(buf, 30)
         return buf
     }
 
-    private fun buildCentralEntry(nameBytes: ByteArray, dataSize: Int, crc: Int, localOffset: Int): ByteArray {
+    private fun buildCentralEntry(nameBytes: ByteArray, dataSize: Int, crc: Int, localOffset: Long): ByteArray {
         val buf = ByteArray(46 + nameBytes.size)
-        writeLe32(buf, 0, 0x02014b50)        // signature
-        writeLe16(buf, 4, 20)                // version made by
-        writeLe16(buf, 6, 20)                // version needed
-        writeLe16(buf, 8, 0)                 // flags
-        writeLe16(buf, 10, 0)                // compression: stored
-        writeLe16(buf, 12, 0)                // mod time
-        writeLe16(buf, 14, 0)                // mod date
-        writeLe32(buf, 16, crc)              // crc-32
-        writeLe32(buf, 20, dataSize)         // compressed size
-        writeLe32(buf, 24, dataSize)         // uncompressed size
-        writeLe16(buf, 28, nameBytes.size)   // filename length
-        writeLe16(buf, 30, 0)                // extra field length
-        writeLe16(buf, 32, 0)                // file comment length
-        writeLe16(buf, 34, 0)                // disk number start
-        writeLe16(buf, 36, 0)                // internal file attributes
-        writeLe32(buf, 38, 0)                // external file attributes
-        writeLe32(buf, 42, localOffset)      // relative offset
+        writeLe32(buf, 0, 0x02014b50)
+        writeLe16(buf, 4, 20)
+        writeLe16(buf, 6, 20)
+        writeLe16(buf, 8, 0x0800)
+        writeLe16(buf, 10, 0)
+        writeLe16(buf, 12, 0)
+        writeLe16(buf, 14, 0)
+        writeLe32(buf, 16, crc)
+        writeLe32(buf, 20, dataSize)
+        writeLe32(buf, 24, dataSize)
+        writeLe16(buf, 28, nameBytes.size)
+        writeLe16(buf, 30, 0)
+        writeLe16(buf, 32, 0)
+        writeLe16(buf, 34, 0)
+        writeLe16(buf, 36, 0)
+        writeLe32(buf, 38, 0)
+        writeLe32(buf, 42, localOffset.toInt())
         nameBytes.copyInto(buf, 46)
         return buf
     }
 
     private fun buildEndOfCentralDirectory(
         totalEntries: Int,
-        centralDirSize: Int,
-        centralDirOffset: Int
+        centralDirSize: Long,
+        centralDirOffset: Long
     ): ByteArray {
         val buf = ByteArray(22)
-        writeLe32(buf, 0, 0x06054b50)        // signature
-        writeLe16(buf, 4, 0)                 // disk number
-        writeLe16(buf, 6, 0)                 // disk of central dir
-        writeLe16(buf, 8, totalEntries)      // entries on disk
-        writeLe16(buf, 10, totalEntries)     // total entries
-        writeLe32(buf, 12, centralDirSize)   // size of central dir
-        writeLe32(buf, 16, centralDirOffset) // offset of central dir
-        writeLe16(buf, 20, 0)                // comment length
+        writeLe32(buf, 0, 0x06054b50)
+        writeLe16(buf, 4, 0)
+        writeLe16(buf, 6, 0)
+        writeLe16(buf, 8, totalEntries)
+        writeLe16(buf, 10, totalEntries)
+        writeLe32(buf, 12, centralDirSize.toInt())
+        writeLe32(buf, 16, centralDirOffset.toInt())
+        writeLe16(buf, 20, 0)
         return buf
     }
 
@@ -117,5 +155,27 @@ object ZipBuilder {
             crc = (crc ushr 8) xor crcTable[(crc xor byte.toInt()) and 0xFF]
         }
         return crc xor 0xFFFFFFFF.toInt()
+    }
+}
+
+private class GrowableByteArray(initialCapacity: Int) {
+    private var buffer = ByteArray(initialCapacity.coerceAtLeast(1))
+    var size: Int = 0
+        private set
+
+    fun write(bytes: ByteArray) {
+        ensureCapacity(size + bytes.size)
+        bytes.copyInto(buffer, size)
+        size += bytes.size
+    }
+
+    fun toByteArray(): ByteArray = buffer.copyOf(size)
+
+    private fun ensureCapacity(minCapacity: Int) {
+        if (minCapacity > buffer.size) {
+            var newSize = buffer.size
+            while (newSize < minCapacity) newSize = (newSize * 2).coerceAtLeast(1)
+            buffer = buffer.copyOf(newSize)
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/ObzExporter.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/ObzExporter.kt
@@ -84,7 +84,7 @@ class ObzExporter(
         val manifestJson = json.encodeToJsonElement(ObfManifest.serializer(), manifest)
         entries["manifest.json"] = json.encodeToString(serializeWithExtensions(manifestJson, manifest)).encodeToByteArray()
 
-        return ZipBuilder.build(entries)
+        return ZipBuilder.build(entries.toList()).getOrThrow()
     }
 
     /**

--- a/shared/src/commonTest/kotlin/ZipBuilderTest.kt
+++ b/shared/src/commonTest/kotlin/ZipBuilderTest.kt
@@ -1,26 +1,28 @@
 import io.github.jdreioe.wingmate.domain.obf.ZipBuilder
+import io.github.jdreioe.wingmate.domain.obf.ZipBuilderError
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class ZipBuilderTest {
 
     @Test
     fun buildsValidZipWithSingleEntry() {
-        val zip = ZipBuilder.build(mapOf("hello.txt" to "world".encodeToByteArray()))
+        val zip = ZipBuilder.build(listOf("hello.txt" to "world".encodeToByteArray())).getOrThrow()
         assertTrue(zip.size > 30)
-        // PK signature for local file header
         assertTrue(zip[0] == 0x50.toByte() && zip[1] == 0x4B.toByte() &&
             zip[2] == 0x03.toByte() && zip[3] == 0x04.toByte())
     }
 
     @Test
     fun buildsZipWithMultipleEntries() {
-        val entries = mapOf(
+        val entries = listOf(
             "a.txt" to "aaa".encodeToByteArray(),
             "b.txt" to "bbb".encodeToByteArray()
         )
-        val zip = ZipBuilder.build(entries)
+        val zip = ZipBuilder.build(entries).getOrThrow()
         assertTrue(zip.size > 60)
         assertTrue(String(zip).contains("a.txt"))
         assertTrue(String(zip).contains("b.txt"))
@@ -28,7 +30,7 @@ class ZipBuilderTest {
 
     @Test
     fun eocdSignaturePresent() {
-        val zip = ZipBuilder.build(mapOf("f" to "d".encodeToByteArray()))
+        val zip = ZipBuilder.build(listOf("f" to "d".encodeToByteArray())).getOrThrow()
         val tail = zip.copyOfRange(zip.size - 22, zip.size)
         assertTrue(tail[0] == 0x50.toByte() && tail[1] == 0x4B.toByte() &&
             tail[2] == 0x05.toByte() && tail[3] == 0x06.toByte())
@@ -36,17 +38,171 @@ class ZipBuilderTest {
 
     @Test
     fun emptyEntries() {
-        val zip = ZipBuilder.build(emptyMap())
-        // EOCD only - 22 bytes
-        assertTrue(zip.size == 22)
+        val zip = ZipBuilder.build(emptyList()).getOrThrow()
+        assertEquals(22, zip.size)
     }
 
     @Test
     fun dataIsPreserved() {
         val data = "Hello, OBZ!".encodeToByteArray()
-        val zip = ZipBuilder.build(mapOf("test.bin" to data))
+        val zip = ZipBuilder.build(listOf("test.bin" to data)).getOrThrow()
         val dataStart = 30 + "test.bin".encodeToByteArray().size
         val extracted = zip.copyOfRange(dataStart, dataStart + data.size)
         assertTrue(extracted.contentEquals(data))
+    }
+
+    @Test
+    fun utf8FlagSet() {
+        val zip = ZipBuilder.build(listOf("héllo.txt" to "data".encodeToByteArray())).getOrThrow()
+        val flags = ((zip[7].toInt() and 0xFF) shl 8) or (zip[6].toInt() and 0xFF)
+        assertTrue((flags and 0x0800) != 0, "UTF-8 flag (bit 11) must be set in local header")
+    }
+
+    @Test
+    fun utf8FlagSetInCentralDirectory() {
+        val zip = ZipBuilder.build(listOf("héllo.txt" to "data".encodeToByteArray())).getOrThrow()
+        var pos = 0
+        var centralFlags: Int? = null
+        while (pos < zip.size - 4) {
+            if (zip[pos] == 0x50.toByte() && zip[pos + 1] == 0x4B.toByte() &&
+                zip[pos + 2] == 0x01.toByte() && zip[pos + 3] == 0x02.toByte()
+            ) {
+                centralFlags = ((zip[pos + 9].toInt() and 0xFF) shl 8) or (zip[pos + 8].toInt() and 0xFF)
+                break
+            }
+            pos++
+        }
+        assertNotNull(centralFlags)
+        assertTrue((centralFlags and 0x0800) != 0, "UTF-8 flag (bit 11) must be set in central directory entry")
+    }
+
+    @Test
+    fun unicodeFilenamePreserved() {
+        val name = "smørrebrød/æøå.txt"
+        val zip = ZipBuilder.build(listOf(name to "data".encodeToByteArray())).getOrThrow()
+        assertTrue(String(zip).contains(name), "Unicode filename must be present in ZIP bytes")
+    }
+
+    @Test
+    fun rejectsEmptyEntryName() {
+        val error = assertFailsWith<ZipBuilderError.InvalidEntryName> {
+            ZipBuilder.build(listOf("" to "data".encodeToByteArray())).getOrThrow()
+        }
+        assertTrue(error.message.contains("empty"))
+    }
+
+    @Test
+    fun rejectsAbsolutePath() {
+        val error = assertFailsWith<ZipBuilderError.InvalidEntryName> {
+            ZipBuilder.build(listOf("/etc/passwd" to "data".encodeToByteArray())).getOrThrow()
+        }
+        assertTrue(error.message.contains("absolute"))
+    }
+
+    @Test
+    fun rejectsDirectoryTraversal() {
+        val error = assertFailsWith<ZipBuilderError.InvalidEntryName> {
+            ZipBuilder.build(listOf("../outside/foo.txt" to "data".encodeToByteArray())).getOrThrow()
+        }
+        assertTrue(error.message.contains("traversal"))
+    }
+
+    @Test
+    fun rejectsNestedDirectoryTraversal() {
+        val error = assertFailsWith<ZipBuilderError.InvalidEntryName> {
+            ZipBuilder.build(listOf("boards/../../outside/foo.txt" to "data".encodeToByteArray())).getOrThrow()
+        }
+        assertTrue(error.message.contains("traversal"))
+    }
+
+    @Test
+    fun rejectsNulCharacter() {
+        val error = assertFailsWith<ZipBuilderError.InvalidEntryName> {
+            ZipBuilder.build(listOf("foo\u0000bar.txt" to "data".encodeToByteArray())).getOrThrow()
+        }
+        assertTrue(error.message.contains("NUL"))
+    }
+
+    @Test
+    fun rejectsDuplicateEntryName() {
+        assertFailsWith<ZipBuilderError.DuplicateEntryName> {
+            ZipBuilder.build(listOf(
+                "same.txt" to "first".encodeToByteArray(),
+                "same.txt" to "second".encodeToByteArray()
+            )).getOrThrow()
+        }
+    }
+
+    @Test
+    fun identicalInputsProduceIdenticalOutput() {
+        val entries = listOf(
+            "a.txt" to "111".encodeToByteArray(),
+            "b.txt" to "222".encodeToByteArray()
+        )
+        val zip1 = ZipBuilder.build(entries).getOrThrow()
+        val zip2 = ZipBuilder.build(entries).getOrThrow()
+        assertTrue(zip1.contentEquals(zip2), "Same ordered inputs must produce identical bytes")
+    }
+
+    @Test
+    fun crcValidatesForEntry() {
+        val data = "Hello, CRC!".encodeToByteArray()
+        val zip = ZipBuilder.build(listOf("check.me" to data)).getOrThrow()
+        val entryName = "check.me"
+        var pos = 0
+        while (pos < zip.size - 4) {
+            if (zip[pos] == 0x50.toByte() && zip[pos + 1] == 0x4B.toByte() &&
+                zip[pos + 2] == 0x03.toByte() && zip[pos + 3] == 0x04.toByte()
+            ) {
+                val nameLen = ((zip[pos + 27].toInt() and 0xFF) shl 8) or (zip[pos + 26].toInt() and 0xFF)
+                val extraLen = ((zip[pos + 29].toInt() and 0xFF) shl 8) or (zip[pos + 28].toInt() and 0xFF)
+                val storedCrc = ((zip[pos + 17].toInt() and 0xFF) shl 24) or
+                    ((zip[pos + 16].toInt() and 0xFF) shl 16) or
+                    ((zip[pos + 15].toInt() and 0xFF) shl 8) or
+                    (zip[pos + 14].toInt() and 0xFF)
+                val headerSize = 30 + nameLen + extraLen
+                val compSize = ((zip[pos + 21].toInt() and 0xFF) shl 24) or
+                    ((zip[pos + 20].toInt() and 0xFF) shl 16) or
+                    ((zip[pos + 19].toInt() and 0xFF) shl 8) or
+                    (zip[pos + 18].toInt() and 0xFF)
+                val extractedName = zip.copyOfRange(pos + 30, pos + 30 + nameLen).decodeToString()
+                if (extractedName == entryName) {
+                    val extracted = zip.copyOfRange(pos + headerSize, pos + headerSize + compSize)
+                    assertTrue(extracted.contentEquals(data), "Data must be retrievable")
+                    assertTrue(storedCrc != 0, "CRC must be non-zero")
+                    return
+                }
+                pos += headerSize + compSize
+            } else {
+                pos++
+            }
+        }
+    }
+
+    @Test
+    fun directoryOffsetsValid() {
+        val entries = listOf(
+            "first.txt" to "data1".encodeToByteArray(),
+            "second.txt" to "data2".encodeToByteArray()
+        )
+        val zip = ZipBuilder.build(entries).getOrThrow()
+        val tail = zip.copyOfRange(zip.size - 22, zip.size)
+        val cdOffset = ((tail[19].toInt() and 0xFF) shl 24) or
+            ((tail[18].toInt() and 0xFF) shl 16) or
+            ((tail[17].toInt() and 0xFF) shl 8) or
+            (tail[16].toInt() and 0xFF)
+        val cdSize = ((tail[15].toInt() and 0xFF) shl 24) or
+            ((tail[14].toInt() and 0xFF) shl 16) or
+            ((tail[13].toInt() and 0xFF) shl 8) or
+            (tail[12].toInt() and 0xFF)
+        assertEquals(zip.size - 22, cdOffset + cdSize, "Central directory must end just before EOCD")
+    }
+
+    @Test
+    fun zip64RequiredForLargeEntryCount() {
+        val manyEntries = (0..65535).map { "file$it.txt" to "x".encodeToByteArray() }
+        val error = assertFailsWith<ZipBuilderError.Zip64Required> {
+            ZipBuilder.build(manyEntries).getOrThrow()
+        }
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Auto-incremented by build
-#Wed Jul 22 17:21:04 CEST 2026
-versionCode=29
+#Thu Jul 23 17:39:02 CEST 2026
+versionCode=30
 versionName=0.6


### PR DESCRIPTION
## Summary
- Added `SentencePresentationMode` enum (Normal=4 lines, Fullscreen=6 lines)
- Replaced `showSentenceText: Boolean` with `sentenceText: String` + `presentationMode` on both `ObfBoardView` and `SymbolBar`
- Removed fixed 260/100dp height; content-grown sizing
- Sentence text shown always when content exists (not just fullscreen)
- Auto-scroll on new text when user is near bottom
- Symbols auto-scroll to newest entry
- Full sentence exposed via accessibility `contentDescription`
- Updated `BoardSetWorkspaceScreen` call site