### PR TITLE
#118 Selection debounce: gate side effects and cross-platform settings

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -156,7 +156,7 @@ The following list is taken from the OpenAAC [AAC App Development](https://www.o
         - [ ] 💡 **eyebrows**
 - [x] ✅ **adaptations**
   As users select buttons, there can be different accommodations based on the needs of the individual user that can make selection and access more meaningful. Below are some selection adaptations that people use or have requested.
-    - [ ] ✅ **debounce (prevent multiple hits)**
+    - [x] ✅ **debounce (prevent multiple hits)**
       Some people accidentally hit buttons multiple times in a row, often in quick succession. Having a debounce option can prevent unintentional repeats. This should be an optional setting though, as some people hit buttons quickly enough that a debounce feature may get in their way.
     - [ ] ✅ **option to speak each word on select**
       Some people use button selection as their main communication approach with AAC. They speak each word as it is selected, and may use the sentence box for additional emphasis. Especially with beginning AAC users, this option provides more immediate feedback and can help the person as well as those supporting them.

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -82,7 +82,6 @@ import io.github.jdreioe.wingmate.application.FeatureUsageEvents
 import io.github.jdreioe.wingmate.application.reportEvent
 import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.application.EditingAccessController
-import io.github.jdreioe.wingmate.application.SelectionDebouncer
 import io.github.jdreioe.wingmate.application.SelectionHighlight
 import io.github.jdreioe.wingmate.domain.Base64Decoder
 import io.github.jdreioe.wingmate.domain.FileStorage
@@ -601,8 +600,7 @@ private fun BoardSetWorkspaceScreen(
     var selectedButtons by remember(boardSetId) {
         mutableStateOf<List<Pair<ObfButton, ImageBitmap?>>>(emptyList())
     }
-    // #118/#120: per-target activation debounce and time-bounded selection highlight.
-    val selectionDebouncer = remember(boardSetId) { SelectionDebouncer() }
+    // #120: time-bounded selection highlight.
     val selectionHighlight = remember(boardSetId) { SelectionHighlight() }
     var highlightedButtonId by remember(boardSetId) { mutableStateOf<String?>(null) }
     var highlightGeneration by remember(boardSetId) { mutableLongStateOf(0L) }
@@ -1298,15 +1296,8 @@ private fun BoardSetWorkspaceScreen(
                         predictionLabels = predictionsById,
                         onButtonClick = { button ->
                             run {
-                                // #118: ignore repeated activations of the same target inside the window.
-                                if (!selectionDebouncer.tryActivate(
-                                        button.id,
-                                        Clock.System.now().toEpochMilliseconds(),
-                                        settings.selectionDebounceMillis
-                                    )
-                                ) {
-                                    return@run
-                                }
+                                // #118: debounce gating now lives in ObfButtonItem, which only
+                                // dispatches accepted activations.
                                 markButtonSelected(button.id)
                                 val actions = parseObfButtonActions(button)
                             if (actions.isNotEmpty()) {

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -33,6 +33,8 @@ import io.github.jdreioe.wingmate.domain.obf.parseObfButtonActions
 import io.github.jdreioe.wingmate.domain.obf.resolveObfLocalizedString
 import io.github.jdreioe.wingmate.domain.obf.ResolvedBoardSettings
 import io.github.jdreioe.wingmate.domain.obf.resolveBoardSettings
+import io.github.jdreioe.wingmate.application.SelectionDebouncer
+import kotlin.time.Clock
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.border
 import androidx.compose.foundation.background
@@ -1092,6 +1094,17 @@ fun ObfButtonItem(
     val voiceUseCase: VoiceUseCase = koinInject()
     val aacLogger: AacLogger = koinInject()
     val settings by rememberReactiveSettings()
+    // #118: per-target activation debounce. Each button instance maps to a single target,
+    // so a per-item guard enforces the per-target rules without shared state.
+    val selectionDebouncer = remember(button.id) { SelectionDebouncer() }
+    // #118: return true when this button's activation should proceed. Edit-mode taps are
+    // deliberate field/dialog operations and must never be debounced.
+    fun tryActivate(): Boolean =
+        !isEditMode && selectionDebouncer.tryActivate(
+            button.id,
+            Clock.System.now().toEpochMilliseconds(),
+            settings.selectionDebounceMillis
+        )
     val effectiveBoardSettings = boardSettings ?: resolveBoardSettings(
         appShowLabels = settings.showLabels,
         appShowSymbols = settings.showSymbols,
@@ -1163,9 +1176,12 @@ fun ObfButtonItem(
                 dwellProgress = (elapsed.toFloat() / duration).coerceIn(0f, 1f)
                 
                 if (elapsed >= duration) {
-                    if (animateSelection) isSelected = true
-                    onClick()
-                    aacLogger.logButtonClick(displayLabel ?: "", phraseId = button.id)
+                    // #118: only pulse, log, and dispatch when the activation is accepted.
+                    if (tryActivate()) {
+                        if (animateSelection) isSelected = true
+                        aacLogger.logButtonClick(displayLabel ?: "", phraseId = button.id)
+                        onClick()
+                    }
                     dwellProgress = 0f
                     break
                 }
@@ -1265,10 +1281,13 @@ fun ObfButtonItem(
                 }
             }
             .let { baseModifier ->
-                val primaryAction = { 
-                    if (animateSelection) isSelected = true
-                    onClick()
-                    aacLogger.logButtonClick(displayLabel ?: "", phraseId = button.id)
+                val primaryAction = {
+                    // #118: only pulse, log, and dispatch when the activation is accepted.
+                    if (tryActivate()) {
+                        if (animateSelection) isSelected = true
+                        aacLogger.logButtonClick(displayLabel ?: "", phraseId = button.id)
+                        onClick()
+                    }
                 }
                 
                 if (settings.holdToSelectMillis > 0 && !isEditMode) {

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/PhraseGrid.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/PhraseGrid.kt
@@ -166,13 +166,19 @@ fun PhraseGrid(
                     PhraseGridItem(
                         item = item,
                         onPlay = {
-                            if (tryActivate(item.id)) onPlay(item)
+                            if (tryActivate(item.id)) {
+                                onPlay(item)
+                                true
+                            } else false
                         },
                         onSpeakSecondary = { onPlaySecondary?.invoke(item) },
                         onLongPress = { onLongPress(item); onToggleWiggleMode?.invoke() },
                         isEditMode = isWiggleMode,
                         onTap = {
-                            if (tryActivate(item.id)) onInsert?.invoke(item)
+                            if (tryActivate(item.id)) {
+                                onInsert?.invoke(item)
+                                true
+                            } else false
                         },
                         onMove = { oldIndex, newIndex -> onMove?.invoke(oldIndex, newIndex) },
                         onDelete = { onDeletePhrase?.invoke(item) },

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/PhraseGridItem.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/PhraseGridItem.kt
@@ -70,10 +70,12 @@ import wingmatekmp.composeapp.generated.resources.phrase_item_speak_secondary
 @Composable
 fun PhraseGridItem(
     item: Phrase,
-    onPlay: () -> Unit,
+    // #118: return true when the activation was accepted (not debounced), so the item only
+    // pulses and logs after a successful selection.
+    onPlay: () -> Boolean,
     onLongPress: () -> Unit,
     onSpeakSecondary: (() -> Unit)? = null,
-    onTap: (() -> Unit)? = null,
+    onTap: (() -> Boolean)? = null,
     isEditMode: Boolean = false,
     onDelete: (() -> Unit)? = null,
     onMove: ((oldIndex: Int, newIndex: Int) -> Unit)? = null,
@@ -164,9 +166,11 @@ fun PhraseGridItem(
                 dwellProgress = (elapsed.toFloat() / duration).coerceIn(0f, 1f)
                 
                 if (elapsed >= duration) {
-                    isSelected = true
-                    onPlay()
-                    aacLogger.logButtonClick(item.text, phraseId = item.id)
+                    // #118: only pulse and log when the activation is accepted.
+                    if (runCatching { onPlay() }.getOrDefault(false)) {
+                        isSelected = true
+                        aacLogger.logButtonClick(item.text, phraseId = item.id)
+                    }
                     dwellProgress = 0f
                     break
                 }
@@ -200,9 +204,11 @@ fun PhraseGridItem(
             .let { baseModifier ->
                 val primaryAction = {
                     showMenu = false
-                    isSelected = true
-                    aacLogger.logButtonClick(item.text, phraseId = item.id)
-                    try { onTap?.invoke() ?: onPlay() } catch (_: Throwable) {}
+                    // #118: pulse and log only after the activation is accepted.
+                    if (runCatching { onTap?.invoke() ?: onPlay() }.getOrDefault(false)) {
+                        isSelected = true
+                        aacLogger.logButtonClick(item.text, phraseId = item.id)
+                    }
                 }
                 
                 if (settings.holdToSelectMillis > 0 && !isEditMode) {

--- a/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/UiSettingsDialog.kt
+++ b/composeApp/src/commonMain/kotlin/io/github/jdreioe/wingmate/ui/UiSettingsDialog.kt
@@ -40,6 +40,10 @@ import wingmatekmp.composeapp.generated.resources.ui_settings_grid_columns_title
 import wingmatekmp.composeapp.generated.resources.ui_settings_high_contrast_title
 import wingmatekmp.composeapp.generated.resources.ui_settings_dwell_to_select_title
 import wingmatekmp.composeapp.generated.resources.ui_settings_dwell_to_select_desc
+import wingmatekmp.composeapp.generated.resources.ui_settings_selection_debounce_title
+import wingmatekmp.composeapp.generated.resources.ui_settings_selection_debounce_desc
+import wingmatekmp.composeapp.generated.resources.ui_settings_selection_highlight_title
+import wingmatekmp.composeapp.generated.resources.ui_settings_selection_highlight_desc
 import wingmatekmp.composeapp.generated.resources.ui_settings_selection_sound_title
 import wingmatekmp.composeapp.generated.resources.ui_settings_auditory_fishing_title
 import wingmatekmp.composeapp.generated.resources.ui_settings_auditory_fishing_desc
@@ -80,6 +84,8 @@ fun UiSettingsDialog(onDismissRequest: () -> Unit) {
     var gridColumns by remember { mutableStateOf(3) }
     var highContrastMode by remember { mutableStateOf(false) }
     var dwellToSelectMillis by remember { mutableStateOf(0L) }
+    var selectionDebounceMillis by remember { mutableStateOf(0L) }
+    var selectionHighlightMillis by remember { mutableStateOf(0L) }
     var selectionSoundEnabled by remember { mutableStateOf(false) }
     var auditoryFishingEnabled by remember { mutableStateOf(false) }
     var usageLoggingEnabled by remember { mutableStateOf(false) }
@@ -110,6 +116,8 @@ fun UiSettingsDialog(onDismissRequest: () -> Unit) {
         highContrastMode = s.highContrastMode
         featureUsageReporter.setEnabled(s.featureUsageReportingEnabled)
         dwellToSelectMillis = s.dwellToSelectMillis
+        selectionDebounceMillis = s.selectionDebounceMillis
+        selectionHighlightMillis = s.selectionHighlightMillis
         selectionSoundEnabled = s.selectionSoundEnabled
         auditoryFishingEnabled = s.auditoryFishingEnabled
         usageLoggingEnabled = s.usageLoggingEnabled
@@ -335,6 +343,50 @@ fun UiSettingsDialog(onDismissRequest: () -> Unit) {
                     steps = 19 // 250ms steps
                 )
                 
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Selection Debounce (#118)
+                Text(
+                    "${stringResource(Res.string.ui_settings_selection_debounce_title)}: ${selectionDebounceMillis.toInt()} ms",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    stringResource(Res.string.ui_settings_selection_debounce_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Slider(
+                    value = selectionDebounceMillis.toFloat(),
+                    onValueChange = { selectionDebounceMillis = it.toLong() },
+                    onValueChangeFinished = {
+                        updateSettings { it.copy(selectionDebounceMillis = selectionDebounceMillis) }
+                    },
+                    valueRange = 0f..1000f,
+                    steps = 19
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Selection Highlight (#120)
+                Text(
+                    "${stringResource(Res.string.ui_settings_selection_highlight_title)}: ${selectionHighlightMillis.toInt()} ms",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    stringResource(Res.string.ui_settings_selection_highlight_desc),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Slider(
+                    value = selectionHighlightMillis.toFloat(),
+                    onValueChange = { selectionHighlightMillis = it.toLong() },
+                    onValueChangeFinished = {
+                        updateSettings { it.copy(selectionHighlightMillis = selectionHighlightMillis) }
+                    },
+                    valueRange = 0f..2000f,
+                    steps = 19
+                )
+
                 Spacer(modifier = Modifier.height(16.dp))
 
                 // Selection Sound

--- a/iosApp/iosApp/Base.lproj/Localizable.strings
+++ b/iosApp/iosApp/Base.lproj/Localizable.strings
@@ -210,6 +210,7 @@
 "settings.accessibility.touch_timing" = "Touch & Timing";
 "settings.accessibility.hold" = "Hold to Select";
 "settings.accessibility.dwell" = "Dwell to Select";
+"settings.accessibility.debounce" = "Selection Debounce";
 "settings.accessibility.feedback" = "Feedback & Logging";
 "settings.accessibility.selection_sound" = "Selection Sound";
 "settings.accessibility.auditory_fishing" = "Auditory Fishing";

--- a/iosApp/iosApp/ViewModels/IosViewModel.swift
+++ b/iosApp/iosApp/ViewModels/IosViewModel.swift
@@ -127,6 +127,7 @@ final class IosViewModel: ObservableObject {
     @Published var highContrastMode: Bool = false
     @Published var holdToSelectMillis: Double = 0
     @Published var dwellToSelectMillis: Double = 0
+    @Published var selectionDebounceMillis: Double = 0
     @Published var selectionSoundEnabled: Bool = false
     @Published var auditoryFishingEnabled: Bool = false
     @Published var usageLoggingEnabled: Bool = false
@@ -406,6 +407,7 @@ final class IosViewModel: ObservableObject {
                 self.highContrastMode = settings.highContrastMode
                 self.holdToSelectMillis = Double(settings.holdToSelectMillis)
                 self.dwellToSelectMillis = Double(settings.dwellToSelectMillis)
+                self.selectionDebounceMillis = Double(settings.selectionDebounceMillis)
                 self.selectionSoundEnabled = settings.selectionSoundEnabled
                 self.auditoryFishingEnabled = settings.auditoryFishingEnabled
                 self.usageLoggingEnabled = settings.usageLoggingEnabled
@@ -449,6 +451,8 @@ final class IosViewModel: ObservableObject {
     }
 
     func insertPhraseText(_ phrase: Shared.Phrase) {
+        // #118: ignore rapid repeated activations of the same target.
+        guard acceptActivation(targetId: phrase.id) else { return }
         let t = phrase.text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !t.isEmpty else { return }
         let nsInput = input as NSString
@@ -841,6 +845,11 @@ final class IosViewModel: ObservableObject {
     func setDwellToSelectMillis(_ value: Double) {
         dwellToSelectMillis = min(max(value, 0), 5_000)
         Task { _ = try? await bridge.updateDwellToSelectMillis(millis: Int64(dwellToSelectMillis)) }
+    }
+
+    func setSelectionDebounceMillis(_ value: Double) {
+        selectionDebounceMillis = min(max(value, 0), 1_000)
+        Task { _ = try? await bridge.updateSelectionDebounceMillis(millis: Int64(selectionDebounceMillis)) }
     }
 
     func setSelectionSoundEnabled(_ enabled: Bool) {
@@ -1594,9 +1603,28 @@ final class IosViewModel: ObservableObject {
             return
         }
 
+        // #118: navigation is an explicit action; speech insertion is debounced per cell.
+        if !acceptActivation(targetId: cell.buttonId) { return }
+
         if let textToSpeak = normalizedOptionalText(cell.vocalization) ?? normalizedOptionalText(cell.label) {
             speak(textToSpeak)
         }
+    }
+
+    // #118: per-target activation debounce. A zero duration disables the guard entirely.
+    private var lastActivationAtMillis: [String: Int64] = [:]
+    private func acceptActivation(targetId: String) -> Bool {
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        let window = Int64(selectionDebounceMillis)
+        if window <= 0 {
+            lastActivationAtMillis[targetId] = nil
+            return true
+        }
+        if let last = lastActivationAtMillis[targetId], now - last < window {
+            return false
+        }
+        lastActivationAtMillis[targetId] = now
+        return true
     }
 
     func refreshBoardPredictions(context: String) async {

--- a/iosApp/iosApp/Views/SettingsView.swift
+++ b/iosApp/iosApp/Views/SettingsView.swift
@@ -334,6 +334,13 @@ private struct AccessibilitySettingsView: View {
                     step: 250,
                     suffix: " ms"
                 )
+                SettingsSliderRow(
+                    title: "settings.accessibility.debounce",
+                    value: Binding(get: { model.selectionDebounceMillis }, set: { model.setSelectionDebounceMillis($0) }),
+                    range: 0...1_000,
+                    step: 50,
+                    suffix: " ms"
+                )
             }
 
             Section("settings.accessibility.feedback") {

--- a/iosApp/iosApp/da.lproj/Localizable.strings
+++ b/iosApp/iosApp/da.lproj/Localizable.strings
@@ -401,6 +401,7 @@
 "settings.accessibility.touch_timing" = "Berøring og timing";
 "settings.accessibility.hold" = "Hold for at vælge";
 "settings.accessibility.dwell" = "Dvæl for at vælge";
+"settings.accessibility.debounce" = "Markeringsde-bounce";
 "settings.accessibility.feedback" = "Feedback og logning";
 "settings.accessibility.selection_sound" = "Lyd ved valg";
 "settings.accessibility.auditory_fishing" = "Auditiv søgning";

--- a/iosApp/iosApp/de.lproj/Localizable.strings
+++ b/iosApp/iosApp/de.lproj/Localizable.strings
@@ -398,6 +398,7 @@
 "settings.accessibility.touch_timing" = "Berührung & Timing";
 "settings.accessibility.hold" = "Zum Auswählen halten";
 "settings.accessibility.dwell" = "Verweilen zum Auswählen";
+"settings.accessibility.debounce" = "Auswahl-Debounce";
 "settings.accessibility.feedback" = "Feedback & Protokollierung";
 "settings.accessibility.selection_sound" = "Auswahlton";
 "settings.accessibility.auditory_fishing" = "Akustische Suche";

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -213,6 +213,8 @@ class KotlinBridge(private val port: Int = 8765) {
                 jsonObj["highContrastMode"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(highContrastMode = it) }
                 jsonObj["holdToSelectMillis"]?.jsonPrimitive?.longOrNull?.let { newSettings = newSettings.copy(holdToSelectMillis = it.coerceAtLeast(0)) }
                 jsonObj["dwellToSelectMillis"]?.jsonPrimitive?.longOrNull?.let { newSettings = newSettings.copy(dwellToSelectMillis = it.coerceAtLeast(0)) }
+                jsonObj["selectionDebounceMillis"]?.jsonPrimitive?.longOrNull?.let { newSettings = newSettings.copy(selectionDebounceMillis = it.coerceAtLeast(0)) }
+                jsonObj["selectionHighlightMillis"]?.jsonPrimitive?.longOrNull?.let { newSettings = newSettings.copy(selectionHighlightMillis = it.coerceAtLeast(0)) }
                 jsonObj["selectionSoundEnabled"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(selectionSoundEnabled = it) }
                 jsonObj["auditoryFishingEnabled"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(auditoryFishingEnabled = it) }
                 jsonObj["usageLoggingEnabled"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(usageLoggingEnabled = it) }

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
@@ -159,6 +159,8 @@ class KoinBridge : KoinComponent {
     suspend fun updateHighContrastMode(enabled: Boolean) = updateSettings { it.copy(highContrastMode = enabled) }
     suspend fun updateHoldToSelectMillis(millis: Long) = updateSettings { it.copy(holdToSelectMillis = millis.coerceIn(0, 2_000)) }
     suspend fun updateDwellToSelectMillis(millis: Long) = updateSettings { it.copy(dwellToSelectMillis = millis.coerceIn(0, 5_000)) }
+    suspend fun updateSelectionDebounceMillis(millis: Long) = updateSettings { it.copy(selectionDebounceMillis = millis.coerceIn(0, 1_000)) }
+    suspend fun updateSelectionHighlightMillis(millis: Long) = updateSettings { it.copy(selectionHighlightMillis = millis.coerceIn(0, 2_000)) }
     suspend fun updateSelectionSoundEnabled(enabled: Boolean) = updateSettings { it.copy(selectionSoundEnabled = enabled) }
     suspend fun updateAuditoryFishingEnabled(enabled: Boolean) = updateSettings { it.copy(auditoryFishingEnabled = enabled) }
     suspend fun updateUsageLoggingEnabled(enabled: Boolean) {


### PR DESCRIPTION
## Summary
Completes #118 (configurable selection debounce). The core debouncer, wiring, and long-press threshold fix were already on the branch; this PR closes the remaining gaps:

- **Gate side effects on accepted activations**: pulse animation and `aacLogger.logButtonClick` now fire only when a debounced activation is accepted, in both `PhraseGridItem` and `ObfButtonItem` (tap + dwell). Board buttons previously logged/pulsed on every tap even when the action was ignored.
- **Board buttons own the gate**: `ObfButtonItem` now enforces per-target debounce (edit-mode taps excluded); the redundant gate in `BoardSetWorkspaceScreen` was removed, and the PhraseScreen board path (previously uncovered) inherits debounce automatically.
- **Cross-platform settings**: debounce + highlight sliders in `UiSettingsDialog` (Compose), `KoinBridge`/Linux `KotlinBridge` update functions, and iOS mirroring (settings slider, da/de/Base strings) with a per-target gate on `insertPhraseText` and `activateSelectedBoardCell`.
- FEATURES.md marks debounce as done.

## Verification
- `:composeApp:compileKotlinDesktop` ✓
- `:composeApp:desktopTest` — 17 suites, 0 failures ✓ (incl. extended long-press threshold tests)
- `:core:domain:jvmTest` — SelectionDebouncer 9/9, SelectionHighlight 7/7 ✓
- `:shared` + `:linuxApp` compile ✓

Closes #118