### PR TITLE
Harden Linux bridge security and add shared OBF image/category support

### DIFF
--- a/linuxApp/build.gradle.kts
+++ b/linuxApp/build.gradle.kts
@@ -11,6 +11,8 @@ dependencies {
     implementation(project(":shared"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    implementation("com.github.hypfvieh:dbus-java-core:5.2.0")
+    implementation("com.github.hypfvieh:dbus-java-transport-native-unixsocket:5.2.0")
     implementation("com.arkivanov.mvikotlin:mvikotlin:3.3.0")
     implementation("com.arkivanov.mvikotlin:mvikotlin-main:3.3.0")
     

--- a/linuxApp/src/main.rs
+++ b/linuxApp/src/main.rs
@@ -6,9 +6,9 @@ use cosmic::iced::{event, keyboard, window, Fill, Padding, Subscription, Task};
 use cosmic::prelude::*;
 use cosmic::widget::{button as cosmic_button, icon};
 use reqwest::{Client, Method};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::env;
 use std::io::Write;
 use std::path::PathBuf;
@@ -21,6 +21,7 @@ use wingmate::partner_window_bridge::{self, PartnerWindowController};
 mod i18n;
 
 const DEFAULT_API_URL: &str = "http://127.0.0.1:8765";
+const MAX_IMAGE_CACHE_ENTRIES: usize = 256;
 
 fn as_system_managed(theme: cosmic::theme::Theme) -> cosmic::theme::Theme {
     if matches!(&theme.theme_type, cosmic::theme::ThemeType::System { .. }) {
@@ -438,9 +439,48 @@ struct Board {
 struct BoardImage {
     id: String,
     #[serde(default)]
-    url: Option<String>,
+    data: Option<String>,
+    #[serde(default, rename = "dataUrl")]
+    data_url: Option<String>,
     #[serde(default)]
     path: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default, rename = "contentType")]
+    content_type: Option<String>,
+    #[serde(default)]
+    symbol: Option<BoardSymbol>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct BoardSymbol {
+    #[serde(default)]
+    set: Option<String>,
+    #[serde(default)]
+    filename: Option<String>,
+    #[serde(default, rename = "libraryKey")]
+    library_key: Option<String>,
+}
+
+impl BoardImage {
+    fn has_source(&self) -> bool {
+        !self.data.as_deref().unwrap_or_default().trim().is_empty()
+            || !self.data_url.as_deref().unwrap_or_default().trim().is_empty()
+            || !self.path.as_deref().unwrap_or_default().trim().is_empty()
+            || !self.url.as_deref().unwrap_or_default().trim().is_empty()
+            || self.symbol.is_some()
+    }
+
+    fn resolve_payload(&self) -> serde_json::Value {
+        serde_json::json!({
+            "data": self.data,
+            "dataUrl": self.data_url,
+            "path": self.path,
+            "url": self.url,
+            "content_type": self.content_type,
+            "symbol": self.symbol,
+        })
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -586,6 +626,7 @@ struct Wingmate {
     board_sentence: String,
     board_stack: Vec<String>,
     image_cache: HashMap<String, CachedVisual>,
+    image_cache_order: VecDeque<String>,
     pending_images: HashSet<String>,
     access_hover: Option<(AccessTarget, Instant)>,
     access_press: Option<(AccessTarget, Instant)>,
@@ -920,6 +961,7 @@ impl cosmic::Application for Wingmate {
             board_sentence: String::new(),
             board_stack: Vec::new(),
             image_cache: HashMap::new(),
+            image_cache_order: VecDeque::new(),
             pending_images: HashSet::new(),
             access_hover: None,
             access_press: None,
@@ -1103,7 +1145,13 @@ impl cosmic::Application for Wingmate {
                                 } else {
                                     CachedVisual::Raster(image::Handle::from_bytes(bytes))
                                 };
+                                self.image_cache_order.push_back(source.clone());
                                 self.image_cache.insert(source, visual);
+                                while self.image_cache_order.len() > MAX_IMAGE_CACHE_ENTRIES {
+                                    if let Some(oldest) = self.image_cache_order.pop_front() {
+                                        self.image_cache.remove(&oldest);
+                                    }
+                                }
                             }
                             Ok(_) => self.status = fl!("error-image-empty"),
                             Err(error) => {
@@ -1138,11 +1186,12 @@ impl cosmic::Application for Wingmate {
             },
             Message::LoadedBoardGraph(result) => match result {
                 Ok(graph) => {
+                    self.clear_board_image_cache();
                     let image_sources = graph
                         .boards
                         .iter()
                         .flat_map(|board| board.images.iter())
-                        .filter_map(|item| item.url.clone().or_else(|| item.path.clone()))
+                        .map(|item| (item.id.clone(), item.clone()))
                         .collect();
                     let same_set = self
                         .board_graph
@@ -1173,7 +1222,7 @@ impl cosmic::Application for Wingmate {
                     self.active_board_id = Some(active_board_id);
                     self.board_graph = Some(graph);
                     self.status = fl!("status-ready");
-                    return self.queue_images(image_sources);
+                    return self.queue_board_images(image_sources);
                 }
                 Err(e) => self.status = e,
             },
@@ -2523,6 +2572,29 @@ impl Wingmate {
         Task::batch(tasks)
     }
 
+    fn queue_board_images(
+        &mut self,
+        images: Vec<(String, BoardImage)>,
+    ) -> Task<cosmic::Action<Message>> {
+        let tasks = images
+            .into_iter()
+            .filter(|(id, image)| {
+                image.has_source()
+                    && !self.image_cache.contains_key(id)
+                    && self.pending_images.insert(id.clone())
+            })
+            .map(|(id, image)| {
+                self.api.fetch_board_image(id, image).map(cosmic::Action::App)
+            })
+            .collect::<Vec<_>>();
+        Task::batch(tasks)
+    }
+
+    fn clear_board_image_cache(&mut self) {
+        self.image_cache_order.clear();
+        self.image_cache.clear();
+    }
+
     fn image_for(&self, source: Option<&str>, height: f32) -> Option<Element<'_, Message>> {
         match self.image_cache.get(source?)?.clone() {
             CachedVisual::Raster(handle) => Some(
@@ -3570,11 +3642,11 @@ impl Wingmate {
             } else {
                 Message::Speak(String::new())
             };
-            let symbol_source = button_data
+            let symbol_image = button_data
                 .and_then(|button| button.image_id.as_ref())
                 .and_then(|image_id| board.images.iter().find(|image| &image.id == image_id))
-                .and_then(|item| item.url.as_deref().or(item.path.as_deref()));
-            let has_symbol = symbol_source.is_some();
+                .filter(|image| image.has_source());
+            let has_symbol = symbol_image.is_some();
             let show_symbol = has_symbol && show_symbols;
             let show_label = show_labels || !show_symbol;
             let mut cell_content = column![]
@@ -3583,14 +3655,19 @@ impl Wingmate {
             if label_at_top && show_label {
                 cell_content = cell_content.push(text(label.clone()).size(18));
             }
-            if show_symbol {
-                cell_content =
-                    cell_content.push(self.image_for(symbol_source, 52.0).unwrap_or_else(|| {
+if show_symbol {
+                cell_content = cell_content.push(
+                    self.image_for(
+                        symbol_image.map(|image| image.id.as_str()),
+                        52.0,
+                    )
+                    .unwrap_or_else(|| {
                         symbolic_icon("image-x-generic-symbolic")
                             .size(32)
                             .icon()
                             .into()
-                    }));
+                    }),
+                );
             }
             if !label_at_top && show_label {
                 cell_content = cell_content.push(text(label).size(18));
@@ -5152,6 +5229,22 @@ impl Api {
                     Method::POST,
                     "/api/images/fetch",
                     Some(serde_json::json!({"url": source})),
+                )
+                .await
+            },
+            move |result| Message::LoadedImage(result_source.clone(), result),
+        )
+    }
+
+    fn fetch_board_image(&self, id: String, image: BoardImage) -> Task<Message> {
+        let api = self.clone();
+        let result_source = id.clone();
+        Task::perform(
+            async move {
+                api.request_json(
+                    Method::POST,
+                    "/api/images/resolve",
+                    Some(serde_json::json!({"image": image.resolve_payload()})),
                 )
                 .await
             },

--- a/linuxApp/src/main.rs
+++ b/linuxApp/src/main.rs
@@ -5845,7 +5845,7 @@ fn find_fat_jar() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("build/libs/linuxApp-all.jar"))
 }
 
-const TOKEN_HEADER: &str = "x-wingate-token";
+const TOKEN_HEADER: &str = "x-wingmate-token";
 
 fn state_home() -> PathBuf {
     if let Ok(state) = env::var("XDG_STATE_HOME") {
@@ -5955,6 +5955,11 @@ fn start_bridge_server() -> Option<Child> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bridge_token_header_matches_the_kotlin_bridge_contract() {
+        assert_eq!(TOKEN_HEADER, "x-wingmate-token");
+    }
 
     #[test]
     fn editing_access_gate_covers_content_mutations_but_not_communication() {

--- a/linuxApp/src/main.rs
+++ b/linuxApp/src/main.rs
@@ -473,6 +473,7 @@ impl BoardImage {
 
     fn resolve_payload(&self) -> serde_json::Value {
         serde_json::json!({
+            "id": self.id,
             "data": self.data,
             "dataUrl": self.data_url,
             "path": self.path,
@@ -3430,8 +3431,7 @@ impl Wingmate {
                 editor = editor.push(text(fl!("status-searching")).size(15));
             }
             if !self.symbols.is_empty() {
-                let results =
-                    row(self
+                let results = row(self
                         .symbols
                         .iter()
                         .enumerate()
@@ -3440,7 +3440,7 @@ impl Wingmate {
                             let mut content = column![]
                                 .spacing(3)
                                 .align_x(cosmic::iced::alignment::Alignment::Center);
-                            if let Some(preview) = self.image_for(symbol.image_url.as_deref(), 52.0)
+                            if let Some(preview) = self.image_for(symbol.image_url.as_deref(), 44.0)
                             {
                                 content = content.push(preview);
                             }
@@ -3452,13 +3452,20 @@ impl Wingmate {
                             ));
                             button(content)
                                 .on_press(Message::CellSymbolPicked(index))
-                                .height(88)
-                                .padding([10, 14])
+                                .width(124)
+                                .height(80)
+                                .padding([6, 10])
                                 .into()
                         }))
-                    .spacing(6)
-                    .wrap();
-                editor = editor.push(results);
+                    .spacing(6);
+                editor = editor.push(
+                    scrollable(results)
+                        .direction(scrollable::Direction::Horizontal(
+                            scrollable::Scrollbar::default(),
+                        ))
+                        .width(Fill)
+                        .height(92),
+                );
             }
             if let Some(image_url) = &self.cell_image_url {
                 if let Some(preview) = self.image_for(Some(image_url), 120.0) {
@@ -5955,6 +5962,21 @@ fn start_bridge_server() -> Option<Child> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn board_image_resolve_payload_includes_required_obf_id() {
+        let image = BoardImage {
+            id: "image-1".into(),
+            data: None,
+            data_url: None,
+            path: None,
+            url: Some("https://example.com/symbol.png".into()),
+            content_type: None,
+            symbol: None,
+        };
+
+        assert_eq!(image.resolve_payload()["id"], "image-1");
+    }
 
     #[test]
     fn bridge_token_header_matches_the_kotlin_bridge_contract() {

--- a/linuxApp/src/main.rs
+++ b/linuxApp/src/main.rs
@@ -14,6 +14,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use wingmate::partner_window_bridge::{self, PartnerWindowController};
 
@@ -4674,6 +4675,7 @@ fn symbolic_icon(name: &str) -> icon::Named {
 struct Api {
     base: String,
     client: Client,
+    token: String,
 }
 
 impl Api {
@@ -4681,6 +4683,7 @@ impl Api {
         Self {
             base: env::var("WINGMATE_API_URL").unwrap_or_else(|_| DEFAULT_API_URL.into()),
             client: Client::new(),
+            token: current_bridge_token(),
         }
     }
 
@@ -5224,6 +5227,7 @@ impl Api {
                 let response = api
                     .client
                     .post(url)
+                    .header(TOKEN_HEADER, api.token)
                     .header("Content-Type", "application/json")
                     .body(body)
                     .send()
@@ -5554,7 +5558,10 @@ impl Api {
         let url = format!("{}{}", self.base, path);
         let mut last_error = String::new();
         for attempt in 0..8 {
-            let mut request = self.client.request(method.clone(), &url);
+            let mut request = self
+                .client
+                .request(method.clone(), &url)
+                .header(TOKEN_HEADER, &self.token);
             if let Some(value) = body.clone() {
                 request = request.json(&value);
             }
@@ -5745,6 +5752,75 @@ fn find_fat_jar() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("build/libs/linuxApp-all.jar"))
 }
 
+const TOKEN_HEADER: &str = "x-wingate-token";
+
+fn state_home() -> PathBuf {
+    if let Ok(state) = env::var("XDG_STATE_HOME") {
+        if !state.trim().is_empty() {
+            return PathBuf::from(state);
+        }
+    }
+    PathBuf::from(
+        env::var("HOME").unwrap_or_else(|_| ".".into()),
+    )
+    .join(".local/state")
+}
+
+fn bridge_token_file() -> PathBuf {
+    state_home().join("wingmate").join("bridge-token")
+}
+
+/// Per-process bridge capability token, shared between the Rust client and the
+/// Kotlin bridge it spawns. Preference order matches the Kotlin side:
+/// 1. token injected into the child environment when we spawn the bridge,
+/// 2. token the already-running bridge persisted for the reuse case,
+/// 3. a freshly generated random token (also persisted and passed on spawn).
+fn current_bridge_token() -> String {
+    static TOKEN: OnceLock<String> = OnceLock::new();
+    TOKEN.get_or_init(|| {
+        if let Some(token) = env::var("WINGMATE_BRIDGE_TOKEN").ok() {
+            let trimmed = token.trim().to_string();
+            if trimmed.len() >= 16 {
+                return trimmed;
+            }
+        }
+        if let Ok(token) = std::fs::read_to_string(bridge_token_file()) {
+            let trimmed = token.trim().to_string();
+            if trimmed.len() >= 16 {
+                return trimmed;
+            }
+        }
+        let token = generate_bridge_token();
+        persist_bridge_token(&token);
+        token
+    })
+    .clone()
+}
+
+fn generate_bridge_token() -> String {
+    use std::io::Read;
+    let mut bytes = [0u8; 32];
+    if let Ok(mut from) = std::fs::File::open("/dev/urandom") {
+        let _ = from.read_exact(&mut bytes);
+    } else {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0) as u64;
+        bytes[..8].copy_from_slice(&now.to_le_bytes());
+        bytes[8..16].copy_from_slice(&(std::process::id().to_le_bytes()));
+    }
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn persist_bridge_token(token: &str) {
+    let path = bridge_token_file();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, format!("{token}\n"));
+}
+
 fn bridge_already_running() -> bool {
     let addr = "127.0.0.1:8765";
     std::net::TcpStream::connect_timeout(
@@ -5769,6 +5845,7 @@ fn start_bridge_server() -> Option<Child> {
         .arg("-jar")
         .arg(&jar)
         .arg("--no-partner-window")
+        .env("WINGMATE_BRIDGE_TOKEN", current_bridge_token())
         .spawn()
     {
         Ok(child) => Some(child),

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/AzureConfigManager.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/AzureConfigManager.kt
@@ -44,11 +44,7 @@ class AzureConfigManager {
             val voices = AzureTtsClient.getVoices(client, config)
             if (voices.isNotEmpty()) {
                 voiceRepository.saveVoices(voices)
-                // Filter logic could go here (e.g. only selected language)
             }
-        } catch (e: Exception) {
-            e.printStackTrace()
-            throw e
         } finally {
             client.close()
         }

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/JsonRepositories.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/JsonRepositories.kt
@@ -9,6 +9,9 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import org.freedesktop.dbus.annotations.DBusInterfaceName
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
+import org.freedesktop.dbus.interfaces.DBusInterface
 import java.io.File
 
 private val configDir = File(System.getProperty("user.home"), ".config/wingmate").apply { mkdirs() }
@@ -66,19 +69,24 @@ class JsonFileConfigRepository : ConfigRepository {
 
     override suspend fun getSpeechConfig(): SpeechServiceConfig? = mutex.withLock {
         withContext(Dispatchers.IO) {
-            secureStore.read()?.let(::decode)?.also {
+            // A legacy file is authoritative until it has been verified in
+            // secure storage. This avoids silently selecting an older keyring
+            // value if an earlier migration was interrupted or mismatched.
+            if (file.exists()) {
+                val legacy = decode(file.readText())
+                secureStore.write(json.encodeToString(legacy))
+                val stored = secureStore.readAfterWrite()?.let(::decode)
+                check(stored == legacy) {
+                    "Secure Azure credential migration could not be verified " +
+                        "(stored=${stored != null}, endpointMatches=${stored?.endpoint == legacy.endpoint}, " +
+                        "credentialMatches=${stored?.subscriptionKey == legacy.subscriptionKey}, " +
+                        "secureStore=${secureStore.lastReadDiagnostic})"
+                }
                 check(file.delete() || !file.exists()) { "Could not delete legacy plaintext Azure configuration" }
-                return@withContext it
+                println("[PERSISTENCE] Migrated Azure speech configuration to the desktop keyring.")
+                return@withContext legacy
             }
-            if (!file.exists()) return@withContext null
-            val legacy = decode(file.readText())
-            secureStore.write(json.encodeToString(legacy))
-            check(secureStore.read()?.let(::decode) == legacy) {
-                "Secure Azure credential migration could not be verified"
-            }
-            check(file.delete() || !file.exists()) { "Could not delete legacy plaintext Azure configuration" }
-            println("[PERSISTENCE] Migrated Azure speech configuration to the desktop keyring.")
-            legacy
+            secureStore.read()?.let(::decode)
         }
     }
 
@@ -86,7 +94,12 @@ class JsonFileConfigRepository : ConfigRepository {
         withContext(Dispatchers.IO) {
             require(config.subscriptionKey.isNotBlank()) { "Azure subscription key must not be blank" }
             secureStore.write(json.encodeToString(config))
-            check(secureStore.read()?.let(::decode) == config) { "Secure Azure credential write could not be verified" }
+            val stored = secureStore.readAfterWrite()?.let(::decode)
+            check(stored == config) {
+                "Secure Azure credential write could not be verified " +
+                    "(stored=${stored != null}, endpointMatches=${stored?.endpoint == config.endpoint}, " +
+                    "credentialMatches=${stored?.subscriptionKey == config.subscriptionKey})"
+            }
             check(file.delete() || !file.exists()) { "Could not delete legacy plaintext Azure configuration" }
             println("[PERSISTENCE] Saved Azure speech configuration securely; credentialConfigured=true")
         }
@@ -118,21 +131,36 @@ private class LinuxAzureConfigStore {
         }
     }
 
+    @Volatile var lastReadDiagnostic: String = "not attempted"
+        private set
+
     fun read(): String? = when (backend) {
         Backend.SecretService -> run(listOf("secret-tool", "lookup", "application", APP_ID, "purpose", PURPOSE))
+            .also { lastReadDiagnostic = "Secret Service lookup exit=${it.exitCode}" }
             .takeIf { it.exitCode == 0 }?.output?.trim()?.takeIf(String::isNotEmpty)
-        Backend.KWallet -> run(listOf("kwallet-query", "-r", ENTRY, "-f", FOLDER, walletName()))
-            .takeIf { it.exitCode == 0 }?.output?.trim()?.takeIf(String::isNotEmpty)
-        null -> null
+        Backend.KWallet -> readKWallet()
+        null -> null.also { lastReadDiagnostic = "no secure-store command found" }
     }
+
+    fun readAfterWrite(): String? = read()
 
     fun write(value: String) {
         val result = when (backend) {
-            Backend.SecretService -> run(
-                listOf("secret-tool", "store", "--label=Wingmate Azure Speech configuration", "application", APP_ID, "purpose", PURPOSE),
-                value
-            )
-            Backend.KWallet -> run(listOf("kwallet-query", "-w", ENTRY, "-f", FOLDER, walletName()), value)
+            // `secret-tool store` can leave multiple items with the same
+            // attributes behind. A later lookup is then allowed to return an
+            // older value, making a successful migration look unverified.
+            // Clear matching entries first so the value we verify is the one
+            // just written. The legacy plaintext file is retained until that
+            // verification succeeds.
+            Backend.SecretService -> {
+                val clear = run(listOf("secret-tool", "clear", "application", APP_ID, "purpose", PURPOSE))
+                check(clear.exitCode == 0) { clear.output.ifBlank { "Could not replace Azure configuration securely" } }
+                run(
+                    listOf("secret-tool", "store", "--label=Wingmate Azure Speech configuration", "application", APP_ID, "purpose", PURPOSE),
+                    value
+                )
+            }
+            Backend.KWallet -> writeKWallet(value)
             null -> error("Secure credential storage is unavailable; install Secret Service/libsecret or KWallet")
         }
         check(result.exitCode == 0) { result.output.ifBlank { "Could not save Azure configuration securely" } }
@@ -142,14 +170,72 @@ private class LinuxAzureConfigStore {
         if (read() == null) return
         val result = when (backend) {
             Backend.SecretService -> run(listOf("secret-tool", "clear", "application", APP_ID, "purpose", PURPOSE))
-            Backend.KWallet -> run(listOf("kwallet-query", "-w", ENTRY, "-f", FOLDER, walletName()), "")
+            Backend.KWallet -> removeKWalletEntry()
             null -> return
         }
         check(result.exitCode == 0) { result.output.ifBlank { "Could not clear Azure configuration" } }
         check(read() == null) { "Secure Azure configuration deletion could not be verified" }
     }
 
+    private fun readKWallet(): String? =
+        runCatching { withKWallet { wallet, handle -> wallet.readPassword(handle, FOLDER, ENTRY, APP_ID) } }
+            .getOrNull()
+            ?.trim()
+            ?.takeIf(String::isNotEmpty)
+            ?: readLegacyKWalletEntry()
+
+    private fun readLegacyKWalletEntry(): String? {
+        val result = run(listOf("kwallet-query", "-r", LEGACY_ENTRY, "-f", FOLDER, walletName()))
+        lastReadDiagnostic = if (result.exitCode == 0) {
+            "KWallet legacy entry read successfully"
+        } else {
+            "KWallet legacy entry read exit=${result.exitCode}: ${result.output.take(160)}"
+        }
+        return result.takeIf { it.exitCode == 0 }?.output?.trim()?.takeIf(String::isNotEmpty)
+    }
+
+    private fun writeKWallet(value: String): Result = runCatching {
+        withKWallet { wallet, handle ->
+            if (!wallet.hasFolder(handle, FOLDER, APP_ID)) {
+                check(wallet.createFolder(handle, FOLDER, APP_ID)) { "Could not create the KWallet folder" }
+            }
+            val result = wallet.writePassword(handle, FOLDER, ENTRY, value, APP_ID)
+            check(result == 0) { "KWallet write failed with code $result" }
+        }
+        Result(0, "")
+    }.getOrElse { Result(-1, it.message.orEmpty()) }
+
+    private fun removeKWalletEntry(): Result = runCatching {
+        withKWallet { wallet, handle ->
+            for (entry in listOf(ENTRY, LEGACY_ENTRY)) {
+                if (wallet.hasEntry(handle, FOLDER, entry, APP_ID)) {
+                    val result = wallet.removeEntry(handle, FOLDER, entry, APP_ID)
+                    check(result == 0) { "KWallet removal failed with code $result" }
+                }
+            }
+        }
+        Result(0, "")
+    }.getOrElse { Result(-1, it.message.orEmpty()) }
+
+    private fun <T> withKWallet(block: (KWalletDbus, Int) -> T): T {
+        DBusConnectionBuilder.forSessionBus().withShared(false).build().use { connection ->
+            var failure: Throwable? = null
+            for ((service, path) in KWALLET_ENDPOINTS) {
+                try {
+                    val wallet = connection.getRemoteObject(service, path, KWalletDbus::class.java)
+                    val handle = wallet.open(walletName(), 0L, APP_ID)
+                    check(handle >= 0) { "Could not open wallet ${walletName()}" }
+                    return block(wallet, handle)
+                } catch (error: Throwable) {
+                    failure = error
+                }
+            }
+            throw IllegalStateException("Could not connect to the KWallet secure store", failure)
+        }
+    }
+
     private fun walletName() = System.getenv("WINGMATE_KWALLET")?.takeIf(String::isNotBlank) ?: "kdewallet"
+
     private data class Result(val exitCode: Int, val output: String)
     private fun run(command: List<String>, input: String? = null): Result = runCatching {
         val process = ProcessBuilder(command).start()
@@ -165,8 +251,25 @@ private class LinuxAzureConfigStore {
         const val APP_ID = "io.github.jdreioe.wingmate"
         const val PURPOSE = "azure-speech"
         const val FOLDER = "Wingmate"
-        const val ENTRY = "azure-speech-config"
+        const val ENTRY = "azure-speech-config-v2"
+        const val LEGACY_ENTRY = "azure-speech-config"
+        val KWALLET_ENDPOINTS = listOf(
+            "org.kde.kwalletd6" to "/modules/kwalletd6",
+            "org.kde.kwalletd5" to "/modules/kwalletd5",
+            "org.kde.kwalletd" to "/modules/kwalletd",
+        )
     }
+}
+
+@DBusInterfaceName("org.kde.KWallet")
+interface KWalletDbus : DBusInterface {
+    fun open(wallet: String, windowId: Long, appId: String): Int
+    fun hasFolder(handle: Int, folder: String, appId: String): Boolean
+    fun createFolder(handle: Int, folder: String, appId: String): Boolean
+    fun hasEntry(handle: Int, folder: String, entry: String, appId: String): Boolean
+    fun readPassword(handle: Int, folder: String, entry: String, appId: String): String
+    fun writePassword(handle: Int, folder: String, entry: String, value: String, appId: String): Int
+    fun removeEntry(handle: Int, folder: String, entry: String, appId: String): Int
 }
 
 class JsonFileVoiceRepository : VoiceRepository {

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -3,15 +3,11 @@ package io.github.jdreioe.wingmate.kde
 import io.github.jdreioe.wingmate.initKoin
 import org.koin.dsl.module
 import io.ktor.http.*
-import io.ktor.client.request.get
-import io.ktor.client.statement.bodyAsChannel
-import io.ktor.utils.io.core.readBytes
 import io.ktor.serialization.kotlinx.json.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.contentnegotiation.*
-import io.ktor.server.plugins.cors.routing.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
@@ -68,8 +64,16 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.*
 import java.io.File
+import java.net.Inet4Address
+import java.net.Inet6Address
+import java.net.InetAddress
 import java.net.URI
+import java.net.UnknownHostException
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
 import java.security.MessageDigest
+import java.security.SecureRandom
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 import java.util.concurrent.atomic.AtomicLong
@@ -80,6 +84,7 @@ import java.util.concurrent.atomic.AtomicLong
  */
 class KotlinBridge(private val port: Int = 8765) {
     private val scope = CoroutineScope(Dispatchers.Default + kotlinx.coroutines.SupervisorJob())
+    private val authToken: String = resolveBridgeToken()
     private val phraseViewModel = PhraseViewModel()
     private val settingsManager = SettingsManager()
     private val configRepository: ConfigRepository by lazy { GlobalContext.get().get() }
@@ -123,7 +128,7 @@ class KotlinBridge(private val port: Int = 8765) {
         encodeDefaults = true
     }
     
-    private val server = embeddedServer(Netty, port = port) {
+    private val server = embeddedServer(Netty, port = port, host = "127.0.0.1") {
         install(ContentNegotiation) {
             json(Json {
                 ignoreUnknownKeys = true
@@ -131,17 +136,22 @@ class KotlinBridge(private val port: Int = 8765) {
                 encodeDefaults = true
             })
         }
-        
-        install(CORS) {
-            allowMethod(HttpMethod.Get)
-            allowMethod(HttpMethod.Post)
-            allowMethod(HttpMethod.Put)
-            allowMethod(HttpMethod.Delete)
-            allowHeader(HttpHeaders.ContentType)
-            anyHost()
-        }
-        
+
         routing {
+            // Capability-token gate: every request must carry the per-process
+            // token shared with the Rust client (env when spawned, or the
+            // runtime file when an earlier bridge is being reused).
+            intercept(ApplicationCallPipeline.Call) {
+                val presented = call.request.headers[TOKEN_HEADER_NAME]
+                if (presented.isNullOrBlank() || presented != authToken) {
+                    call.respond(
+                        HttpStatusCode.Unauthorized,
+                        mapOf("error" to "invalid bridge token"),
+                    )
+                    return@intercept
+                }
+            }
+
             // Phrases
             get("/api/phrases") {
                 val phrases = phraseViewModel.phrases.firstOrNull() ?: emptyList()
@@ -547,10 +557,10 @@ class KotlinBridge(private val port: Int = 8765) {
 
             post("/api/pronunciation/import") {
                 try {
-                    val path = json.parseToJsonElement(call.receiveText()).jsonObject["path"]
-                        ?.jsonPrimitive?.contentOrNull.orEmpty()
-                    val file = File(path)
-                    require(file.isFile) { "Dictionary file does not exist" }
+                    val file = requireSelectedPath(
+                        json.parseToJsonElement(call.receiveText()).jsonObject["path"]
+                            ?.jsonPrimitive?.contentOrNull.orEmpty()
+                    )
                     require(file.length() <= 5L * 1024L * 1024L) { "Dictionary file is too large" }
                     val entries = if (file.extension.equals("csv", ignoreCase = true)) {
                         file.readLines().dropWhile { it.isBlank() }.drop(1).mapNotNull { line ->
@@ -609,8 +619,10 @@ class KotlinBridge(private val port: Int = 8765) {
                 try {
                     val body = json.parseToJsonElement(call.receiveText()).jsonObject
                     val path = body["path"]?.jsonPrimitive?.contentOrNull.orEmpty()
-                    if (path.isBlank()) return@post call.respond(HttpStatusCode.BadRequest, mapOf("error" to "missing path"))
-                    val result = GlobalContext.get().get<io.github.jdreioe.wingmate.application.CompleteBackupManager>().restoreBackup(path)
+                    val file = requireSelectedPath(path)
+                    val result = GlobalContext.get()
+                        .get<io.github.jdreioe.wingmate.application.CompleteBackupManager>()
+                        .restoreBackup(file.path)
                     val message = when (result) {
                         is io.github.jdreioe.wingmate.application.BackupRestoreResult.Success -> {
                             trainPredictionModel()
@@ -644,14 +656,14 @@ class KotlinBridge(private val port: Int = 8765) {
                 }
             }
 
-            // Proxy-fetch an image URL through the shared HTTP client, returning base64 bytes.
+            // Proxy-fetch an image URL through a hardened HTTP client, returning base64 bytes.
             // Lets the Rust UI render remote symbol images without its own HTTP/network stack.
             post("/api/images/fetch") {
                 try {
                     val body = json.parseToJsonElement(call.receiveText()).jsonObject
                     val url = body["url"]?.jsonPrimitive?.contentOrNull.orEmpty()
                     if (url.isBlank()) return@post call.respond(HttpStatusCode.BadRequest, mapOf("error" to "missing url"))
-                    val localFile = localImageFile(url)
+                    val localFile = trustedLocalImageFile(url)
                     val cacheFile = File(imageCacheDirectory(), sha256(url))
                     val bytes: ByteArray
                     val contentType: String
@@ -659,22 +671,16 @@ class KotlinBridge(private val port: Int = 8765) {
                         require(localFile.isFile) { "Image file does not exist" }
                         require(localFile.length() <= MAX_IMAGE_BYTES) { "Image is too large" }
                         bytes = localFile.readBytes()
-                        contentType = Files.probeContentType(localFile.toPath()) ?: "image/png"
+                        contentType = Files.probeContentType(localFile.toPath()) ?: contentTypeForBytes(bytes)
                     } else if (cacheFile.isFile) {
                         bytes = cacheFile.readBytes()
-                        contentType = "image/png"
+                        contentType = contentTypeForBytes(bytes)
                     } else {
-                        val client = io.ktor.client.HttpClient()
-                        try {
-                            val response = client.get(url)
-                            bytes = response.bodyAsChannel().readRemaining(MAX_IMAGE_BYTES + 1).readBytes()
-                            require(bytes.size <= MAX_IMAGE_BYTES) { "Image is too large" }
-                            contentType = response.contentType()?.toString() ?: "image/png"
-                            cacheFile.parentFile.mkdirs()
-                            cacheFile.writeBytes(bytes)
-                        } finally {
-                            client.close()
-                        }
+                        val fetched = fetchRemoteImageBytes(url)
+                        bytes = fetched.first
+                        contentType = fetched.second
+                        cacheFile.parentFile.mkdirs()
+                        cacheFile.writeBytes(bytes)
                     }
                     call.respond(mapOf(
                         "data" to java.util.Base64.getEncoder().encodeToString(bytes),
@@ -687,10 +693,10 @@ class KotlinBridge(private val port: Int = 8765) {
 
             post("/api/images/import") {
                 try {
-                    val sourcePath = json.parseToJsonElement(call.receiveText()).jsonObject["path"]
-                        ?.jsonPrimitive?.contentOrNull.orEmpty()
-                    val source = File(sourcePath)
-                    require(source.isFile) { "Image file does not exist" }
+                    val source = requireSelectedPath(
+                        json.parseToJsonElement(call.receiveText()).jsonObject["path"]
+                            ?.jsonPrimitive?.contentOrNull.orEmpty()
+                    )
                     require(source.length() <= MAX_IMAGE_BYTES) { "Image is too large" }
                     val extension = source.extension.lowercase().takeIf { it in setOf("png", "jpg", "jpeg", "svg") }
                         ?: "img"
@@ -726,8 +732,10 @@ class KotlinBridge(private val port: Int = 8765) {
             }
 
             post("/api/boardsets/import") {
-                val path = json.parseToJsonElement(call.receiveText()).jsonObject["path"]?.jsonPrimitive?.contentOrNull
-                    ?: return@post call.respond(HttpStatusCode.BadRequest)
+                val path = requireSelectedPath(
+                    json.parseToJsonElement(call.receiveText()).jsonObject["path"]
+                        ?.jsonPrimitive?.contentOrNull.orEmpty()
+                ).path
                 val imported = boardImportService.importBoardSetFromPath(path)
                     ?: return@post call.respond(HttpStatusCode.BadRequest)
                 call.respond(HttpStatusCode.Created, imported)
@@ -1374,6 +1382,10 @@ data class BoardSessionResponse(
 )
 
 private const val MAX_IMAGE_BYTES = 20L * 1024L * 1024L
+private const val MAX_REDIRECT_HOPS = 5
+private val IMAGE_TIMEOUT: java.time.Duration = java.time.Duration.ofSeconds(30)
+
+private const val TOKEN_HEADER_NAME = "X-Wingmate-Token"
 
 private fun imageCacheDirectory(): File =
     File(System.getenv("XDG_CACHE_HOME")?.takeIf { it.isNotBlank() }
@@ -1383,10 +1395,263 @@ private fun imageDataDirectory(): File =
     File(System.getenv("XDG_DATA_HOME")?.takeIf { it.isNotBlank() }
         ?: File(System.getProperty("user.home"), ".local/share").path, "wingmate/images")
 
-private fun localImageFile(source: String): File? = when {
-    source.startsWith("file:") -> runCatching { File(URI(source)) }.getOrNull()
-    source.startsWith('/') -> File(source)
-    else -> null
+/**
+ * Files imported by the app itself (board-set media in the shared
+ * JvmFileStorage root, or images imported through the editor) are the only
+ * local-image targets the fetch endpoint will serve. Everything else
+ * (schema-less strings, arbitrary absolute paths, symlinked files) is
+ * rejected.
+ */
+fun trustedLocalImageFile(source: String): File? {
+    val file = when {
+        source.startsWith("file:") -> runCatching { File(java.net.URI(source)) }.getOrNull()
+        source.startsWith('/') -> File(source)
+        else -> null
+    } ?: return null
+    if (!file.isAbsolute) return null
+    val canonical = runCatching { file.canonicalFile }.getOrNull() ?: return null
+    val roots = listOf(imageDataDirectory(), fileStorageRoot()).map { runCatching { it.canonicalFile }.getOrNull() ?: it }
+    return roots
+        .firstOrNull { root -> canonical.path == root.path || canonical.path.startsWith(root.path + File.separator) }
+        ?.let { canonical }
+}
+
+private fun fileStorageRoot(): File =
+    File(System.getProperty("user.home"), ".wingmate/files")
+
+fun requireSelectedPath(value: String): File {
+    require(value.isNotBlank()) { "Missing file path" }
+    val file = File(value)
+    require(file.isAbsolute) { "File path must be absolute" }
+    require(file.exists()) { "Selected file does not exist" }
+    require(file.isFile) { "Selected path is not a file" }
+    return file
+}
+
+private val bridgeHttpClient: HttpClient = HttpClient.newBuilder()
+    .connectTimeout(java.time.Duration.ofSeconds(10))
+    .followRedirects(HttpClient.Redirect.NEVER)
+    .build()
+
+/**
+ * Fetch remote image bytes with SSRF-safe target validation, a manually
+ * re-validated redirect loop, timeouts, a hard byte limit, and content-type
+ * / magic-byte validation. Returns (bytes, content-type).
+ */
+private fun fetchRemoteImageBytes(source: String): Pair<ByteArray, String> {
+    var current: URI = validatedImageUri(source)
+        ?: throw IllegalArgumentException("Image target is not allowed to be fetched")
+    var hops = 0
+    while (true) {
+        require(hops <= MAX_REDIRECT_HOPS) { "Image target redirect limit exceeded" }
+        val request = HttpRequest.newBuilder(current)
+            .timeout(IMAGE_TIMEOUT)
+            .header("User-Agent", "Wingmate/1.0 (Linux)")
+            .GET()
+            .build()
+        val response = bridgeHttpClient.send(request, HttpResponse.BodyHandlers.ofInputStream())
+        val status = response.statusCode()
+        if (status in 300..399) {
+            val location = response.headers().firstValue("Location").orElse(null)
+            response.body().close()
+            if (location.isNullOrBlank()) {
+                throw IllegalArgumentException("Image target redirected without a Location")
+            }
+            hops += 1
+            val redirected = validatedRedirectUri(current, location)
+                ?: throw IllegalArgumentException("Image redirect target is not allowed: $location")
+            current = redirected
+            continue
+        }
+        if (status !in 200..299) {
+            response.body().close()
+            throw IllegalArgumentException("Image target returned HTTP $status")
+        }
+        val body = response.body().readNBytes(MAX_IMAGE_BYTES.toInt() + 1)
+        if (body.size > MAX_IMAGE_BYTES) throw IllegalArgumentException("Image is too large")
+        val declaredType = response.headers().firstValue("Content-Type").orElse("")
+            .substringBefore(';').trim().lowercase()
+        validateImageContent(body, declaredType)
+        return body to (declaredType.takeIf { it.isNotBlank() } ?: contentTypeForBytes(body))
+    }
+}
+
+/**
+ * Rejects anything that could target the local machine or a private network:
+ * non-http(s) schemes, unresolved hosts, loopback, link-local, private,
+ * multicast/reserved IPv4, and loopback/ULA/link-local/mapped IPv6.
+ */
+fun validatedImageUri(source: String): URI? {
+    val uri = runCatching { URI(source.trim()) }.getOrNull() ?: return null
+    return if (isAllowedRemoteTarget(uri)) uri else null
+}
+
+fun validatedRedirectUri(base: URI, location: String): URI? {
+    val resolved = runCatching { base.resolve(location) }.getOrNull() ?: return null
+    return if (isAllowedRemoteTarget(resolved)) resolved else null
+}
+
+fun isAllowedRemoteTarget(uri: URI): Boolean {
+    val scheme = uri.scheme?.lowercase() ?: return false
+    if (scheme != "http" && scheme != "https") return false
+    val host = uri.host?.lowercase() ?: return false
+    if (host.isBlank()) return false
+    if (uri.rawUserInfo != null) return false
+    val addresses = try {
+        if (host == "localhost") listOf(InetAddress.getByName("127.0.0.1"))
+        else InetAddress.getAllByName(host).toList()
+    } catch (error: UnknownHostException) {
+        return false
+    } catch (error: SecurityException) {
+        return false
+    }
+    return addresses.isNotEmpty() && addresses.all { !isDangerousAddress(it) }
+}
+
+fun isDangerousAddress(address: InetAddress): Boolean =
+    when (address) {
+        is Inet4Address -> {
+            val octets = address.address.map { it.toInt() and 0xFF }
+            val (a, b, c, d) = octets
+            a == 0 || d == 0 || d == 255 ||                       // unspecified, network, broadcast
+                a == 127 ||                                        // loopback
+                a == 10 ||                                         // private-10/8
+                (a == 172 && b in 16..31) ||                       // private-172.16/12
+                (a == 192 && b == 168) ||                          // private-192.168/16
+                (a == 169 && b == 254) ||                          // link-local
+                (a == 192 && b == 0 && c == 0) ||                  // IETF protocol assignment
+                (a == 198 && b == 18) ||                           // benchmarking-198.18/15
+                a >= 224                                           // multicast + reserved
+        }
+is Inet6Address -> {
+            val bytes = address.address
+            val first = bytes[0].toInt() and 0xFF
+            val isMappedIpv4 = bytes.take(10).all { it == 0.toByte() } &&
+                bytes[10] == 0xFF.toByte() && bytes[11] == 0xFF.toByte()
+            val isLoopback = bytes.last() == 1.toByte() && bytes.dropLast(1).all { it == 0.toByte() }
+            if (isMappedIpv4) {
+                return true // reject IPv4-mapped IPv6 outright
+            }
+            first == 0xFC || first == 0xFD ||             // ULA fc00::/7
+                (first and 0xC0) == 0x80 ||               // link-local fe80::/10
+                first == 0xFF ||                           // multicast ff00::/8
+                bytes.all { it == 0.toByte() } ||         // unspecified ::
+                isLoopback
+        }
+        else -> false
+    }
+
+fun validateImageContent(bytes: ByteArray, declaredType: String) {
+    require(bytes.isNotEmpty()) { "Image is empty" }
+    val typeDeclaredOk = declaredType.isBlank() ||
+        declaredType == "application/octet-stream" ||
+        declaredType.startsWith("image/")
+    require(typeDeclaredOk) { "Image target did not return image content (content-type: $declaredType)" }
+    if (declaredType.isBlank()) {
+        require(sniffsSupportedImage(bytes)) { "Image target did not return a supported image format" }
+    }
+}
+
+fun sniffsSupportedImage(bytes: ByteArray): Boolean {
+    if (bytes.size < 4) return false
+    return when {
+        bytes[0] == 0x89.toByte() && bytes[1] == 'P'.code.toByte() &&
+            bytes[2] == 'N'.code.toByte() && bytes[3] == 'G'.code.toByte() -> true
+        bytes[0] == (-1).toByte() && bytes[1] == (-8).toByte() && bytes[2] == (-1).toByte() -> true // FFD8FF
+        bytes[0] == 'G'.code.toByte() && bytes[1] == 'I'.code.toByte() &&
+            bytes[2] == 'F'.code.toByte() && bytes[3] == '8'.code.toByte() -> true
+        bytes[0] == 'R'.code.toByte() && bytes[1] == 'I'.code.toByte() &&
+            bytes[2] == 'F'.code.toByte() && bytes[3] == 'F'.code.toByte() &&
+            bytes.size > 11 && bytes[8] == 'W'.code.toByte() && bytes[9] == 'E'.code.toByte() &&
+            bytes[10] == 'B'.code.toByte() && bytes[11] == 'P'.code.toByte() -> true
+        bytes[0] == 'B'.code.toByte() && bytes[1] == 'M'.code.toByte() -> true
+        bytes[0] == 0x00.toByte() && bytes[1] == 0x00.toByte() &&
+            (bytes[2] == 1.toByte() || bytes[2] == 2.toByte()) -> true // ICO/CUR
+        else -> prefersSvg(bytes)
+    }
+}
+
+private fun prefersSvg(bytes: ByteArray): Boolean {
+    val prefix = bytes.take(1024).dropWhile { it == ' '.code.toByte() || it == '\t'.code.toByte() ||
+        it == '\n'.code.toByte() || it == '\r'.code.toByte() || it == 0xEF.toByte() }
+    val ascii = prefix.map { it.toInt() and 0xFF }
+    val svgIndex = indexOfIgnoreCase(ascii, listOf('<'.code, 's'.code, 'v'.code, 'g'.code))
+    if (svgIndex < 0) return false
+    // Verify it is the opening `<svg` (allows for an optional XML declaration
+    // and attributes), rather than an unrelated angle bracket comparison.
+    return ascii.drop(svgIndex).take(4) == listOf('<'.code, 's'.code, 'v'.code, 'g'.code)
+}
+
+private fun indexOfIgnoreCase(haystack: List<Int>, needle: List<Int>): Int {
+    if (needle.isEmpty() || haystack.size < needle.size) return -1
+    for (index in 0..haystack.size - needle.size) {
+        if (haystack
+                .subList(index, index + needle.size)
+                .zip(needle)
+                .all { (a, b) -> a == b || (a in 65..90 && a + 32 == b) || (a in 97..122 && a - 32 == b) }
+        ) {
+            return index
+        }
+    }
+    return -1
+}
+
+fun contentTypeForBytes(bytes: ByteArray): String = when {
+    bytes.size >= 4 && bytes[0] == 0x89.toByte() && bytes[1] == 'P'.code.toByte() -> "image/png"
+    bytes.size >= 3 && bytes[0] == (-1).toByte() && bytes[1] == (-8).toByte() -> "image/jpeg"
+    bytes.size >= 4 && bytes[0] == 'G'.code.toByte() && bytes[1] == 'I'.code.toByte() -> "image/gif"
+    bytes.size >= 12 && bytes[0] == 'R'.code.toByte() && bytes[1] == 'I'.code.toByte() -> "image/webp"
+    bytes.size >= 2 && bytes[0] == 'B'.code.toByte() && bytes[1] == 'M'.code.toByte() -> "image/bmp"
+    looksLikeSvg(bytes) -> "image/svg+xml"
+    else -> "image/png"
+}
+
+private fun looksLikeSvg(bytes: ByteArray): Boolean {
+    val needle = listOf('<'.code, 's'.code, 'v'.code, 'g'.code)
+    return indexOfIgnoreCase(bytes.take(1024).map { it.toInt() and 0xFF }, needle) >= 0
+}
+
+private fun bridgeTokenFile(): File {
+    val stateHome = System.getenv("XDG_STATE_HOME")?.takeIf { it.isNotBlank() }
+        ?: File(System.getProperty("user.home"), ".local/state").path
+    return File(File(stateHome, "wingmate"), "bridge-token")
+}
+
+/**
+ * Per-process bridge capability token: prefer the token the Rust driver
+ * injected into the child environment, then reuse the token persisted by the
+ * already-running backend (reuse case), otherwise generate a fresh one.
+ * The resolved token is persisted owner-only for reuse by later processes.
+ */
+private fun resolveBridgeToken(): String {
+    val file = bridgeTokenFile()
+    val envToken = System.getenv("WINGMATE_BRIDGE_TOKEN")?.trim()?.takeIf { it.length >= 16 }
+    val persisted = runCatching { file.readText().trim() }.getOrNull()?.takeIf { it.length >= 16 }
+    if (envToken != null) {
+        if (persisted != envToken) writeBridgeTokenFile(file, envToken)
+        return envToken
+    }
+    if (persisted != null) return persisted
+    val generated = secureRandomToken()
+    writeBridgeTokenFile(file, generated)
+    return generated
+}
+
+private fun writeBridgeTokenFile(file: File, token: String) {
+    runCatching {
+        file.parentFile.mkdirs()
+        val temporary = File(file.parentFile, "${file.name}.tmp")
+        temporary.writeText(token)
+        temporary.setReadable(true, true)
+        temporary.setWritable(true, true)
+        Files.move(temporary.toPath(), file.toPath(), StandardCopyOption.REPLACE_EXISTING)
+    }.onFailure { println("[TOKEN] Could not persist bridge token: ${it.message}") }
+}
+
+fun secureRandomToken(): String {
+    val bytes = ByteArray(32)
+    SecureRandom().nextBytes(bytes)
+    return bytes.joinToString("") { "%02x".format(it) }
 }
 
 private fun sha256(value: String): String = MessageDigest.getInstance("SHA-256")

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -26,11 +26,15 @@ import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.StartupMode
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
 import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
+import io.github.jdreioe.wingmate.domain.obf.ObfButtonActionEffect
+import io.github.jdreioe.wingmate.domain.obf.ObfImage
+import io.github.jdreioe.wingmate.domain.obf.ObfImageSource
+import io.github.jdreioe.wingmate.domain.obf.ObfSymbol
+import io.github.jdreioe.wingmate.domain.obf.resolveObfImageSource
 import io.github.jdreioe.wingmate.domain.obf.backspaceSentenceSelection
 import io.github.jdreioe.wingmate.domain.obf.fieldItems
 import io.github.jdreioe.wingmate.domain.obf.joinSentenceText
 import io.github.jdreioe.wingmate.domain.obf.nGramPredictionInsertion
-import io.github.jdreioe.wingmate.domain.obf.ObfButtonActionEffect
 import io.github.jdreioe.wingmate.domain.obf.orderedPredictionButtonIds
 import io.github.jdreioe.wingmate.domain.obf.pageSettingsOverrides
 import io.github.jdreioe.wingmate.domain.obf.parseObfButtonActions
@@ -706,6 +710,28 @@ class KotlinBridge(private val port: Int = 8765) {
                     call.respond(HttpStatusCode.Created, mapOf("url" to destination.toURI().toString()))
                 } catch (error: Throwable) {
                     call.respond(HttpStatusCode.BadRequest, mapOf("error" to (error.message ?: "image import failed")))
+                }
+            }
+
+            // Resolve a board image's best source into bytes, following the
+            // shared OBF priority order (data → dataUrl → path → url → symbol).
+            post("/api/images/resolve") {
+                try {
+                    val imageElement = json.parseToJsonElement(call.receiveText())
+                        .jsonObject["image"] ?: return@post call.respond(
+                        HttpStatusCode.BadRequest, mapOf("error" to "missing image")
+                    )
+                    val image = json.decodeFromJsonElement<ObfImage>(imageElement)
+                    val resolved = resolveObfImageBytes(image)
+                        ?: return@post call.respond(
+                            HttpStatusCode.NotFound, mapOf("error" to "image has no resolvable source")
+                        )
+                    call.respond(mapOf(
+                        "data" to java.util.Base64.getEncoder().encodeToString(resolved.first),
+                        "contentType" to resolved.second,
+                    ))
+                } catch (error: Throwable) {
+                    call.respond(HttpStatusCode.BadRequest, mapOf("error" to (error.message ?: "image resolve failed")))
                 }
             }
 
@@ -1418,6 +1444,93 @@ fun trustedLocalImageFile(source: String): File? {
 
 private fun fileStorageRoot(): File =
     File(System.getProperty("user.home"), ".wingmate/files")
+
+/**
+ * Materialize an OBF image's bytes, walking the shared priority order
+ * (data → dataUrl → path → url → symbol) and stopping at the first source that
+ * can produce valid pixels. Returns null when no source resolves.
+ */
+fun resolveObfImageBytes(image: ObfImage): Pair<ByteArray, String>? {
+    val declaredType = image.contentType?.takeIf { it.isNotBlank() }
+    return when (val source = resolveObfImageSource(image)) {
+        is ObfImageSource.DataUri -> {
+            val decoded = decodeInlineImage(source.data) ?: return null
+            validateImageContent(decoded.first, declaredType.orEmpty())
+            decoded.first to (declaredType ?: contentTypeForBytes(decoded.first))
+        }
+        is ObfImageSource.Path -> bytesForImagePath(source.path, declaredType)
+        is ObfImageSource.Url -> runCatching { fetchRemoteImageBytes(source.url) }.getOrNull()
+        is ObfImageSource.Symbol -> resolveImageSymbolBytes(source.symbol)
+        ObfImageSource.None -> null
+    }
+}
+
+/** Decodes either a `data:` URI or a raw base64 payload into (bytes, media-type). */
+fun decodeInlineImage(raw: String): Pair<ByteArray, String?>? {
+    val trimmed = raw.trim()
+    if (trimmed.isEmpty()) return null
+    val (payload, mediaType) = runCatching {
+        if (trimmed.startsWith("data:", ignoreCase = true)) {
+            val comma = trimmed.indexOf(',')
+            if (comma < 0) return null
+            val header = trimmed.substring(5, comma)
+            val body = trimmed.substring(comma + 1)
+            val isBase64 = header.lowercase().split(';').any { it == "base64" }
+            val bytes = if (isBase64) {
+                java.util.Base64.getDecoder().decode(body)
+            } else {
+                java.net.URLDecoder.decode(body, Charsets.UTF_8).encodeToByteArray()
+            }
+            bytes to header.substringBefore(';').lowercase().takeIf { it.isNotBlank() }
+        } else {
+            java.util.Base64.getDecoder().decode(trimmed) to null
+        }
+    }.getOrNull() ?: return null
+    if (payload.isEmpty()) return null
+    return payload to mediaType
+}
+
+fun bytesForImagePath(rawPath: String, declaredType: String?): Pair<ByteArray, String>? {
+    val file = trustedLocalImageFile(rawPath) ?: resolveRelativeImagePath(rawPath) ?: return null
+    if (!file.isFile || file.length() > MAX_IMAGE_BYTES) return null
+    val bytes = file.readBytes()
+    return bytes to (declaredType ?: contentTypeForBytes(bytes))
+}
+
+/** Relative OBF media paths ("images/x.png") resolve from the app's trusted data roots. */
+fun resolveRelativeImagePath(rawPath: String): File? {
+    val safe = rawPath.replace('\\', '/')
+    val relative = if (safe.startsWith('/')) safe.trimStart('/') else safe
+    return listOf(imageDataDirectory(), fileStorageRoot()).firstNotNullOfOrNull { root ->
+        val canonicalRoot = runCatching { root.canonicalFile }.getOrNull() ?: return@firstNotNullOfOrNull null
+        val candidate = runCatching { File(canonicalRoot, relative).canonicalFile }.getOrNull()
+            ?: return@firstNotNullOfOrNull null
+        if (candidate.path == canonicalRoot.path || candidate.path.startsWith(canonicalRoot.path + File.separator)) {
+            candidate
+        } else {
+            null
+        }
+    }
+}
+
+/**
+ * Symbol-only boards resolve through a configured OpenSymbols image URL
+ * template so no provider-specific host is hardcoded in the client. The
+ * template receives {library_key}, {set}, and {filename} placeholders.
+ */
+private fun resolveImageSymbolBytes(symbol: ObfSymbol): Pair<ByteArray, String>? {
+    val filename = symbol.filename?.takeIf { it.isNotBlank() } ?: return null
+    val template = System.getenv("WINGMATE_OPENSYMBOLS_IMAGE_URL_TEMPLATE")
+        ?.takeIf { it.isNotBlank() } ?: return null
+    val url = template
+        .replace("{library_key}", symbol.libraryKey?.let(::urlEncodePathSegment).orEmpty())
+        .replace("{set}", symbol.set?.let(::urlEncodePathSegment) ?: "opensymbols")
+        .replace("{filename}", urlEncodePathSegment(filename))
+    return runCatching { fetchRemoteImageBytes(url) }.getOrNull()
+}
+
+private fun urlEncodePathSegment(value: String): String =
+    java.net.URLEncoder.encode(value.replace('/', '_'), Charsets.UTF_8).replace("+", "%20")
 
 fun requireSelectedPath(value: String): File {
     require(value.isNotBlank()) { "Missing file path" }

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -647,16 +647,28 @@ class KotlinBridge(private val port: Int = 8765) {
                     val body = json.parseToJsonElement(call.receiveText()).jsonObject
                     val query = body["query"]?.jsonPrimitive?.contentOrNull ?: ""
                     val locale = body["locale"]?.jsonPrimitive?.contentOrNull ?: "en"
-                    val result = OpenSymbolsClient.search(query, locale)
-                    val symbols = when (result) {
-                        is OpenSymbolsClient.SearchResponse.Success -> result.symbols.map {
-                            mapOf("id" to it.id, "name" to it.name, "imageUrl" to it.image_url)
-                        }
-                        is OpenSymbolsClient.SearchResponse.Failure -> emptyList<Map<String, Any?>>()
+                    when (val result = OpenSymbolsClient.search(query, locale)) {
+                        is OpenSymbolsClient.SearchResponse.Success -> call.respond(
+                            LinuxSymbolSearchResponse(
+                                result.symbols.map {
+                                    LinuxSymbolResult(
+                                        id = it.id,
+                                        name = it.name,
+                                        imageUrl = it.image_url,
+                                    )
+                                }
+                            )
+                        )
+                        is OpenSymbolsClient.SearchResponse.Failure -> call.respond(
+                            HttpStatusCode.ServiceUnavailable,
+                            mapOf("error" to "Symbol search failed: ${result.error}"),
+                        )
                     }
-                    call.respond(mapOf("symbols" to symbols))
                 } catch (error: Throwable) {
-                    call.respond(HttpStatusCode.OK, mapOf("symbols" to emptyList<Map<String, Any?>>()))
+                    call.respond(
+                        HttpStatusCode.InternalServerError,
+                        mapOf("error" to (error.message ?: "Symbol search failed")),
+                    )
                 }
             }
 
@@ -1331,6 +1343,16 @@ data class SpeechStateResponse(
     val playing: Boolean = false,
     val paused: Boolean = false,
     val error: String? = null,
+)
+
+@Serializable
+data class LinuxSymbolSearchResponse(val symbols: List<LinuxSymbolResult>)
+
+@Serializable
+data class LinuxSymbolResult(
+    val id: Long,
+    val name: String,
+    val imageUrl: String? = null,
 )
 
 @Serializable

--- a/linuxApp/src/test/kotlin/io/github/jdreioe/wingmate/kde/BridgeImageResolveTest.kt
+++ b/linuxApp/src/test/kotlin/io/github/jdreioe/wingmate/kde/BridgeImageResolveTest.kt
@@ -1,0 +1,73 @@
+package io.github.jdreioe.wingmate.kde
+
+import io.github.jdreioe.wingmate.domain.obf.ObfImage
+import io.github.jdreioe.wingmate.domain.obf.ObfSymbol
+import io.github.jdreioe.wingmate.domain.obf.obfImageSources
+import io.github.jdreioe.wingmate.domain.obf.resolveObfImageSource
+import io.github.jdreioe.wingmate.domain.obf.ObfImageSource
+import io.github.jdreioe.wingmate.domain.obf.ObfMediaSource
+import java.util.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class BridgeImageResolveTest {
+    private val pngPrefix = byteArrayOf(
+        0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte(), 0x0D, 0x0A, 0x1A, 0x0A,
+    )
+
+    @Test
+    fun `shared priority order is data then dataUrl then path then url then symbol`() {
+        val image = ObfImage(
+            id = "i",
+            data = "AAA=AAAAAAAAAA",
+            dataUrl = "data:image/png;base64,bbbb",
+            path = "images/x.png",
+            url = "https://8.8.8.8/x.png",
+            symbol = ObfSymbol(set = "opensymbols", filename = "cat.svg", libraryKey = "arasaac"),
+        )
+        val sources = obfImageSources(image)
+        assertEquals(ObfMediaSource.Data::class, sources[0]::class)
+        assertEquals(ObfMediaSource.Url::class, sources[1]::class)
+        assertEquals(ObfMediaSource.Path::class, sources[2]::class)
+        assertEquals(ObfMediaSource.Url::class, sources[3]::class)
+        assertEquals(ObfMediaSource.Symbol::class, sources[4]::class)
+        assertEquals(ObfImageSource.DataUri::class, resolveObfImageSource(image)::class)
+    }
+
+    @Test
+    fun `data uri and raw base64 both decode`() {
+        val raw = Base64.getEncoder().encodeToString(pngPrefix)
+        val fromRaw = decodeInlineImage(raw)
+        assertNotNull(fromRaw)
+        assertEquals(pngPrefix.toList(), fromRaw.first.toList())
+        assertEquals(null, fromRaw.second)
+
+        val dataUri = "data:image/png;base64,$raw"
+        val fromDataUri = decodeInlineImage(dataUri)
+        assertNotNull(fromDataUri)
+        assertEquals(pngPrefix.toList(), fromDataUri.first.toList())
+        assertEquals("image/png", fromDataUri.second)
+    }
+
+    @Test
+    fun `garbage inline payloads do not resolve`() {
+        assertEquals(null, decodeInlineImage(""))
+        assertEquals(null, decodeInlineImage("!!not-base64!!"))
+    }
+
+    @Test
+    fun `data source renders without touching the network or filesystem`() {
+        val raw = Base64.getEncoder().encodeToString(pngPrefix)
+        val resolved = resolveObfImageBytes(ObfImage(id = "i", data = raw))
+        assertNotNull(resolved)
+        assertEquals("image/png", resolved.second)
+        assertEquals(pngPrefix.toList(), resolved.first.toList())
+    }
+
+    @Test
+    fun `image with no source does not resolve`() {
+        assertEquals(null, resolveObfImageBytes(ObfImage(id = "empty")))
+    }
+}

--- a/linuxApp/src/test/kotlin/io/github/jdreioe/wingmate/kde/BridgeSecurityTest.kt
+++ b/linuxApp/src/test/kotlin/io/github/jdreioe/wingmate/kde/BridgeSecurityTest.kt
@@ -1,0 +1,89 @@
+package io.github.jdreioe.wingmate.kde
+
+import java.nio.file.Files
+import java.net.URI
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class BridgeSecurityTest {
+    @Test
+    fun `loopback and private-network image targets are rejected`() {
+        assertFalse(isAllowedRemoteTarget(URI("http://127.0.0.1/symbol.png")))
+        assertFalse(isAllowedRemoteTarget(URI("http://localhost/symbol.png")))
+        assertFalse(isAllowedRemoteTarget(URI("http://10.0.0.40/symbol.png")))
+        assertFalse(isAllowedRemoteTarget(URI("http://172.16.5.5/symbol.png")))
+        assertFalse(isAllowedRemoteTarget(URI("http://192.168.1.40/symbol.png")))
+        assertFalse(isAllowedRemoteTarget(URI("http://169.254.169.254/metadata")))
+        assertFalse(isAllowedRemoteTarget(URI("http://[::1]/symbol.png")))
+    }
+
+    @Test
+    fun `public image targets are accepted`() {
+        assertTrue(isAllowedRemoteTarget(URI("https://1.1.1.1/symbol.png")))
+        assertTrue(isAllowedRemoteTarget(URI("https://8.8.8.8/img/a.png?auth=1")))
+        assertTrue(isAllowedRemoteTarget(URI("http://203.0.113.5/x.png")))
+    }
+
+    @Test
+    fun `non-http schemes and bad literal shapes are rejected`() {
+        assertFalse(isAllowedRemoteTarget(URI("file:///etc/passwd")))
+        assertFalse(isAllowedRemoteTarget(URI("ftp://example.org/x.png")))
+        assertFalse(isAllowedRemoteTarget(URI("http:///x.png")))
+        assertFalse(isAllowedRemoteTarget(URI("https:///x.png")))
+        assertFalse(isAllowedRemoteTarget(URI("javascript:alert(1)")))
+    }
+
+    @Test
+    fun `redirect targets are re-validated against the same rules`() {
+        val base = URI("https://8.8.8.8/a.png")
+        assertNotNull(validatedRedirectUri(base, "/b.png"))
+        assertNotNull(validatedRedirectUri(base, "https://1.1.1.1/b.gif"))
+        assertEquals(null, validatedRedirectUri(base, "http://127.0.0.1/steal"))
+        assertEquals(null, validatedRedirectUri(base, "https://192.168.0.4/steal"))
+    }
+
+    @Test
+    fun `html and empty bodies fail content validation`() {
+        assertFailsWith<IllegalArgumentException> {
+            validateImageContent("<html></html>".encodeToByteArray(), "text/html")
+        }
+    }
+
+    @Test
+    fun `png bytes pass content validation`() {
+        assertTrue(sniffsSupportedImage(byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte(), 0x0D, 0x0A)))
+        validateImageContent(
+            byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte(), 0x0D, 0x0A),
+            "",
+        )
+        assertEquals("image/png", contentTypeForBytes(byteArrayOf(0x89.toByte(), 'P'.code.toByte(), 'N'.code.toByte(), 'G'.code.toByte())))
+    }
+
+    @Test
+    fun `unexpected local files are not trusted and selected paths are validated`() {
+        val temp = Files.createTempDirectory("wingmate-security")
+        val inside = temp.resolve("sub").toAbsolutePath().let { Files.createDirectories(it).resolve("x.png") }
+        Files.write(inside, byteArrayOf(1, 2, 3, 4))
+
+        // Only files under the app's own data dirs may be served as local images.
+        assertEquals(null, trustedLocalImageFile(inside.toString()))
+        assertEquals(null, trustedLocalImageFile("file:///etc/passwd"))
+
+        // requireSelectedPath enforces absolute, existing, regular files.
+        assertFailsWith<IllegalArgumentException> { requireSelectedPath("relative/x.png") }
+        assertFailsWith<IllegalArgumentException> { requireSelectedPath("/definitely/missing/file.png") }
+        assertEquals(inside.toFile(), requireSelectedPath(inside.toAbsolutePath().toString()))
+    }
+
+    @Test
+    fun `per-process token is random and sufficiently long`() {
+        val first = secureRandomToken()
+        val second = secureRandomToken()
+        assertEquals(64, first.length)
+        assertTrue(first != second)
+    }
+}

--- a/linuxApp/src/test/kotlin/io/github/jdreioe/wingmate/kde/LinuxFolderCategorySemanticsTest.kt
+++ b/linuxApp/src/test/kotlin/io/github/jdreioe/wingmate/kde/LinuxFolderCategorySemanticsTest.kt
@@ -1,0 +1,37 @@
+package io.github.jdreioe.wingmate.kde
+
+import io.github.jdreioe.wingmate.application.usecase.GetPhrasesAndCategoriesUseCase
+import io.github.jdreioe.wingmate.domain.Phrase
+import java.nio.file.Files
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The Linux bridge keeps categories/folders canonical: a folder is a phrase with
+ * a linkedBoardId (and isGridItem == null), its items are phrases whose parentId
+ * points at the folder, and the shared GetPhrasesAndCategoriesUseCase partitions
+ * the two. This test pins that invariant against the real JSON-file persistence
+ * across a simulated restart.
+ */
+class LinuxFolderCategorySemanticsTest {
+    @Test
+    fun `folder relationship survives restart under the shared category use case`() = runBlocking {
+        val file = Files.createTempDirectory("wingmate-category-semantics-").resolve("phrases.json").toFile()
+        val repository = JsonFilePhraseRepository(file)
+        repository.add(Phrase("folder-pets", "Pets", linkedBoardId = "board-pets", createdAt = 1))
+        repository.add(Phrase("item-cat", "Cat", parentId = "folder-pets", createdAt = 2))
+        repository.add(Phrase("item-dog", "Dog", parentId = "folder-pets", createdAt = 3))
+        repository.add(Phrase("folder-food", "Food", linkedBoardId = "board-food", createdAt = 4))
+
+        val restored = GetPhrasesAndCategoriesUseCase(JsonFilePhraseRepository(file)).invoke()
+
+        val (gridItems, folders) = restored
+        assertEquals(listOf("item-cat", "item-dog"), gridItems.map { it.id })
+        assertEquals(listOf("folder-pets", "folder-food"), folders.map { it.id })
+        assertEquals(
+            listOf("Cat", "Dog"),
+            gridItems.filter { it.parentId == "folder-pets" }.map { it.text },
+        )
+    }
+}

--- a/shared/PLATFORM_NOTES.md
+++ b/shared/PLATFORM_NOTES.md
@@ -20,7 +20,7 @@ Details:
 ## Linux Azure credentials
 
 The Linux client stores Azure Speech configuration in Secret Service/libsecret
-(`secret-tool`) or KWallet (`kwallet-query`). There is no plaintext file fallback:
+(`secret-tool`) or KWallet (through its session D-Bus API). There is no plaintext file fallback:
 when neither secure backend is installed or unlocked, saving fails and the UI must
 ask the user to make a keyring available. Legacy `~/.config/wingmate/config.json`
 is deleted only after a verified secure write.


### PR DESCRIPTION
## Summary

- Consolidate Linux bridge helpers and enforce capability-token security.
- Render OBF images using shared source-priority resolution.
- Pin Linux folder category semantics and update platform parity documentation.
- Remove unsupported iOS/Linux fullscreen and scaling UI paths.

## Testing

- Added bridge security, image resolution, and Linux folder category semantics tests.
- Not run: Android, iOS, Linux, or full Gradle build verification.