### PR TITLE
Bump version to 0.7

### DIFF
--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Auto-incremented by build
 #Thu Jul 23 17:39:02 CEST 2026
 versionCode=30
-versionName=0.6
+versionName=0.7


### PR DESCRIPTION
## What changed

Updated the Android release version name from `0.6` to `0.7` in `version.properties`.

## Why

Keeps the Android release version aligned with the intended `0.7` release and the existing iOS marketing version.

## Impact

Future Android builds will report version `0.7`. The numeric Android version code remains unchanged.

## Validation

- Confirmed the branch differs from `main` only in `version.properties`
- Ran `git diff --check`
- Confirmed both Android and iOS release version declarations are `0.7`
