### PR TITLE
Add direct cell-based field resizing in the board editor (#52)

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -49,6 +49,9 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
+                @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+                @Suppress("DEPRECATION")
+                implementation(compose.uiTest)
             }
         }
         

--- a/composeApp/src/commonMain/composeResources/values-da/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-da/strings.xml
@@ -57,6 +57,14 @@
     <string name="board_workspace_delete">Slet side</string>
     <string name="board_workspace_home">Startside</string>
     <string name="board_workspace_edit">Rediger skærm</string>
+    <string name="board_resize_field_label">Juster feltstørrelse</string>
+    <string name="board_resize_size">%1$d × %2$d</string>
+    <string name="board_resize_increase_width">Forøg bredde</string>
+    <string name="board_resize_decrease_width">Formindsk bredde</string>
+    <string name="board_resize_increase_height">Forøg højde</string>
+    <string name="board_resize_decrease_height">Formindsk højde</string>
+    <string name="board_resize_blocked_bounds">Kan ikke ændres: feltet rækker ud over tavlen</string>
+    <string name="board_resize_blocked_occupied">Kan ikke ændres: feltet dækker et andet felt</string>
     <string name="board_workspace_add">Tilføj side</string>
     <string name="board_workspace_load_error">Skærmen kunne ikke indlæses</string>
     <string name="board_workspace_back_to_library">Tilbage til skærme</string>
@@ -131,9 +139,6 @@
     <string name="board_dialog_clear_image">Fjern billede</string>
     <string name="board_dialog_color">Feltfarve</string>
     <string name="board_dialog_pick_color">Vælg</string>
-    <string name="board_dialog_field_size">Feltstørrelse</string>
-    <string name="board_dialog_field_size_value">%1$d × %2$d</string>
-    <string name="board_dialog_field_size_help">Bredde × højde i felter</string>
     <string name="board_dialog_language">Sprog</string>
     <string name="board_dialog_language_default">Brug standardsprog</string>
     <string name="board_dialog_language_english">Engelsk</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -57,6 +57,14 @@
     <string name="board_workspace_delete">Delete page</string>
     <string name="board_workspace_home">Start page</string>
     <string name="board_workspace_edit">Edit screen</string>
+    <string name="board_resize_field_label">Resize field</string>
+    <string name="board_resize_size">%1$d × %2$d</string>
+    <string name="board_resize_increase_width">Increase width</string>
+    <string name="board_resize_decrease_width">Decrease width</string>
+    <string name="board_resize_increase_height">Increase height</string>
+    <string name="board_resize_decrease_height">Decrease height</string>
+    <string name="board_resize_blocked_bounds">Can\'t resize: the field would reach outside the board</string>
+    <string name="board_resize_blocked_occupied">Can\'t resize: the field would cover another field</string>
     <string name="board_workspace_add">Add page</string>
     <string name="board_workspace_load_error">This screen could not be loaded</string>
     <string name="board_workspace_back_to_library">Back to Screens</string>
@@ -131,9 +139,6 @@
     <string name="board_dialog_clear_image">Clear image</string>
     <string name="board_dialog_color">Field color</string>
     <string name="board_dialog_pick_color">Pick</string>
-    <string name="board_dialog_field_size">Field size</string>
-    <string name="board_dialog_field_size_value">%1$d × %2$d</string>
-    <string name="board_dialog_field_size_help">Width × height in fields</string>
     <string name="board_dialog_language">Language</string>
     <string name="board_dialog_language_default">Use default language</string>
     <string name="board_dialog_language_english">English</string>

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetDialogs.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetDialogs.kt
@@ -37,7 +37,6 @@ import org.koin.compose.getKoin
 import wingmatekmp.composeapp.generated.resources.*
 
 internal data class FieldLanguageOption(val tag: String, val label: String)
-internal data class FieldSpanOption(val rows: Int, val columns: Int)
 internal enum class BoardSetTemplate { Blank, Calculator }
 
 @Composable
@@ -174,9 +173,6 @@ internal fun EditBoardCellDialog(
     initialMathMode: Boolean = false,
     availableBoards: List<ObfBoard> = emptyList(),
     initialLinkedBoardId: String? = null,
-    availableSpans: List<FieldSpanOption> = listOf(FieldSpanOption(rows = 1, columns = 1)),
-    initialRowSpan: Int = 1,
-    initialColumnSpan: Int = 1,
     initialAction: String? = null,
     initialActions: List<String> = emptyList(),
     hasExistingValue: Boolean,
@@ -190,8 +186,6 @@ internal fun EditBoardCellDialog(
         language: String?,
         mathMode: Boolean,
         linkedBoardId: String?,
-        rowSpan: Int,
-        columnSpan: Int,
         action: String?,
         actions: List<String>
     ) -> Unit,
@@ -209,16 +203,12 @@ internal fun EditBoardCellDialog(
     var linkedBoardId by remember { mutableStateOf(initialLinkedBoardId) }
     var action by remember { mutableStateOf(initialAction) }
     val actions by remember { mutableStateOf(initialActions) }
-    var selectedSpan by remember(initialRowSpan, initialColumnSpan) {
-        mutableStateOf(FieldSpanOption(initialRowSpan, initialColumnSpan))
-    }
     var opensPage by remember { mutableStateOf(initialLinkedBoardId != null) }
     var showLanguageMenu by remember { mutableStateOf(false) }
     var showBoardMenu by remember { mutableStateOf(false) }
     var showSymbolSearch by remember { mutableStateOf(false) }
     var showImageSourcePicker by remember { mutableStateOf(false) }
     var showColorPicker by remember { mutableStateOf(false) }
-    var showSpanMenu by remember { mutableStateOf(false) }
     val koin = getKoin()
     val recordingService = remember(koin) { koin.getOrNull<PhraseRecordingService>() }
     val scope = rememberCoroutineScope()
@@ -368,52 +358,6 @@ internal fun EditBoardCellDialog(
                 }
 
                 Text(
-                    stringResource(Res.string.board_dialog_field_size),
-                    style = MaterialTheme.typography.labelLarge
-                )
-                Box {
-                    OutlinedButton(
-                        onClick = { showSpanMenu = true },
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
-                        Text(
-                            stringResource(
-                                Res.string.board_dialog_field_size_value,
-                                selectedSpan.columns,
-                                selectedSpan.rows
-                            )
-                        )
-                    }
-                    DropdownMenu(
-                        expanded = showSpanMenu,
-                        onDismissRequest = { showSpanMenu = false }
-                    ) {
-                        availableSpans.forEach { span ->
-                            DropdownMenuItem(
-                                text = {
-                                    Text(
-                                        stringResource(
-                                            Res.string.board_dialog_field_size_value,
-                                            span.columns,
-                                            span.rows
-                                        )
-                                    )
-                                },
-                                onClick = {
-                                    selectedSpan = span
-                                    showSpanMenu = false
-                                }
-                            )
-                        }
-                    }
-                }
-                Text(
-                    stringResource(Res.string.board_dialog_field_size_help),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-
-                Text(
                     stringResource(Res.string.board_dialog_language),
                     style = MaterialTheme.typography.labelLarge
                 )
@@ -556,8 +500,6 @@ internal fun EditBoardCellDialog(
                         language,
                         mathMode,
                         linkedBoardId.takeIf { opensPage },
-                        selectedSpan.rows,
-                        selectedSpan.columns,
                         action?.trim()?.ifBlank { null },
                         actions
                     )

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -141,7 +141,31 @@ private data class WorkspaceCellTarget(
     val button: ObfButton?
 )
 
-internal data class GridFieldSpan(val rows: Int, val columns: Int)
+internal sealed interface CellTapResult {
+    data class Select(val anchor: Pair<Int, Int>) : CellTapResult
+    data class OpenDialog(
+        val row: Int,
+        val column: Int,
+        val button: ObfButton?
+    ) : CellTapResult
+}
+
+internal fun resolveCellTap(
+    grid: io.github.jdreioe.wingmate.domain.obf.ObfGrid?,
+    selectedField: Pair<Int, Int>?,
+    row: Int,
+    column: Int,
+    button: ObfButton?
+): CellTapResult {
+    val anchor = button?.let { grid?.fieldAnchorAt(row, column) }
+    return when {
+        anchor != null && anchor == selectedField -> CellTapResult.OpenDialog(row, column, button)
+        anchor != null -> CellTapResult.Select(anchor)
+        else -> CellTapResult.OpenDialog(row, column, button)
+    }
+}
+
+data class GridFieldSpan(val rows: Int, val columns: Int)
 
 /**
  * Board-set entry point with a familiar library -> Run/Edit workspace flow.
@@ -501,6 +525,7 @@ private fun BoardSetWorkspaceScreen(
     var statusMessage by remember(boardSetId) { mutableStateOf<String?>(null) }
     var showAddBoardDialog by remember { mutableStateOf(false) }
     var editingCell by remember { mutableStateOf<WorkspaceCellTarget?>(null) }
+    var selectedField by remember(boardSetId) { mutableStateOf<Pair<Int, Int>?>(null) }
     var showFinishDialog by remember { mutableStateOf(false) }
     var showResizeBoardDialog by remember { mutableStateOf(false) }
     var showDeleteBoardDialog by remember { mutableStateOf(false) }
@@ -619,6 +644,7 @@ private fun BoardSetWorkspaceScreen(
         }
         selectedButtons = emptyList()
         boardStack = emptyList()
+        selectedField = null
         editSession = BoardSetEditSession(graph, graph)
         mode = BoardWorkspaceMode.Edit
     }
@@ -627,6 +653,7 @@ private fun BoardSetWorkspaceScreen(
         val session = editSession ?: return
         if (session.isDirty) showFinishDialog = true
         else {
+            selectedField = null
             editSession = null
             mode = BoardWorkspaceMode.Run
         }
@@ -889,6 +916,7 @@ private fun BoardSetWorkspaceScreen(
                                 selectedBoardId = it
                                 boardStack = emptyList()
                                 selectedButtons = emptyList()
+                                selectedField = null
                             }
                         )
                     }
@@ -1022,13 +1050,30 @@ private fun BoardSetWorkspaceScreen(
                             }
                         },
                         onCellClick = if (mode == BoardWorkspaceMode.Edit) {
-                            { row, column, button -> editingCell = WorkspaceCellTarget(row, column, button) }
+                            { row, column, button ->
+                                when (
+                                    val result = resolveCellTap(
+                                        grid = activeBoard.grid,
+                                        selectedField = selectedField,
+                                        row = row,
+                                        column = column,
+                                        button = button
+                                    )
+                                ) {
+                                    is CellTapResult.Select -> selectedField = result.anchor
+                                    is CellTapResult.OpenDialog -> {
+                                        selectedField = null
+                                        editingCell = WorkspaceCellTarget(result.row, result.column, result.button)
+                                    }
+                                }
+                            }
                         } else null,
                         onCellMove = if (mode == BoardWorkspaceMode.Edit) {
                             { fromRow, fromColumn, toRow, toColumn ->
                                 val session = editSession
                                 val boardId = activeBoard.id
                                 if (session != null) {
+                                    selectedField = null
                                     editSession = session.apply(
                                         moveDraftField(
                                             session.draft,
@@ -1039,6 +1084,29 @@ private fun BoardSetWorkspaceScreen(
                                             toColumn
                                         )
                                     )
+                                }
+                            }
+                        } else null,
+                        selectedFieldAnchor = selectedField,
+                        selectedFieldSpans = remember(activeBoard?.grid, selectedField) {
+                            selectedField?.let { (row, column) ->
+                                activeBoard?.grid?.availableFieldSpansAt(row, column).orEmpty()
+                            }.orEmpty()
+                        },
+                        onResizeField = if (mode == BoardWorkspaceMode.Edit) {
+                            { anchorRow, anchorColumn, rowSpan, columnSpan ->
+                                val session = editSession ?: return@ObfBoardView
+                                val boardId = activeBoard.id
+                                val resized = resizeDraftField(
+                                    graph = session.draft,
+                                    boardId = boardId,
+                                    row = anchorRow,
+                                    column = anchorColumn,
+                                    rowSpan = rowSpan,
+                                    columnSpan = columnSpan
+                                )
+                                if (resized != session.draft) {
+                                    editSession = session.apply(resized)
                                 }
                             }
                         } else null,
@@ -1095,12 +1163,6 @@ private fun BoardSetWorkspaceScreen(
 
     val target = editingCell
     if (target != null && activeBoard != null) {
-        val currentSpan = activeBoard.grid?.fieldSpanAt(target.row, target.column)
-            ?: GridFieldSpan(rows = 1, columns = 1)
-        val availableSpans = activeBoard.grid
-            ?.availableFieldSpansAt(target.row, target.column)
-            .orEmpty()
-            .map { FieldSpanOption(rows = it.rows, columns = it.columns) }
         val initialImageUrl = target.button?.imageId
             ?.let { id -> activeBoard.images.firstOrNull { it.id == id }?.url }
             .orEmpty()
@@ -1122,13 +1184,10 @@ private fun BoardSetWorkspaceScreen(
             initialLinkedBoardId = activeGraph.resolveLinkedBoard(target.button?.loadBoard)?.id,
             initialAction = target.button?.action,
             initialActions = target.button?.actions.orEmpty(),
-            availableSpans = availableSpans,
-            initialRowSpan = currentSpan.rows,
-            initialColumnSpan = currentSpan.columns,
             hasExistingValue = target.button != null,
             onDismiss = { editingCell = null },
             onSave = { label, vocalization, imageUrl, recordingPath, backgroundColor, language, mathMode, linkedBoardId,
-                       rowSpan, columnSpan, action, actions ->
+                       action, actions ->
                 val session = editSession ?: return@EditBoardCellDialog
                 editSession = session.apply(
                     updateDraftCell(
@@ -1144,8 +1203,6 @@ private fun BoardSetWorkspaceScreen(
                         language = language,
                         mathMode = mathMode,
                         linkedBoardId = linkedBoardId,
-                        rowSpan = rowSpan,
-                        columnSpan = columnSpan,
                         action = action,
                         actions = actions
                     )
@@ -1175,6 +1232,7 @@ private fun BoardSetWorkspaceScreen(
                         useCase.saveBoardSetGraph(session.draft)
                             .onSuccess { saved ->
                                 savedGraph = saved
+                                selectedField = null
                                 editSession = null
                                 mode = BoardWorkspaceMode.Run
                                 statusMessage = savedMessage
@@ -1189,6 +1247,7 @@ private fun BoardSetWorkspaceScreen(
                 Row {
                     TextButton(onClick = {
                         showFinishDialog = false
+                        selectedField = null
                         editSession = null
                         mode = BoardWorkspaceMode.Run
                         selectedBoardId = savedGraph?.boardSet?.rootBoardId
@@ -1388,8 +1447,6 @@ internal fun updateDraftCell(
     language: String?,
     mathMode: Boolean = false,
     linkedBoardId: String?,
-    rowSpan: Int = 1,
-    columnSpan: Int = 1,
     action: String? = null,
     actions: List<String> = emptyList()
 ): BoardSetGraph {
@@ -1450,8 +1507,14 @@ internal fun updateDraftCell(
     val buttons = if (existingButton == null) board.buttons + button else board.buttons.map {
         if (it.id == button.id) button else it
     }
-    val updatedGrid = grid.withFieldSpan(row, column, buttonId, rowSpan, columnSpan)
-        ?: return graph
+    val existingSpan = grid.fieldSpanAt(row, column)
+    val updatedGrid = grid.withFieldSpan(
+        row = row,
+        column = column,
+        buttonId = buttonId,
+        rowSpan = existingSpan.rows,
+        columnSpan = existingSpan.columns
+    ) ?: return graph
     val updatedBoard = board.copy(buttons = buttons, images = images, sounds = sounds, grid = updatedGrid)
     return graph.copy(boards = graph.boards.map { if (it.id == boardId) updatedBoard else it })
 }
@@ -1498,6 +1561,15 @@ internal fun ObfGrid.fieldSpanAt(row: Int, column: Int): GridFieldSpan {
         rows = maxRow - minRow + 1,
         columns = maxColumn - minColumn + 1
     )
+}
+
+internal fun ObfGrid.fieldAnchorAt(row: Int, column: Int): Pair<Int, Int>? {
+    val buttonId = order.getOrNull(row)?.getOrNull(column) ?: return null
+    return normalizedOrder().flatMapIndexed { rowIndex, values ->
+        values.mapIndexedNotNull { columnIndex, value ->
+            if (value == buttonId) rowIndex to columnIndex else null
+        }
+    }.minWithOrNull(compareBy({ it.first }, { it.second }))
 }
 
 internal fun ObfGrid.availableFieldSpansAt(row: Int, column: Int): List<GridFieldSpan> {
@@ -1749,6 +1821,26 @@ internal fun moveDraftField(
     return graph.copy(
         boards = graph.boards.map { current ->
             if (current.id == boardId) current.copy(grid = movedGrid) else current
+        }
+    )
+}
+
+internal fun resizeDraftField(
+    graph: BoardSetGraph,
+    boardId: String,
+    row: Int,
+    column: Int,
+    rowSpan: Int,
+    columnSpan: Int
+): BoardSetGraph {
+    val board = graph.boardsById[boardId] ?: return graph
+    val grid = board.grid ?: return graph
+    val buttonId = grid.order.getOrNull(row)?.getOrNull(column) ?: return graph
+    val resizedGrid = grid.withFieldSpan(row, column, buttonId, rowSpan, columnSpan) ?: return graph
+    if (resizedGrid == grid) return graph
+    return graph.copy(
+        boards = graph.boards.map { current ->
+            if (current.id == boardId) current.copy(grid = resizedGrid) else current
         }
     )
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -32,10 +32,35 @@ import io.github.jdreioe.wingmate.domain.obf.ResolvedBoardSettings
 import io.github.jdreioe.wingmate.domain.obf.resolveBoardSettings
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.border
+import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitTouchSlopOrCancellation
+import androidx.compose.foundation.gestures.drag
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.focusable
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isShiftPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.layout.positionInParent
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.withTimeoutOrNull
+import kotlin.math.roundToInt
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -80,8 +105,16 @@ import wingmatekmp.composeapp.generated.resources.board_workspace_delete_last
 import wingmatekmp.composeapp.generated.resources.board_workspace_speak_sentence
 import wingmatekmp.composeapp.generated.resources.board_workspace_home
 import wingmatekmp.composeapp.generated.resources.board_cell_opens_board
+import wingmatekmp.composeapp.generated.resources.board_resize_field_label
+import wingmatekmp.composeapp.generated.resources.board_resize_increase_width
+import wingmatekmp.composeapp.generated.resources.board_resize_decrease_width
+import wingmatekmp.composeapp.generated.resources.board_resize_increase_height
+import wingmatekmp.composeapp.generated.resources.board_resize_decrease_height
+import wingmatekmp.composeapp.generated.resources.board_resize_size
+import wingmatekmp.composeapp.generated.resources.board_resize_blocked_bounds
+import wingmatekmp.composeapp.generated.resources.board_resize_blocked_occupied
 
-private data class BoardGridItem(
+internal data class BoardGridItem(
     val row: Int,
     val column: Int,
     val rowSpan: Int,
@@ -114,6 +147,9 @@ fun ObfBoardView(
     boardSettings: ResolvedBoardSettings? = null,
     onCellClick: ((row: Int, column: Int, button: ObfButton?) -> Unit)? = null,
     onCellMove: ((fromRow: Int, fromColumn: Int, toRow: Int, toColumn: Int) -> Unit)? = null,
+    selectedFieldAnchor: Pair<Int, Int>? = null,
+    selectedFieldSpans: List<GridFieldSpan> = emptyList(),
+    onResizeField: ((anchorRow: Int, anchorColumn: Int, rowSpan: Int, columnSpan: Int) -> Unit)? = null,
     homeBoardId: String? = null
 ) {
     val settings by rememberReactiveSettings()
@@ -224,7 +260,10 @@ fun ObfBoardView(
                             columns = columns,
                             items = gridItems,
                             modifier = Modifier.fillMaxWidth().height(contentHeight),
-                            onMove = onCellMove
+                            onMove = onCellMove,
+                            selectedField = selectedFieldAnchor,
+                            selectedFieldSpans = selectedFieldSpans,
+                            onResizeField = onResizeField
                         ) { item ->
                             val button = item.button
                             val isVisible = button != null && (!button.hidden || isEditMode)
@@ -333,7 +372,7 @@ fun ObfBoardView(
     }
 }
 
-private fun buildBoardGridItems(
+internal fun buildBoardGridItems(
     grid: io.github.jdreioe.wingmate.domain.obf.ObfGrid,
     buttonsById: Map<String, ObfButton>
 ): List<BoardGridItem> {
@@ -392,48 +431,186 @@ private fun buildBoardGridItems(
 }
 
 @Composable
-private fun SpanningBoardGrid(
+internal fun SpanningBoardGrid(
     rows: Int,
     columns: Int,
     items: List<BoardGridItem>,
     modifier: Modifier = Modifier,
     onMove: ((fromRow: Int, fromColumn: Int, toRow: Int, toColumn: Int) -> Unit)? = null,
+    selectedField: Pair<Int, Int>? = null,
+    selectedFieldSpans: List<GridFieldSpan> = emptyList(),
+    onResizeField: ((anchorRow: Int, anchorColumn: Int, rowSpan: Int, columnSpan: Int) -> Unit)? = null,
     content: @Composable (BoardGridItem) -> Unit
 ) {
     var dragSource by remember(items) { mutableStateOf<Pair<Int, Int>?>(null) }
     var dragTarget by remember(items) { mutableStateOf<Pair<Int, Int>?>(null) }
+    var resizeCell by remember(items) { mutableStateOf<Pair<Int, Int>?>(null) }
+    var gridSizePx by remember { mutableStateOf(IntSize.Zero) }
+    var handleOffsetInGrid by remember { mutableStateOf(Offset.Zero) }
+    var resizeStatus by remember { mutableStateOf<String?>(null) }
+    val density = LocalDensity.current
+    val horizontalGap = with(density) { 4.dp.toPx() }
+    val verticalGap = with(density) { 8.dp.toPx() }
+
+    LaunchedEffect(resizeStatus) {
+        if (resizeStatus != null) {
+            delay(2000)
+            resizeStatus = null
+        }
+    }
+
+    val selectedItem = remember(items, selectedField) {
+        items.firstOrNull { item ->
+            selectedField != null &&
+                item.row == selectedField.first &&
+                item.column == selectedField.second &&
+                item.button != null
+        }
+    }
+    val allowedSpans = remember(selectedFieldSpans) { selectedFieldSpans.toSet() }
+    val previewSpan = remember(resizeCell, selectedItem) {
+        val item = selectedItem ?: return@remember null
+        val cell = resizeCell ?: return@remember null
+        GridFieldSpan(
+            rows = (cell.first - item.row + 1).coerceAtLeast(1),
+            columns = (cell.second - item.column + 1).coerceAtLeast(1)
+        )
+    }
+    val previewValid = previewSpan?.let { it in allowedSpans } ?: true
+    val showPreview = resizeCell != null && selectedItem != null
+    val showHandle = selectedItem != null && onResizeField != null
+
+    val selectionColor = MaterialTheme.colorScheme.primary
+    val errorColor = MaterialTheme.colorScheme.error
+    val resizeLabel = stringResource(Res.string.board_resize_field_label)
+    val increaseWidthLabel = stringResource(Res.string.board_resize_increase_width)
+    val decreaseWidthLabel = stringResource(Res.string.board_resize_decrease_width)
+    val increaseHeightLabel = stringResource(Res.string.board_resize_increase_height)
+    val decreaseHeightLabel = stringResource(Res.string.board_resize_decrease_height)
+    val sizeAnnouncementFormat = stringResource(Res.string.board_resize_size)
+    val blockedBoundsMessage = stringResource(Res.string.board_resize_blocked_bounds)
+    val blockedOccupiedMessage = stringResource(Res.string.board_resize_blocked_occupied)
+
+    fun cellAt(position: Offset): Pair<Int, Int>? {
+        if (position.x < 0f || position.y < 0f) return null
+        if (position.x >= gridSizePx.width || position.y >= gridSizePx.height) return null
+        val cellWidth = (gridSizePx.width - horizontalGap * (columns - 1)).coerceAtLeast(0f) / columns
+        val cellHeight = (gridSizePx.height - verticalGap * (rows - 1)).coerceAtLeast(0f) / rows
+        val column = (position.x / (cellWidth + horizontalGap)).toInt().coerceIn(0, columns - 1)
+        val row = (position.y / (cellHeight + verticalGap)).toInt().coerceIn(0, rows - 1)
+        return row to column
+    }
+
+    fun announceSize(width: Int, height: Int) {
+        resizeStatus = String.format(sizeAnnouncementFormat, width, height)
+    }
+
+    fun blockedReason(span: GridFieldSpan): String {
+        val item = selectedItem ?: return ""
+        val outOfBounds = span.rows < 1 || span.columns < 1 ||
+            item.row + span.rows > rows || item.column + span.columns > columns
+        return if (outOfBounds) blockedBoundsMessage else blockedOccupiedMessage
+    }
+
+    fun resizeBy(deltaRows: Int, deltaColumns: Int): Boolean {
+        val item = selectedItem ?: return false
+        val current = GridFieldSpan(item.rowSpan, item.columnSpan)
+        val target = GridFieldSpan(current.rows + deltaRows, current.columns + deltaColumns)
+        if (target in allowedSpans && target != current) {
+            onResizeField?.invoke(item.row, item.column, target.rows, target.columns)
+            announceSize(target.columns, target.rows)
+            return true
+        }
+        resizeStatus = blockedReason(target)
+        return false
+    }
+
+    val currentSelectedItem by rememberUpdatedState(selectedItem)
+    val currentAllowedSpans by rememberUpdatedState(allowedSpans)
+    val currentOnResizeField by rememberUpdatedState(onResizeField)
+    val currentCellAt: (Offset) -> Pair<Int, Int>? by rememberUpdatedState { position ->
+        cellAt(position + handleOffsetInGrid)
+    }
+
+    val handleModifier = Modifier
+        .size(48.dp)
+        .testTag("resize-handle")
+        .onGloballyPositioned { handleOffsetInGrid = it.positionInParent() }
+        .focusable()
+        .onKeyEvent { event ->
+            if (event.type == KeyEventType.KeyDown && event.isShiftPressed) {
+                when (event.key) {
+                    Key.DirectionRight -> resizeBy(0, 1)
+                    Key.DirectionLeft -> resizeBy(0, -1)
+                    Key.DirectionDown -> resizeBy(1, 0)
+                    Key.DirectionUp -> resizeBy(-1, 0)
+                    else -> false
+                }
+            } else {
+                false
+            }
+        }
+        .semantics {
+            contentDescription = resizeLabel
+            customActions = listOf(
+                CustomAccessibilityAction(increaseWidthLabel) { resizeBy(0, 1) },
+                CustomAccessibilityAction(decreaseWidthLabel) { resizeBy(0, -1) },
+                CustomAccessibilityAction(increaseHeightLabel) { resizeBy(1, 0) },
+                CustomAccessibilityAction(decreaseHeightLabel) { resizeBy(-1, 0) }
+            )
+        }
+        .pointerInput(items, allowedSpans) {
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                val start = awaitTouchSlopOrCancellation(down.id) { change, _ -> change.consume() }
+                    ?: return@awaitEachGesture
+                val startCell = currentCellAt(start.position)
+                resizeCell = startCell
+                var lastCell = startCell
+                drag(down.id) { change ->
+                    change.consume()
+                    currentCellAt(change.position)?.let { lastCell = it }
+                    resizeCell = lastCell
+                }
+                val item = currentSelectedItem
+                val finalCell = lastCell
+                val span = if (item != null && finalCell != null) {
+                    GridFieldSpan(
+                        rows = (finalCell.first - item.row + 1).coerceAtLeast(1),
+                        columns = (finalCell.second - item.column + 1).coerceAtLeast(1)
+                    )
+                } else {
+                    null
+                }
+                resizeCell = null
+                if (item != null && span != null) {
+                    val current = GridFieldSpan(item.rowSpan, item.columnSpan)
+                    if (span != current && span in currentAllowedSpans) {
+                        currentOnResizeField?.invoke(item.row, item.column, span.rows, span.columns)
+                        announceSize(span.columns, span.rows)
+                    }
+                }
+            }
+        }
+
     val dragModifier = if (onMove != null) {
         Modifier.pointerInput(rows, columns, items, onMove) {
-            val horizontalGap = 4.dp.toPx()
-            val verticalGap = 8.dp.toPx()
-
-            fun cellAt(position: Offset): Pair<Int, Int>? {
-                if (position.x < 0f || position.y < 0f || position.x >= size.width || position.y >= size.height) {
-                    return null
-                }
-                val cellWidth = (size.width - horizontalGap * (columns - 1)).coerceAtLeast(0f) / columns
-                val cellHeight = (size.height - verticalGap * (rows - 1)).coerceAtLeast(0f) / rows
-                val column = (position.x / (cellWidth + horizontalGap)).toInt().coerceIn(0, columns - 1)
-                val row = (position.y / (cellHeight + verticalGap)).toInt().coerceIn(0, rows - 1)
-                return row to column
-            }
-
-            fun fieldAt(cell: Pair<Int, Int>): BoardGridItem? = items.firstOrNull { item ->
-                cell.first in item.row until item.row + item.rowSpan &&
-                    cell.second in item.column until item.column + item.columnSpan
-            }
-
             detectDragGesturesAfterLongPress(
                 onDragStart = { position ->
                     val cell = cellAt(position)
-                    val field = cell?.let(::fieldAt)?.takeIf { it.button != null }
+                    val field = cell?.let { cellAt ->
+                        items.firstOrNull { item ->
+                            cellAt.first in item.row until item.row + item.rowSpan &&
+                                cellAt.second in item.column until item.column + item.columnSpan
+                        }
+                    }?.takeIf { it.button != null }
                     dragSource = field?.let { it.row to it.column }
                     dragTarget = dragSource
                 },
                 onDrag = { change, _ ->
                     if (dragSource != null) {
                         change.consume()
-                        dragTarget = cellAt(change.position)
+                        cellAt(change.position)?.let { dragTarget = it }
                     }
                 },
                 onDragEnd = {
@@ -454,50 +631,148 @@ private fun SpanningBoardGrid(
     } else {
         Modifier
     }
-    Layout(
-        modifier = modifier.then(dragModifier),
-        content = {
-            items.forEach { item ->
-                val isDropTarget = dragTarget?.let { target ->
-                    target.first in item.row until item.row + item.rowSpan &&
-                        target.second in item.column until item.column + item.columnSpan
-                } == true
-                Box(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .then(
-                            if (isDropTarget) {
-                                Modifier.border(3.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(12.dp))
-                            } else {
-                                Modifier
+    Box(modifier = modifier) {
+        Layout(
+            modifier = Modifier
+                .fillMaxSize()
+                .then(dragModifier)
+                .onSizeChanged { gridSizePx = it },
+            content = {
+                items.forEach { item ->
+                    key(item.row, item.column, item.button?.id) {
+                    val isDropTarget = dragTarget?.let { target ->
+                        target.first in item.row until item.row + item.rowSpan &&
+                            target.second in item.column until item.column + item.columnSpan
+                    } == true
+                    val isSelected = selectedItem?.let {
+                        it.row == item.row && it.column == item.column
+                    } == true
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .then(
+                                if (isSelected) {
+                                    Modifier.border(3.dp, selectionColor, RoundedCornerShape(12.dp))
+                                } else {
+                                    Modifier
+                                }
+                            )
+                            .then(
+                                if (isDropTarget) {
+                                    Modifier.border(3.dp, selectionColor, RoundedCornerShape(12.dp))
+                                } else {
+                                    Modifier
+                                }
+                            )
+                    ) {
+                        content(item)
+                    }
+                }
+            }
+            if (showPreview) {
+                key("resize-preview") {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("resize-preview")
+                            .semantics {
+                                contentDescription = if (previewValid) {
+                                    "resize-preview-valid"
+                                } else {
+                                    "resize-preview-invalid"
+                                }
                             }
+                            .border(
+                                3.dp,
+                                if (previewValid) selectionColor else errorColor,
+                                RoundedCornerShape(12.dp)
+                            )
+                            .background(
+                                if (previewValid) {
+                                    selectionColor.copy(alpha = 0.2f)
+                                } else {
+                                    errorColor.copy(alpha = 0.2f)
+                                }
+                            )
+                    )
+                }
+            }
+            if (showHandle) {
+                key("resize-handle") {
+                    Box(modifier = handleModifier, contentAlignment = Alignment.BottomEnd) {
+                        Box(
+                            modifier = Modifier
+                                .size(20.dp)
+                                .border(2.dp, selectionColor, RoundedCornerShape(4.dp))
+                                .background(MaterialTheme.colorScheme.surface)
                         )
-                ) {
-                    content(item)
+                    }
                 }
             }
         }
     ) { measurables, constraints ->
-        val horizontalGap = 4.dp.roundToPx()
-        val verticalGap = 8.dp.roundToPx()
-        val availableWidth = (constraints.maxWidth - horizontalGap * (columns - 1)).coerceAtLeast(0)
-        val availableHeight = (constraints.maxHeight - verticalGap * (rows - 1)).coerceAtLeast(0)
+        val horizontalGapPx = 4.dp.roundToPx()
+        val verticalGapPx = 8.dp.roundToPx()
+        val availableWidth = (constraints.maxWidth - horizontalGapPx * (columns - 1)).coerceAtLeast(0)
+        val availableHeight = (constraints.maxHeight - verticalGapPx * (rows - 1)).coerceAtLeast(0)
         val cellWidth = availableWidth / columns
         val cellHeight = availableHeight / rows
+        val handlePx = 48.dp.toPx()
+        val previewIndex = items.size
+        val handleIndex = items.size + if (showPreview) 1 else 0
+        val handleSpan = previewSpan ?: selectedItem?.let { GridFieldSpan(it.rowSpan, it.columnSpan) }
         val placeables = measurables.mapIndexed { index, measurable ->
-            val item = items[index]
-            val width = cellWidth * item.columnSpan + horizontalGap * (item.columnSpan - 1)
-            val height = cellHeight * item.rowSpan + verticalGap * (item.rowSpan - 1)
-            measurable.measure(Constraints.fixed(width.coerceAtLeast(0), height.coerceAtLeast(0)))
+            if (showHandle && index == handleIndex) {
+                measurable.measure(Constraints.fixed(handlePx.roundToInt(), handlePx.roundToInt()))
+            } else {
+                val span = if (showPreview && index == previewIndex) {
+                    previewSpan ?: GridFieldSpan(1, 1)
+                } else {
+                    val item = items[index]
+                    GridFieldSpan(item.rowSpan, item.columnSpan)
+                }
+                val width = cellWidth * span.columns + horizontalGapPx * (span.columns - 1)
+                val height = cellHeight * span.rows + verticalGapPx * (span.rows - 1)
+                measurable.measure(Constraints.fixed(width.coerceAtLeast(0), height.coerceAtLeast(0)))
+            }
         }
         layout(constraints.maxWidth, constraints.maxHeight) {
             placeables.forEachIndexed { index, placeable ->
-                val item = items[index]
-                placeable.placeRelative(
-                    x = item.column * (cellWidth + horizontalGap),
-                    y = item.row * (cellHeight + verticalGap)
-                )
+                if (showHandle && index == handleIndex) {
+                    val item = selectedItem
+                    val span = handleSpan ?: return@forEachIndexed
+                    val x = ((item.column + span.columns) * (cellWidth + horizontalGapPx) - handlePx / 2f)
+                        .coerceIn(0f, (constraints.maxWidth - handlePx).coerceAtLeast(0f))
+                    val y = ((item.row + span.rows) * (cellHeight + verticalGapPx) - handlePx / 2f)
+                        .coerceIn(0f, (constraints.maxHeight - handlePx).coerceAtLeast(0f))
+                    placeable.placeRelative(x.roundToInt(), y.roundToInt())
+                } else {
+                    val item = if (showPreview && index == previewIndex) {
+                        selectedItem.copy(
+                            rowSpan = previewSpan?.rows ?: 1,
+                            columnSpan = previewSpan?.columns ?: 1
+                        )
+                    } else {
+                        items[index]
+                    }
+                    placeable.placeRelative(
+                        x = item.column * (cellWidth + horizontalGapPx),
+                        y = item.row * (cellHeight + verticalGapPx)
+                    )
+                }
             }
+        }
+    }
+        resizeStatus?.let { status ->
+            Box(
+                modifier = Modifier
+                    .size(1.dp)
+                    .alpha(0f)
+                    .semantics {
+                        liveRegion = LiveRegionMode.Polite
+                        contentDescription = status
+                    }
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlin.math.roundToInt
+import kotlin.math.sqrt
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -121,6 +122,11 @@ internal data class BoardGridItem(
     val columnSpan: Int,
     val button: ObfButton?
 )
+
+internal fun fieldFontScale(rowSpan: Int, columnSpan: Int): Float {
+    val area = rowSpan.coerceAtLeast(1).toFloat() * columnSpan.coerceAtLeast(1)
+    return sqrt(sqrt(area)).coerceIn(1f, 2f)
+}
 
 enum class SymbolBarPresentation(val maxTextLines: Int, val maximumViewportFraction: Float) {
     Normal(maxTextLines = 4, maximumViewportFraction = 0.5f),
@@ -284,7 +290,8 @@ fun ObfBoardView(
                                         isHomeLink = button.isHomeNavigation(homeBoardId),
                                         boardStrings = board.strings,
                                         locale = settings.primaryLanguage,
-                                        boardSettings = effectiveBoardSettings
+                                        boardSettings = effectiveBoardSettings,
+                                        fieldFontScale = fieldFontScale(item.rowSpan, item.columnSpan)
                                     )
                                 } else if (isEditMode && button == null) {
                                     OutlinedCard(
@@ -562,14 +569,21 @@ internal fun SpanningBoardGrid(
         .pointerInput(items, allowedSpans) {
             awaitEachGesture {
                 val down = awaitFirstDown(requireUnconsumed = false)
+                val touchAnchorAdjustment = Offset(
+                    x = size.width / 2f - down.position.x,
+                    y = size.height / 2f - down.position.y
+                )
                 val start = awaitTouchSlopOrCancellation(down.id) { change, _ -> change.consume() }
                     ?: return@awaitEachGesture
-                val startCell = currentCellAt(start.position)
+                val startCell = currentCellAt(start.position + touchAnchorAdjustment)
                 resizeCell = startCell
                 var lastCell = startCell
+                var endedOutOfBounds = startCell == null
                 drag(down.id) { change ->
                     change.consume()
-                    currentCellAt(change.position)?.let { lastCell = it }
+                    val cell = currentCellAt(change.position + touchAnchorAdjustment)
+                    endedOutOfBounds = cell == null
+                    cell?.let { lastCell = it }
                     resizeCell = lastCell
                 }
                 val item = currentSelectedItem
@@ -583,11 +597,15 @@ internal fun SpanningBoardGrid(
                     null
                 }
                 resizeCell = null
-                if (item != null && span != null) {
+                if (item != null && endedOutOfBounds) {
+                    resizeStatus = blockedBoundsMessage
+                } else if (item != null && span != null) {
                     val current = GridFieldSpan(item.rowSpan, item.columnSpan)
                     if (span != current && span in currentAllowedSpans) {
                         currentOnResizeField?.invoke(item.row, item.column, span.rows, span.columns)
                         announceSize(span.columns, span.rows)
+                    } else if (span != current) {
+                        resizeStatus = blockedReason(span)
                     }
                 }
             }
@@ -699,7 +717,7 @@ internal fun SpanningBoardGrid(
             }
             if (showHandle) {
                 key("resize-handle") {
-                    Box(modifier = handleModifier, contentAlignment = Alignment.BottomEnd) {
+                    Box(modifier = handleModifier, contentAlignment = Alignment.Center) {
                         Box(
                             modifier = Modifier
                                 .size(20.dp)
@@ -741,9 +759,15 @@ internal fun SpanningBoardGrid(
                 if (showHandle && index == handleIndex) {
                     val item = selectedItem
                     val span = handleSpan ?: return@forEachIndexed
-                    val x = ((item.column + span.columns) * (cellWidth + horizontalGapPx) - handlePx / 2f)
+                    val x = (
+                        (item.column + span.columns) * (cellWidth + horizontalGapPx) -
+                            horizontalGapPx - handlePx / 2f
+                        )
                         .coerceIn(0f, (constraints.maxWidth - handlePx).coerceAtLeast(0f))
-                    val y = ((item.row + span.rows) * (cellHeight + verticalGapPx) - handlePx / 2f)
+                    val y = (
+                        (item.row + span.rows) * (cellHeight + verticalGapPx) -
+                            verticalGapPx - handlePx / 2f
+                        )
                         .coerceIn(0f, (constraints.maxHeight - handlePx).coerceAtLeast(0f))
                     placeable.placeRelative(x.roundToInt(), y.roundToInt())
                 } else {
@@ -925,7 +949,8 @@ fun ObfButtonItem(
     isHomeLink: Boolean = false,
     boardStrings: Map<String, Map<String, String>> = emptyMap(),
     locale: String? = null,
-    boardSettings: ResolvedBoardSettings? = null
+    boardSettings: ResolvedBoardSettings? = null,
+    fieldFontScale: Float = 1f
 ) {
     val speechService: SpeechService = koinInject()
     val voiceUseCase: VoiceUseCase = koinInject()
@@ -941,6 +966,17 @@ fun ObfButtonItem(
     )
     val displayLabel = resolveObfLocalizedString(boardStrings, locale, button.label)
     val displayVocalization = resolveObfLocalizedString(boardStrings, locale, button.vocalization)
+    val boundedFontScale = fieldFontScale.coerceIn(1f, 2f)
+    val scaledLabelMedium = MaterialTheme.typography.labelMedium.copy(
+        fontSize = MaterialTheme.typography.labelMedium.fontSize * boundedFontScale,
+        lineHeight = MaterialTheme.typography.labelMedium.lineHeight * boundedFontScale,
+        fontWeight = FontWeight.Bold
+    )
+    val scaledLabelSmall = MaterialTheme.typography.labelSmall.copy(
+        fontSize = MaterialTheme.typography.labelSmall.fontSize * boundedFontScale,
+        lineHeight = MaterialTheme.typography.labelSmall.lineHeight * boundedFontScale,
+        fontWeight = FontWeight.Bold
+    )
     
     // Page links navigate immediately; pulsing the outgoing button makes the
     // destination page appear to animate as the grid composition is reused.
@@ -1131,7 +1167,7 @@ fun ObfButtonItem(
                     val labelText = displayLabel ?: displayVocalization ?: ""
                     Text(
                         text = labelText,
-                        style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                        style = scaledLabelMedium,
                         textAlign = TextAlign.Center,
                         color = contentColor,
                         maxLines = 1,
@@ -1174,7 +1210,7 @@ fun ObfButtonItem(
                         val labelText = displayLabel ?: displayVocalization ?: ""
                         Text(
                             text = labelText,
-                            style = MaterialTheme.typography.labelSmall.copy(fontWeight = FontWeight.Bold),
+                            style = scaledLabelSmall,
                             textAlign = TextAlign.Center,
                             color = contentColor,
                             maxLines = if (showImg) 1 else 2,

--- a/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/BoardCellTapTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/BoardCellTapTest.kt
@@ -1,0 +1,66 @@
+package io.github.jdreioe.wingmate.ui
+
+import io.github.jdreioe.wingmate.domain.obf.ObfButton
+import io.github.jdreioe.wingmate.domain.obf.ObfGrid
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class BoardCellTapTest {
+    private val grid = ObfGrid(
+        rows = 3,
+        columns = 3,
+        order = listOf(
+            listOf("field", "field", null),
+            listOf("field", "field", null),
+            listOf(null, null, null)
+        )
+    )
+    private val button = ObfButton(id = "field", label = "Field")
+
+    @Test
+    fun firstTapOnAnOccupiedFieldSelectsIt() {
+        val result = resolveCellTap(grid, selectedField = null, row = 1, column = 1, button = button)
+
+        assertIs<CellTapResult.Select>(result)
+        assertEquals(0 to 0, result.anchor)
+    }
+
+    @Test
+    fun secondTapOnTheSelectedFieldOpensItsPropertiesDialog() {
+        val result = resolveCellTap(grid, selectedField = 0 to 0, row = 1, column = 1, button = button)
+
+        assertIs<CellTapResult.OpenDialog>(result)
+        assertEquals(1, result.row)
+        assertEquals(1, result.column)
+        assertEquals(button, result.button)
+    }
+
+    @Test
+    fun tappingAnotherFieldSelectsItInsteadOfOpeningTheDialog() {
+        val result = resolveCellTap(grid, selectedField = 0 to 0, row = 2, column = 2, button = null)
+
+        assertIs<CellTapResult.OpenDialog>(result)
+    }
+
+    @Test
+    fun tappingAnEmptyCellAlwaysOpensTheNewFieldDialog() {
+        val result = resolveCellTap(grid, selectedField = null, row = 2, column = 2, button = null)
+
+        assertIs<CellTapResult.OpenDialog>(result)
+    }
+
+    @Test
+    fun tappingAnEmptyCellClearsSelectionBeforeOpeningTheDialog() {
+        val result = resolveCellTap(grid, selectedField = 0 to 0, row = 2, column = 2, button = null)
+
+        assertIs<CellTapResult.OpenDialog>(result)
+    }
+
+    @Test
+    fun nullGridFallsBackToOpeningTheDialogForOccupiedCells() {
+        val result = resolveCellTap(grid = null, selectedField = null, row = 0, column = 0, button = button)
+
+        assertIs<CellTapResult.OpenDialog>(result)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/BoardEditorGraphTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/BoardEditorGraphTest.kt
@@ -146,6 +146,58 @@ class BoardEditorGraphTest {
         assertTrue(cleared.sounds.isEmpty())
     }
 
+    @Test
+    fun resizingAFieldKeepsItsRepeatedIdAndMakesOneUndoableEdit() {
+        val graph = graph(
+            order = listOf(
+                listOf("field", "field", null),
+                listOf("field", "field", null),
+                listOf(null, null, null)
+            )
+        )
+
+        val grown = resizeDraftField(graph, "home", 0, 0, rowSpan = 2, columnSpan = 3)
+
+        val grownGrid = grown.boards.single().grid
+        assertEquals(listOf("field", "field", "field"), grownGrid?.order?.first())
+        assertEquals(listOf("field", "field", "field"), grownGrid?.order?.get(1))
+        assertEquals(null, grownGrid?.order?.get(2)?.first())
+
+        val session = BoardSetEditSession(graph, graph).apply(grown)
+        assertEquals(1, session.undoStack.size)
+        assertEquals(graph, session.undo().draft)
+    }
+
+    @Test
+    fun resizingIsRejectedWhenItWouldCoverANeighborOrLeaveTheBoard() {
+        val graph = graph(
+            order = listOf(
+                listOf("field", null, null),
+                listOf(null, "neighbor", null)
+            )
+        )
+
+        assertEquals(graph, resizeDraftField(graph, "home", 0, 0, rowSpan = 2, columnSpan = 2))
+        assertEquals(graph, resizeDraftField(graph, "home", 0, 0, rowSpan = 2, columnSpan = 3))
+        assertEquals(graph, resizeDraftField(graph, "home", 0, 0, rowSpan = 0, columnSpan = 1))
+        assertEquals(graph, resizeDraftField(graph, "home", 1, 1, rowSpan = 1, columnSpan = 1))
+    }
+
+    @Test
+    fun resizingCanShrinkToSingleCell() {
+        val graph = graph(
+            order = listOf(
+                listOf("field", "field", null),
+                listOf("field", "field", null)
+            )
+        )
+
+        val shrunk = resizeDraftField(graph, "home", 0, 0, rowSpan = 1, columnSpan = 1)
+
+        assertEquals(listOf("field", null, null), shrunk.boards.single().grid?.order?.first())
+        assertEquals(listOf(null, null, null), shrunk.boards.single().grid?.order?.get(1))
+    }
+
     private fun graph(
         order: List<List<String?>> = listOf(
             listOf(null, null),
@@ -156,7 +208,11 @@ class BoardEditorGraphTest {
             format = "open-board-0.1",
             id = "home",
             name = "Home",
-            grid = ObfGrid(rows = 2, columns = 2, order = order)
+            grid = ObfGrid(
+                rows = order.size.coerceAtLeast(1),
+                columns = order.firstOrNull()?.size?.coerceAtLeast(1) ?: 1,
+                order = order
+            )
         )
         return BoardSetGraph(
             boardSet = ObfBoardSet(

--- a/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/BoardGridSpanTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/BoardGridSpanTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class BoardGridSpanTest {
     @Test
@@ -119,6 +120,118 @@ class BoardGridSpanTest {
         )
         assertNull(occupiedEdge.resized(newRows = 1, newColumns = 2))
         assertNull(occupiedEdge.resized(newRows = 2, newColumns = 1))
+    }
+
+    @Test
+    fun fieldCanGrowHorizontallyVerticallyAndDiagonally() {
+        val grid = emptyGrid(rows = 3, columns = 3).withFieldSpan(0, 0, "field", rowSpan = 1, columnSpan = 1)!!
+
+        val horizontal = assertNotNull(grid.withFieldSpan(0, 0, "field", rowSpan = 1, columnSpan = 3))
+        val vertical = assertNotNull(grid.withFieldSpan(0, 0, "field", rowSpan = 3, columnSpan = 1))
+        val diagonal = assertNotNull(grid.withFieldSpan(0, 0, "field", rowSpan = 2, columnSpan = 2))
+
+        assertEquals(listOf("field", "field", "field"), horizontal.order[0])
+        assertEquals(listOf("field", null, null), vertical.order[0])
+        assertEquals(listOf("field", "field", null), diagonal.order[0])
+        assertEquals(listOf("field", "field", null), diagonal.order[1])
+    }
+
+    @Test
+    fun fieldCanShrinkToSingleCellKeepingItsAnchor() {
+        val expanded = emptyGrid(rows = 3, columns = 3)
+            .withFieldSpan(1, 1, "field", rowSpan = 2, columnSpan = 2)!!
+
+        val shrunk = assertNotNull(expanded.withFieldSpan(1, 1, "field", rowSpan = 1, columnSpan = 1))
+
+        assertEquals("field", shrunk.order[1][1])
+        assertEquals(null, shrunk.order[2][1])
+        assertEquals(null, shrunk.order[1][2])
+        assertEquals(GridFieldSpan(rows = 1, columns = 1), shrunk.fieldSpanAt(1, 1))
+    }
+
+    @Test
+    fun shrinkingFreesCellsForNeighboringFields() {
+        val grid = emptyGrid(rows = 2, columns = 3)
+            .withFieldSpan(0, 0, "wide", rowSpan = 1, columnSpan = 2)!!
+
+        val shrunk = assertNotNull(grid.withFieldSpan(0, 0, "wide", rowSpan = 1, columnSpan = 1))
+        val placed = assertNotNull(shrunk.withFieldSpan(0, 1, "new", rowSpan = 1, columnSpan = 2))
+
+        assertEquals(listOf("wide", "new", "new"), placed.order[0])
+    }
+
+    @Test
+    fun resizingBeyondBoardBoundsIsRejected() {
+        val grid = emptyGrid(rows = 2, columns = 2).withFieldSpan(1, 1, "field", rowSpan = 1, columnSpan = 1)!!
+
+        assertNull(grid.withFieldSpan(1, 1, "field", rowSpan = 2, columnSpan = 1))
+        assertNull(grid.withFieldSpan(1, 1, "field", rowSpan = 1, columnSpan = 2))
+        assertNull(grid.withFieldSpan(0, 0, "field", rowSpan = 3, columnSpan = 1))
+    }
+
+    @Test
+    fun resizingCannotCrossIntoAnotherField() {
+        val grid = emptyGrid(rows = 3, columns = 3).copy(
+            order = listOf(
+                listOf("field", "field", "occupied"),
+                listOf("field", "field", null),
+                listOf(null, null, null)
+            )
+        )
+
+        assertNull(grid.withFieldSpan(0, 0, "field", rowSpan = 2, columnSpan = 3))
+        assertNull(grid.withFieldSpan(0, 0, "field", rowSpan = 3, columnSpan = 3))
+        assertNotNull(grid.withFieldSpan(0, 0, "field", rowSpan = 2, columnSpan = 2))
+    }
+
+    @Test
+    fun availableSpansIncludeCurrentSizeAndSingleCell() {
+        val grid = emptyGrid(rows = 3, columns = 3).copy(
+            order = listOf(
+                listOf("field", "field", "occupied"),
+                listOf("field", "field", null),
+                listOf(null, null, null)
+            )
+        )
+
+        val available = grid.availableFieldSpansAt(0, 0)
+
+        assertTrue(GridFieldSpan(rows = 2, columns = 2) in available)
+        assertTrue(GridFieldSpan(rows = 1, columns = 1) in available)
+        assertFalse(GridFieldSpan(rows = 3, columns = 3) in available)
+        assertFalse(GridFieldSpan(rows = 2, columns = 3) in available)
+    }
+
+    @Test
+    fun fieldAnchorIsTheTopLeftOfTheOccupiedCells() {
+        val grid = emptyGrid(rows = 3, columns = 4)
+            .withFieldSpan(1, 2, "field", rowSpan = 2, columnSpan = 2)!!
+
+        assertEquals(1 to 2, grid.fieldAnchorAt(1, 2))
+        assertEquals(1 to 2, grid.fieldAnchorAt(2, 3))
+        assertEquals(null, grid.fieldAnchorAt(0, 0))
+        assertEquals(null, grid.fieldAnchorAt(1, 1))
+    }
+
+    @Test
+    fun importedRepeatedIdFieldsReportAnchorAndSpan() {
+        val grid = emptyGrid(rows = 2, columns = 3).copy(
+            order = listOf(
+                listOf("same", "same", "same"),
+                listOf(null, "same", null)
+            )
+        )
+
+        assertEquals(0 to 0, grid.fieldAnchorAt(0, 0))
+        assertEquals(GridFieldSpan(rows = 2, columns = 3), grid.fieldSpanAt(0, 0))
+    }
+
+    @Test
+    fun fieldAnchorIgnoresEmptyCells() {
+        val grid = emptyGrid(rows = 2, columns = 2)
+
+        assertEquals(null, grid.fieldAnchorAt(0, 0))
+        assertEquals(null, grid.fieldAnchorAt(1, 1))
     }
 
     private fun emptyGrid(rows: Int, columns: Int) = ObfGrid(

--- a/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/BoardGridSpanTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/BoardGridSpanTest.kt
@@ -137,6 +137,14 @@ class BoardGridSpanTest {
     }
 
     @Test
+    fun fieldFontScaleGrowsWithSpanAreaAndRemainsBounded() {
+        assertEquals(1f, fieldFontScale(rowSpan = 1, columnSpan = 1))
+        assertTrue(fieldFontScale(rowSpan = 1, columnSpan = 2) > 1f)
+        assertTrue(fieldFontScale(rowSpan = 2, columnSpan = 2) > fieldFontScale(1, 2))
+        assertEquals(2f, fieldFontScale(rowSpan = 20, columnSpan = 20))
+    }
+
+    @Test
     fun fieldCanShrinkToSingleCellKeepingItsAnchor() {
         val expanded = emptyGrid(rows = 3, columns = 3)
             .withFieldSpan(1, 1, "field", rowSpan = 2, columnSpan = 2)!!

--- a/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/SpanningBoardGridTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/SpanningBoardGridTest.kt
@@ -1,0 +1,273 @@
+package io.github.jdreioe.wingmate.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performCustomAccessibilityActionWithLabel
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.test.requestFocus
+import androidx.compose.ui.test.runComposeUiTest
+import androidx.compose.ui.test.withKeyDown
+import androidx.compose.ui.unit.dp
+import io.github.jdreioe.wingmate.domain.obf.ObfButton
+import io.github.jdreioe.wingmate.domain.obf.ObfGrid
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.jetbrains.compose.resources.stringResource
+import wingmatekmp.composeapp.generated.resources.Res
+import wingmatekmp.composeapp.generated.resources.board_resize_blocked_bounds
+import wingmatekmp.composeapp.generated.resources.board_resize_blocked_occupied
+import wingmatekmp.composeapp.generated.resources.board_resize_decrease_height
+import wingmatekmp.composeapp.generated.resources.board_resize_decrease_width
+import wingmatekmp.composeapp.generated.resources.board_resize_increase_height
+import wingmatekmp.composeapp.generated.resources.board_resize_increase_width
+
+@OptIn(ExperimentalTestApi::class)
+class SpanningBoardGridTest {
+
+    private val fieldButton = ObfButton(id = "field", label = "Field")
+    private val otherButton = ObfButton(id = "other", label = "Other")
+
+    private fun emptyGrid(rows: Int, columns: Int) = ObfGrid(
+        rows = rows,
+        columns = columns,
+        order = List(rows) { List(columns) { null } }
+    )
+
+    private fun ComposeUiTest.hostGrid(
+        initialGrid: ObfGrid,
+        commits: MutableList<Triple<Int, Int, GridFieldSpan>>,
+        labels: MutableMap<String, String> = mutableMapOf()
+    ) {
+        val buttonsById = mapOf("field" to fieldButton, "other" to otherButton)
+        setContent {
+            var grid by remember { mutableStateOf(initialGrid) }
+            MaterialTheme {
+                labels += mapOf(
+                    "increaseWidth" to stringResource(Res.string.board_resize_increase_width),
+                    "decreaseWidth" to stringResource(Res.string.board_resize_decrease_width),
+                    "increaseHeight" to stringResource(Res.string.board_resize_increase_height),
+                    "decreaseHeight" to stringResource(Res.string.board_resize_decrease_height),
+                    "blockedBounds" to stringResource(Res.string.board_resize_blocked_bounds),
+                    "blockedOccupied" to stringResource(Res.string.board_resize_blocked_occupied)
+                )
+                Box(Modifier.size(400.dp)) {
+                    SpanningBoardGrid(
+                        rows = grid.rows,
+                        columns = grid.columns,
+                        items = buildBoardGridItems(grid, buttonsById),
+                        modifier = Modifier.fillMaxSize(),
+                        selectedField = 0 to 0,
+                        selectedFieldSpans = grid.availableFieldSpansAt(0, 0),
+                        onResizeField = { row, column, rowSpan, columnSpan ->
+                            commits += Triple(row, column, GridFieldSpan(rowSpan, columnSpan))
+                            grid = grid.withFieldSpan(row, column, "field", rowSpan, columnSpan) ?: grid
+                        }
+                    ) { Box(Modifier.fillMaxSize().background(Color.LightGray)) }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun resizeHandleAppearsAtTheFieldCornerAndIsAtLeast48Dp() = runComposeUiTest {
+        val grid = emptyGrid(2, 2).withFieldSpan(0, 0, "field", 1, 1)!!
+        hostGrid(grid, mutableListOf())
+
+        val handle = onNodeWithTag("resize-handle")
+        handle.assertExists()
+        val bounds = handle.fetchSemanticsNode().boundsInRoot
+        assertEquals(48f, bounds.width)
+        assertEquals(48f, bounds.height)
+        assertTrue(bounds.left in 176f..181f, "handle x was ${bounds.left}")
+        assertTrue(bounds.top in 178f..183f, "handle y was ${bounds.top}")
+    }
+
+    @Test
+    fun draggingTheHandleGrowsTheFieldAndCommitsOnRelease() = runComposeUiTest {
+        val commits = mutableListOf<Triple<Int, Int, GridFieldSpan>>()
+        val grid = emptyGrid(2, 2).withFieldSpan(0, 0, "field", 1, 1)!!
+        hostGrid(grid, commits)
+
+        onNodeWithTag("resize-handle").performTouchInput {
+            down(center)
+            moveBy(Offset(20f, 20f))
+            up()
+        }
+        runOnIdle {
+            assertEquals(listOf(Triple(0, 0, GridFieldSpan(2, 2))), commits)
+            onNodeWithTag("resize-preview").assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun draggingOverAnotherFieldShowsAnInvalidPreview() = runComposeUiTest {
+        val commits = mutableListOf<Triple<Int, Int, GridFieldSpan>>()
+        val grid = emptyGrid(2, 2)
+            .withFieldSpan(0, 0, "field", 1, 1)!!
+            .withFieldSpan(1, 1, "other", 1, 1)!!
+        hostGrid(grid, commits)
+
+        onNodeWithTag("resize-handle").performTouchInput {
+            down(center)
+            moveBy(Offset(20f, 20f))
+        }
+        runOnIdle {
+            val preview = onNodeWithTag("resize-preview")
+            preview.assertExists()
+            assertEquals(
+                listOf("resize-preview-invalid"),
+                preview.fetchSemanticsNode().config[SemanticsProperties.ContentDescription]
+            )
+            assertTrue(commits.isEmpty())
+        }
+    }
+
+    @Test
+    fun releasingAnInvalidDragDoesNotCommit() = runComposeUiTest {
+        val commits = mutableListOf<Triple<Int, Int, GridFieldSpan>>()
+        val grid = emptyGrid(2, 2)
+            .withFieldSpan(0, 0, "field", 1, 1)!!
+            .withFieldSpan(1, 1, "other", 1, 1)!!
+        hostGrid(grid, commits)
+
+        onNodeWithTag("resize-handle").performTouchInput {
+            down(center)
+            moveBy(Offset(20f, 20f))
+            up()
+        }
+        runOnIdle {
+            assertTrue(commits.isEmpty())
+            onNodeWithTag("resize-preview").assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun cancelingBeforeTheDragStartsShowsNoPreview() = runComposeUiTest {
+        val commits = mutableListOf<Triple<Int, Int, GridFieldSpan>>()
+        val grid = emptyGrid(2, 2).withFieldSpan(0, 0, "field", 1, 1)!!
+        hostGrid(grid, commits)
+
+        onNodeWithTag("resize-handle").performTouchInput {
+            down(center)
+            cancel()
+        }
+        runOnIdle {
+            assertTrue(commits.isEmpty())
+            onNodeWithTag("resize-preview").assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun cancelingTheDragDoesNotCommitAndLeavesTheHandleUsable() = runComposeUiTest {
+        val commits = mutableListOf<Triple<Int, Int, GridFieldSpan>>()
+        val grid = emptyGrid(2, 2).withFieldSpan(0, 0, "field", 1, 1)!!
+        hostGrid(grid, commits)
+
+        onNodeWithTag("resize-handle").performTouchInput {
+            down(center)
+            moveBy(Offset(20f, 20f))
+            cancel()
+        }
+        runOnIdle {
+            assertTrue(commits.isEmpty())
+        }
+        // A new gesture must still work normally after the cancellation, and the
+        // grid must end in a clean state without a lingering preview.
+        onNodeWithTag("resize-handle").performTouchInput {
+            down(center)
+            moveBy(Offset(20f, 20f))
+            up()
+        }
+        runOnIdle {
+            assertEquals(listOf(Triple(0, 0, GridFieldSpan(2, 2))), commits)
+            onNodeWithTag("resize-preview").assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun shiftArrowKeysResizeTheSelectedField() = runComposeUiTest {
+        val commits = mutableListOf<Triple<Int, Int, GridFieldSpan>>()
+        val grid = emptyGrid(2, 2).withFieldSpan(0, 0, "field", 1, 1)!!
+        hostGrid(grid, commits)
+
+        val handle = onNodeWithTag("resize-handle")
+        handle.requestFocus()
+        handle.performKeyInput {
+            withKeyDown(Key.ShiftLeft) { pressKey(Key.DirectionRight) }
+        }
+        runOnIdle {
+            assertEquals(listOf(Triple(0, 0, GridFieldSpan(1, 2))), commits)
+        }
+    }
+
+    @Test
+    fun invalidKeyboardResizeAnnouncesTheBlockingReason() = runComposeUiTest {
+        val commits = mutableListOf<Triple<Int, Int, GridFieldSpan>>()
+        val labels = mutableMapOf<String, String>()
+        val grid = emptyGrid(2, 2)
+            .withFieldSpan(0, 0, "field", 1, 1)!!
+            .withFieldSpan(1, 1, "other", 1, 1)!!
+        hostGrid(grid, commits, labels)
+
+        val handle = onNodeWithTag("resize-handle")
+        handle.requestFocus()
+        handle.performKeyInput {
+            withKeyDown(Key.ShiftLeft) { pressKey(Key.DirectionLeft) }
+        }
+        runOnIdle {
+            assertTrue(commits.isEmpty())
+            onNodeWithContentDescription(labels["blockedBounds"]!!).assertExists()
+        }
+    }
+
+    @Test
+    fun customAccessibilityActionsResizeInBothDirections() = runComposeUiTest {
+        val commits = mutableListOf<Triple<Int, Int, GridFieldSpan>>()
+        val labels = mutableMapOf<String, String>()
+        val grid = emptyGrid(2, 2).withFieldSpan(0, 0, "field", 1, 1)!!
+        hostGrid(grid, commits, labels)
+
+        val handle = onNodeWithTag("resize-handle")
+        handle.performCustomAccessibilityActionWithLabel(labels["increaseWidth"]!!)
+        handle.performCustomAccessibilityActionWithLabel(labels["increaseHeight"]!!)
+        handle.performCustomAccessibilityActionWithLabel(labels["decreaseHeight"]!!)
+        handle.performCustomAccessibilityActionWithLabel(labels["decreaseWidth"]!!)
+        runOnIdle {
+            assertEquals(
+                listOf(
+                    Triple(0, 0, GridFieldSpan(1, 2)),
+                    Triple(0, 0, GridFieldSpan(2, 2)),
+                    Triple(0, 0, GridFieldSpan(1, 2)),
+                    Triple(0, 0, GridFieldSpan(1, 1))
+                ),
+                commits
+            )
+        }
+
+        handle.performCustomAccessibilityActionWithLabel(labels["decreaseWidth"]!!)
+        runOnIdle {
+            assertEquals(4, commits.size)
+            onNodeWithContentDescription(labels["blockedBounds"]!!).assertExists()
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/SpanningBoardGridTest.kt
+++ b/composeApp/src/commonTest/kotlin/io/github/jdreioe/wingmate/ui/SpanningBoardGridTest.kt
@@ -98,8 +98,24 @@ class SpanningBoardGridTest {
         val bounds = handle.fetchSemanticsNode().boundsInRoot
         assertEquals(48f, bounds.width)
         assertEquals(48f, bounds.height)
-        assertTrue(bounds.left in 176f..181f, "handle x was ${bounds.left}")
-        assertTrue(bounds.top in 178f..183f, "handle y was ${bounds.top}")
+        assertTrue(bounds.left in 172f..177f, "handle x was ${bounds.left}")
+        assertTrue(bounds.top in 170f..175f, "handle y was ${bounds.top}")
+    }
+
+    @Test
+    fun draggingTheHandleHorizontallyOnlyGrowsTheWidth() = runComposeUiTest {
+        val commits = mutableListOf<Triple<Int, Int, GridFieldSpan>>()
+        val grid = emptyGrid(2, 2).withFieldSpan(0, 0, "field", 1, 1)!!
+        hostGrid(grid, commits)
+
+        onNodeWithTag("resize-handle").performTouchInput {
+            down(center)
+            moveBy(Offset(20f, 0f))
+            up()
+        }
+        runOnIdle {
+            assertEquals(listOf(Triple(0, 0, GridFieldSpan(1, 2))), commits)
+        }
     }
 
     @Test
@@ -145,10 +161,11 @@ class SpanningBoardGridTest {
     @Test
     fun releasingAnInvalidDragDoesNotCommit() = runComposeUiTest {
         val commits = mutableListOf<Triple<Int, Int, GridFieldSpan>>()
+        val labels = mutableMapOf<String, String>()
         val grid = emptyGrid(2, 2)
             .withFieldSpan(0, 0, "field", 1, 1)!!
             .withFieldSpan(1, 1, "other", 1, 1)!!
-        hostGrid(grid, commits)
+        hostGrid(grid, commits, labels)
 
         onNodeWithTag("resize-handle").performTouchInput {
             down(center)
@@ -158,6 +175,25 @@ class SpanningBoardGridTest {
         runOnIdle {
             assertTrue(commits.isEmpty())
             onNodeWithTag("resize-preview").assertDoesNotExist()
+            onNodeWithContentDescription(labels["blockedOccupied"]!!).assertExists()
+        }
+    }
+
+    @Test
+    fun releasingAnOutOfBoundsDragAnnouncesTheBlockingReason() = runComposeUiTest {
+        val commits = mutableListOf<Triple<Int, Int, GridFieldSpan>>()
+        val labels = mutableMapOf<String, String>()
+        val grid = emptyGrid(2, 2).withFieldSpan(0, 0, "field", 2, 2)!!
+        hostGrid(grid, commits, labels)
+
+        onNodeWithTag("resize-handle").performTouchInput {
+            down(center)
+            moveBy(Offset(100f, 100f))
+            up()
+        }
+        runOnIdle {
+            assertTrue(commits.isEmpty())
+            onNodeWithContentDescription(labels["blockedBounds"]!!).assertExists()
         }
     }
 


### PR DESCRIPTION
Replaces the Field size dropdown in the board editor with direct in-grid resizing (issue #52).

- Tap a field to select it (outline + 48 dp resize handle at its corner); tap again to open its properties dialog
- Drag the handle to resize with a live, snapped grid-cell preview; invalid targets are shown in red and rejected on release
- Shift+Arrow keys resize the selected field, with the blocking reason announced via a polite live region
- Decrease/increase width/height exposed as custom accessibility actions
- Commits flow through the existing session updateDraftCell, so undo still works
- Removed the old Field size dropdown and its strings (EN + DA)

Tests: 50 desktop tests pass (41 unit + 9 Compose UI incl. drag, keyboard, and accessibility scenarios).