### PR TITLE
#119 Add configurable speech policy across platforms

### DIFF
--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -120,7 +120,7 @@ import io.github.jdreioe.wingmate.domain.obf.CellTapResult
 import io.github.jdreioe.wingmate.domain.obf.nGramPredictionInsertion
 import io.github.jdreioe.wingmate.domain.obf.backspaceSentenceSelection
 import io.github.jdreioe.wingmate.domain.obf.shouldAddBoardSelection
-import io.github.jdreioe.wingmate.domain.obf.shouldSpeakBoardSelection
+import io.github.jdreioe.wingmate.domain.obf.shouldSpeakSelectionImmediately
 import io.github.jdreioe.wingmate.domain.obf.applyBoardReturnBehavior
 import io.github.jdreioe.wingmate.domain.obf.buildResolvedSentence
 import io.github.jdreioe.wingmate.domain.obf.orderedPredictionButtonIds
@@ -1483,7 +1483,10 @@ private fun BoardSetWorkspaceScreen(
                                     val sound = button.soundId?.let { id ->
                                         activeBoard.sounds.firstOrNull { it.id == id }
                                     }
-                                    if (shouldSpeakBoardSelection(resolvedBoardSettings.activationBehavior)) {
+                                    if (shouldSpeakSelectionImmediately(
+                                        settings.speechPolicy,
+                                        resolvedBoardSettings.activationBehavior
+                                    )) {
                                         scope.launch(Dispatchers.IO) {
                                             val recordedPath = sound?.path?.takeIf {
                                                 it.isNotBlank() && sound.data.isNullOrBlank() && sound.dataUrl.isNullOrBlank()

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/PhraseScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/PhraseScreen.kt
@@ -58,6 +58,7 @@ import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.domain.CategoryItem
 import io.github.jdreioe.wingmate.domain.Phrase
 import io.github.jdreioe.wingmate.domain.PredictionResult
+import io.github.jdreioe.wingmate.domain.SpeechPolicy
 import io.github.jdreioe.wingmate.domain.SpeechSegment
 import io.github.jdreioe.wingmate.domain.SpeechTextProcessor
 import io.github.jdreioe.wingmate.domain.TextEditingPolicy
@@ -1081,6 +1082,34 @@ fun PhraseScreen(
                             }
                         }
                     }
+                    // #119: unified phrase playback for the grid's explicit play affordance and
+                    // immediate-policy insertion. Plays the recording when present, else TTS.
+                    suspend fun speakPhraseFromGrid(phrase: Phrase) {
+                        val selected = runCatching { voiceUseCase.selected() }.getOrNull()
+                        val textToSpeak = phrase.name?.ifBlank { null } ?: phrase.text
+                        val playedRecorded = phrase.recordingPath?.let { path ->
+                            runCatching {
+                                speechService.speakRecordedAudio(
+                                    audioFilePath = path,
+                                    textForHistory = textToSpeak,
+                                    voice = selected
+                                )
+                            }.getOrDefault(false)
+                        } ?: false
+                        if (!playedRecorded) {
+                            speechService.speak(textToSpeak, selected)
+                        }
+                        featureUsageReporter.reportEvent(
+                            FeatureUsageEvents.PHRASE_PLAYED,
+                            "source" to "grid",
+                            "used_recording" to playedRecorded.toString()
+                        )
+                        // Refresh history from repo
+                        try {
+                            val list = saidRepo.list()
+                            uiScope.launch { historyItems = list.filter { it.visibleInHistory }.sortedByDescending { it.date ?: it.createdAt ?: 0L } }
+                        } catch (_: Throwable) {}
+                    }
                     PhraseGrid(
                         phrases = visiblePhrases,
                         onInsert = { phrase ->
@@ -1097,6 +1126,12 @@ fun PhraseScreen(
                                 FeatureUsageEvents.PHRASE_INSERTED,
                                 "source" to if (phrase.parentId == HistoryCategoryId) "history" else "grid"
                             )
+                            // #119: immediate speech policy also speaks the inserted phrase.
+                            if (settings.speechPolicy == SpeechPolicy.Immediate && phrase.linkedBoardId == null) {
+                                uiScope.launch(Dispatchers.IO) {
+                                    runCatching { speakPhraseFromGrid(phrase) }
+                                }
+                            }
                         },
                         onPlay = { phrase ->
                             // Classic Folder Navigation: if item has a linked board, entering it updates the view
@@ -1111,30 +1146,7 @@ fun PhraseScreen(
                             } else {
                                 uiScope.launch(Dispatchers.IO) {
                                     try {
-                                        val selected = runCatching { voiceUseCase.selected() }.getOrNull()
-                                        val textToSpeak = phrase.name?.ifBlank { null } ?: phrase.text
-                                        val playedRecorded = phrase.recordingPath?.let { path ->
-                                            runCatching {
-                                                speechService.speakRecordedAudio(
-                                                    audioFilePath = path,
-                                                    textForHistory = textToSpeak,
-                                                    voice = selected
-                                                )
-                                            }.getOrDefault(false)
-                                        } ?: false
-                                        if (!playedRecorded) {
-                                            speechService.speak(textToSpeak, selected)
-                                        }
-                                        featureUsageReporter.reportEvent(
-                                            FeatureUsageEvents.PHRASE_PLAYED,
-                                            "source" to "grid",
-                                            "used_recording" to playedRecorded.toString()
-                                        )
-                                        // Refresh history from repo
-                                        try {
-                                            val list = saidRepo.list()
-                                            uiScope.launch { historyItems = list.filter { it.visibleInHistory }.sortedByDescending { it.date ?: it.createdAt ?: 0L } }
-                                        } catch (_: Throwable) {}
+                                        speakPhraseFromGrid(phrase)
                                     } catch (_: Throwable) {}
                                 }
                             }

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
@@ -50,6 +50,7 @@ import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
 import io.github.jdreioe.wingmate.domain.obf.BoardActivationBehavior
 import io.github.jdreioe.wingmate.domain.obf.BoardReturnBehavior
+import io.github.jdreioe.wingmate.domain.SpeechPolicy
 import io.github.jdreioe.wingmate.infrastructure.ArasaacDownloadProgress
 import io.github.jdreioe.wingmate.infrastructure.ArasaacSymbolDownloadService
 import io.github.jdreioe.wingmate.infrastructure.ImageCacher
@@ -128,6 +129,7 @@ fun SettingsScreen(
     var dwellToSelectMillis by remember { mutableStateOf(0L) }
     var selectionSoundEnabled by remember { mutableStateOf(false) }
     var auditoryFishingEnabled by remember { mutableStateOf(false) }
+    var speechPolicy by remember { mutableStateOf(SpeechPolicy.Immediate) }
     var selectionDebounceMillis by remember { mutableStateOf(0L) }
     var selectionHighlightMillis by remember { mutableStateOf(0L) }
     var selectKeyBinding by remember { mutableStateOf("") }
@@ -223,6 +225,7 @@ fun SettingsScreen(
         dwellToSelectMillis = s.dwellToSelectMillis
         selectionSoundEnabled = s.selectionSoundEnabled
         auditoryFishingEnabled = s.auditoryFishingEnabled
+        speechPolicy = s.speechPolicy
         selectionDebounceMillis = s.selectionDebounceMillis
         selectionHighlightMillis = s.selectionHighlightMillis
         selectKeyBinding = s.selectKeyBinding
@@ -524,6 +527,11 @@ fun SettingsScreen(
                                         onSelectionSoundChange = { checked -> selectionSoundEnabled = checked; updateSettings { it.copy(selectionSoundEnabled = checked) } },
                                         auditoryFishingEnabled = auditoryFishingEnabled,
                                         onAuditoryFishingChange = { checked -> auditoryFishingEnabled = checked; updateSettings { it.copy(auditoryFishingEnabled = checked) } },
+                                        speechPolicy = speechPolicy,
+                                        onSpeechPolicyChange = { policy ->
+                                            speechPolicy = policy
+                                            updateSettings { it.copy(speechPolicy = policy) }
+                                        },
                                         selectionDebounceMillis = selectionDebounceMillis,
                                         onSelectionDebounceChange = { selectionDebounceMillis = it },
                                         onSelectionDebounceChangeFinished = { updateSettings { it.copy(selectionDebounceMillis = selectionDebounceMillis) } },
@@ -1441,6 +1449,8 @@ private fun AccessibilitySection(
     onSelectionSoundChange: (Boolean) -> Unit,
     auditoryFishingEnabled: Boolean,
     onAuditoryFishingChange: (Boolean) -> Unit,
+    speechPolicy: SpeechPolicy,
+    onSpeechPolicyChange: (SpeechPolicy) -> Unit,
     selectionDebounceMillis: Long,
     onSelectionDebounceChange: (Long) -> Unit,
     onSelectionDebounceChangeFinished: () -> Unit,
@@ -1517,6 +1527,22 @@ private fun AccessibilitySection(
             checked = selectionSoundEnabled,
             onCheckedChange = onSelectionSoundChange,
             title = stringResource(R.string.ui_settings_selection_sound_title)
+        )
+        SettingsGroupDivider()
+        SettingsChoiceChips(
+            title = stringResource(R.string.ui_settings_speech_policy_title),
+            description = stringResource(R.string.ui_settings_speech_policy_desc),
+            selected = speechPolicy,
+            options = SpeechPolicy.entries,
+            label = { policy ->
+                stringResource(
+                    when (policy) {
+                        SpeechPolicy.Immediate -> R.string.ui_settings_speech_policy_immediate
+                        SpeechPolicy.SentenceOnly -> R.string.ui_settings_speech_policy_sentence_only
+                    }
+                )
+            },
+            onSelect = onSpeechPolicyChange
         )
         SettingsGroupDivider()
         SettingsSwitch(

--- a/androidApp/src/main/res/values-da-rDK/strings.xml
+++ b/androidApp/src/main/res/values-da-rDK/strings.xml
@@ -520,6 +520,10 @@
     <string name="ui_settings_selection_highlight_title">Markeringsfremhævning (ms)</string>
     <string name="ui_settings_selection_highlight_desc">Vis en kort ramme efter at have valgt en knap. Sæt til 0 for at deaktivere.</string>
     <string name="ui_settings_selection_sound_title">Markeringslyd</string>
+    <string name="ui_settings_speech_policy_title">Tale ved valg</string>
+    <string name="ui_settings_speech_policy_desc">Tal hver valgte enhed med det samme, eller hold dig tavs indtil den sammensatte sætning aktiveres.</string>
+    <string name="ui_settings_speech_policy_immediate">Straks</string>
+    <string name="ui_settings_speech_policy_sentence_only">Kun sætning</string>
     <string name="ui_settings_auditory_fishing_title">Auditiv bekræftelse</string>
     <string name="ui_settings_auditory_fishing_desc">Hvisk mærkaten når en knap berøres eller holdes over.</string>
     <string name="ui_settings_usage_logging_title">Standardiseret logning (OBL)</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -547,6 +547,10 @@
     <string name="ui_settings_selection_highlight_title">Selection highlight (ms)</string>
     <string name="ui_settings_selection_highlight_desc">Show a brief outline after selecting a button. Set to 0 to disable.</string>
     <string name="ui_settings_selection_sound_title">Selection sound</string>
+    <string name="ui_settings_speech_policy_title">Speech on select</string>
+    <string name="ui_settings_speech_policy_desc">Speak each selection immediately, or stay silent until the composed sentence is activated.</string>
+    <string name="ui_settings_speech_policy_immediate">Immediate</string>
+    <string name="ui_settings_speech_policy_sentence_only">Sentence only</string>
     <string name="ui_settings_auditory_fishing_title">Auditory fishing</string>
     <string name="ui_settings_auditory_fishing_desc">Whisper the label when a button is hovered or touched.</string>
     <string name="ui_settings_usage_logging_title">Standardized logging (OBL)</string>

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/model.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/model.kt
@@ -2,7 +2,28 @@ package io.github.jdreioe.wingmate.domain
 
 import io.github.jdreioe.wingmate.domain.obf.BoardActivationBehavior
 import io.github.jdreioe.wingmate.domain.obf.BoardReturnBehavior
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+
+/**
+ * How selections speak while the user composes, applied as a global access
+ * preference across every native client.
+ *
+ * - [Immediate]: each applicable selection (phrase, board button, recording)
+ *   speaks as it is selected.
+ * - [SentenceOnly]: composition is silent; speech happens only when the
+ *   constructed sentence is explicitly activated (the [`:speak` action] or the
+ *   sentence-bar speak button). Helpers such as auditory fishing, button
+ *   previews, and scanning prompts are documented exceptions and still speak.
+ */
+@Serializable
+enum class SpeechPolicy {
+    @SerialName("immediate")
+    Immediate,
+
+    @SerialName("sentence_only")
+    SentenceOnly
+}
 
 @Serializable
 data class Phrase(
@@ -115,6 +136,9 @@ data class Settings(
     val pointerEmphasisScale: Float = 1.5f,
     val selectionSoundEnabled: Boolean = false,
     val auditoryFishingEnabled: Boolean = false,
+    // #119: immediate speech on each selection versus keeping composition silent
+    // until the constructed sentence is activated.
+    val speechPolicy: SpeechPolicy = SpeechPolicy.Immediate,
     // #118: ignore repeated activations of the same target inside this window (ms). 0 disables.
     val selectionDebounceMillis: Long = 0,
     // #120: show a time-bounded visual highlight on the last selected target (ms). 0 disables.

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/BoardSessionLogic.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/BoardSessionLogic.kt
@@ -1,5 +1,7 @@
 package io.github.jdreioe.wingmate.domain.obf
 
+import io.github.jdreioe.wingmate.domain.SpeechPolicy
+
 /**
  * Shared board-session logic used identically by every native client
  * (Android Compose, iOS SwiftUI, Linux). Keeping these here means prediction
@@ -30,6 +32,19 @@ fun shouldAddBoardSelection(behavior: BoardActivationBehavior): Boolean =
 /** Whether the activation behavior speaks the selection. */
 fun shouldSpeakBoardSelection(behavior: BoardActivationBehavior): Boolean =
     behavior != BoardActivationBehavior.AddOnly
+
+/**
+ * Whether a single selection speaks immediately, honoring the global speech
+ * policy. In immediate mode the selection's activation behavior decides; in
+ * sentence-only mode nothing speaks while composing. Applies identically to
+ * OBF buttons, recorded sounds, and phrase-grid selections.
+ */
+fun shouldSpeakSelectionImmediately(policy: SpeechPolicy, behavior: BoardActivationBehavior): Boolean =
+    policy == SpeechPolicy.Immediate && shouldSpeakBoardSelection(behavior)
+
+/** Convenience for phrase-grid selections, which carry no board-level behavior. */
+fun shouldSpeakPhraseSelection(policy: SpeechPolicy): Boolean =
+    policy == SpeechPolicy.Immediate
 
 /**
  * Resolve the board to show after a selection, given the return behavior and the

--- a/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/SpeechPolicyTest.kt
+++ b/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/SpeechPolicyTest.kt
@@ -1,0 +1,98 @@
+package io.github.jdreioe.wingmate.domain.obf
+
+import io.github.jdreioe.wingmate.domain.Settings
+import io.github.jdreioe.wingmate.domain.SpeechPolicy
+import io.github.jdreioe.wingmate.domain.TtsEngine
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * #119 — immediate versus composed-sentence speech.
+ *
+ * The single shared gate [shouldSpeakSelectionImmediately] decides both text
+ * and recorded-sound playback on every native client, so the matrix below is
+ * the source of truth for phrases, OBF buttons, and recordings.
+ */
+class SpeechPolicyTest {
+
+    @Test
+    fun immediatePolicySpeaksSpeakableBoardBehaviors() {
+        assertTrue(
+            shouldSpeakSelectionImmediately(SpeechPolicy.Immediate, BoardActivationBehavior.SpeakAndAdd)
+        )
+        assertTrue(
+            shouldSpeakSelectionImmediately(SpeechPolicy.Immediate, BoardActivationBehavior.SpeakOnly)
+        )
+        // A board that opts out of speech stays silent even in immediate mode.
+        assertFalse(
+            shouldSpeakSelectionImmediately(SpeechPolicy.Immediate, BoardActivationBehavior.AddOnly)
+        )
+    }
+
+    @Test
+    fun sentenceOnlyPolicyNeverSpeaksDuringComposition() {
+        BoardActivationBehavior.entries.forEach { behavior ->
+            assertFalse(
+                shouldSpeakSelectionImmediately(SpeechPolicy.SentenceOnly, behavior),
+                "SentenceOnly must stay silent for $behavior"
+            )
+        }
+    }
+
+    @Test
+    fun phraseSelectionsFollowTheSamePolicy() {
+        assertTrue(shouldSpeakPhraseSelection(SpeechPolicy.Immediate))
+        assertFalse(shouldSpeakPhraseSelection(SpeechPolicy.SentenceOnly))
+    }
+
+    @Test
+    fun compositionStillAddsSelectionsInEveryMode() {
+        // Sentence construction stays correct regardless of the speech policy.
+        assertEquals(
+            true,
+            shouldAddBoardSelection(BoardActivationBehavior.SpeakAndAdd)
+        )
+        assertTrue(shouldAddBoardSelection(BoardActivationBehavior.AddOnly))
+        assertFalse(shouldAddBoardSelection(BoardActivationBehavior.SpeakOnly))
+    }
+
+    @Test
+    fun nonSpeechActionsNeverProduceASpeakEffect() {
+        listOf(":space", ":backspace", ":clear", ":home", ":native-keyboard", ":prediction")
+            .forEach { action ->
+                assertFalse(
+                    parseObfButtonAction(action) === ObfButtonActionEffect.Speak,
+                    "$action must never produce a Speak effect"
+                )
+            }
+    }
+
+    @Test
+    fun speakActionAlwaysSpeaksTheSentence() {
+        // Explicit sentence activation is the one speech path that ignores the policy.
+        assertTrue(parseObfButtonAction(":speak") === ObfButtonActionEffect.Speak)
+    }
+
+    @Test
+    fun defaultPolicyIsImmediateAndRoundTripsThroughSettingsJson() {
+        assertEquals(SpeechPolicy.Immediate, Settings().speechPolicy)
+
+        val json = Json { ignoreUnknownKeys = true }
+        val settings = Settings(
+            ttsEngine = TtsEngine.SYSTEM,
+            speechPolicy = SpeechPolicy.SentenceOnly
+        )
+        val roundTripped = json.decodeFromString<Settings>(
+            json.encodeToString(Settings.serializer(), settings)
+        )
+        assertEquals(SpeechPolicy.SentenceOnly, roundTripped.speechPolicy)
+        // An existing saved setting without the new field keeps the immediate default.
+        assertEquals(
+            SpeechPolicy.Immediate,
+            json.decodeFromString<Settings>("{}").speechPolicy
+        )
+    }
+}

--- a/iosApp/iosApp/Base.lproj/Localizable.strings
+++ b/iosApp/iosApp/Base.lproj/Localizable.strings
@@ -221,6 +221,9 @@
 "settings.accessibility.feedback" = "Feedback & Logging";
 "settings.accessibility.selection_sound" = "Selection Sound";
 "settings.accessibility.auditory_fishing" = "Auditory Fishing";
+"settings.speech_policy.title" = "Speech When Selecting";
+"settings.speech_policy.immediate" = "Immediate";
+"settings.speech_policy.sentence_only" = "Sentence Only";
 "settings.accessibility.usage_logging" = "Standardized Logging (OBL)";
 "settings.general.startup" = "Open at Startup";
 "settings.general.startup_mode" = "Startup Mode";

--- a/iosApp/iosApp/ViewModels/IosViewModel.swift
+++ b/iosApp/iosApp/ViewModels/IosViewModel.swift
@@ -141,6 +141,8 @@ final class IosViewModel: ObservableObject {
     @Published var selectionDebounceMillis: Double = 0
     @Published var selectionSoundEnabled: Bool = false
     @Published var auditoryFishingEnabled: Bool = false
+    // #119: legacy immediate speech per selection, or sentence-only composition.
+    @Published var speechPolicy: String = "Immediate"
     @Published var selectKeyBinding: String = ""
     @Published var restModeKeyBinding: String = ""
     @Published var pointerEmphasisStyle: String = "System"
@@ -475,6 +477,7 @@ final class IosViewModel: ObservableObject {
                 self.selectionDebounceMillis = Double(settings.selectionDebounceMillis)
                 self.selectionSoundEnabled = settings.selectionSoundEnabled
                 self.auditoryFishingEnabled = settings.auditoryFishingEnabled
+                self.speechPolicy = settings.speechPolicy.name
                 self.selectKeyBinding = settings.selectKeyBinding
                 self.restModeKeyBinding = settings.restModeKeyBinding
                 self.pointerEmphasisStyle = settings.pointerEmphasisStyle.name
@@ -566,6 +569,10 @@ final class IosViewModel: ObservableObject {
         isApplyingSentencePhraseInput = true
         onInputChanged(input)
         isApplyingSentencePhraseInput = false
+        // #119: immediate speech policy speaks each inserted phrase as it is composed.
+        if speechPolicy == "Immediate" {
+            speak(title)
+        }
         #if DEBUG
         // Incremental learning for development builds with predictions enabled.
         Task { _ = try? await bridge.learnPhrase(text: t) }
@@ -1011,6 +1018,18 @@ final class IosViewModel: ObservableObject {
     func setAuditoryFishingEnabled(_ enabled: Bool) {
         auditoryFishingEnabled = enabled
         Task { _ = try? await bridge.updateAuditoryFishingEnabled(enabled: enabled) }
+    }
+
+    func setSpeechPolicy(_ policy: String) {
+        guard policy == "Immediate" || policy == "SentenceOnly" else { return }
+        speechPolicy = policy
+        Task { _ = try? await bridge.updateSpeechPolicy(policy: policy) }
+    }
+
+    /// Whether a single board/button selection speaks immediately, honoring the
+    /// global speech policy and the resolved board activation behavior.
+    var shouldSpeakSelectionImmediately: Bool {
+        bridge.speechPolicySpeaksSelection(policy: speechPolicy, behavior: boardActivationBehavior)
     }
 
     func setBoardShowMessageBar(_ enabled: Bool) {

--- a/iosApp/iosApp/Views/SettingsView.swift
+++ b/iosApp/iosApp/Views/SettingsView.swift
@@ -366,6 +366,13 @@ private struct AccessibilitySettingsView: View {
                 Toggle("settings.accessibility.selection_sound", isOn: Binding(
                     get: { model.selectionSoundEnabled }, set: { model.setSelectionSoundEnabled($0) }
                 ))
+                Picker("settings.speech_policy.title", selection: Binding(
+                    get: { model.speechPolicy }, set: { model.setSpeechPolicy($0) }
+                )) {
+                    Text("settings.speech_policy.immediate").tag("Immediate")
+                    Text("settings.speech_policy.sentence_only").tag("SentenceOnly")
+                }
+                .pickerStyle(.menu)
                 Toggle("settings.accessibility.auditory_fishing", isOn: Binding(
                     get: { model.auditoryFishingEnabled }, set: { model.setAuditoryFishingEnabled($0) }
                 ))

--- a/iosApp/iosApp/Views/SymbolBoardWorkspaceView.swift
+++ b/iosApp/iosApp/Views/SymbolBoardWorkspaceView.swift
@@ -1490,8 +1490,8 @@ struct SymbolBoardWorkspaceView: View {
         if cell.actions.isEmpty {
             let behavior = model.boardActivationBehavior
             let shouldAdd = behavior != "SpeakOnly"
-            let shouldSpeak = behavior != "AddOnly"
-            if let sound = trimmed(cell.soundDataUrl) {
+            let shouldSpeak = model.shouldSpeakSelectionImmediately
+            if shouldSpeak, let sound = trimmed(cell.soundDataUrl) {
                 model.playBoardButtonSound(sound)
             }
             if shouldAdd {

--- a/iosApp/iosApp/da.lproj/Localizable.strings
+++ b/iosApp/iosApp/da.lproj/Localizable.strings
@@ -413,6 +413,9 @@
 "settings.accessibility.feedback" = "Feedback og logning";
 "settings.accessibility.selection_sound" = "Lyd ved valg";
 "settings.accessibility.auditory_fishing" = "Auditiv søgning";
+"settings.speech_policy.title" = "Tale ved valg";
+"settings.speech_policy.immediate" = "Straks";
+"settings.speech_policy.sentence_only" = "Kun sætning";
 "settings.accessibility.usage_logging" = "Standardiseret logning (OBL)";
 "settings.general.startup" = "Åbn ved opstart";
 "settings.general.startup_mode" = "Opstartstilstand";

--- a/iosApp/iosApp/de.lproj/Localizable.strings
+++ b/iosApp/iosApp/de.lproj/Localizable.strings
@@ -410,6 +410,9 @@
 "settings.accessibility.feedback" = "Feedback & Protokollierung";
 "settings.accessibility.selection_sound" = "Auswahlton";
 "settings.accessibility.auditory_fishing" = "Akustische Suche";
+"settings.speech_policy.title" = "Sprache beim Auswählen";
+"settings.speech_policy.immediate" = "Sofort";
+"settings.speech_policy.sentence_only" = "Nur Satz";
 "settings.accessibility.usage_logging" = "Standardisierte Protokollierung (OBL)";
 "settings.general.startup" = "Beim Start öffnen";
 "settings.general.startup_mode" = "Startmodus";

--- a/linuxApp/i18n/da/wingmate.ftl
+++ b/linuxApp/i18n/da/wingmate.ftl
@@ -163,6 +163,7 @@ display-button-scale = Knapstørrelse
 display-input-scale = Størrelse på inputfelt
 access-selection-timing = Valgtiming
 access-selection-sound = Afspil en lyd ved valg
+access-speech-policy = Tale ved valg
 access-auditory-cue = Afspil et signal, mens valgmuligheder udforskes
 access-switch-scanning = Kontaktscanning
 access-enable-scanning = Aktivér scanning (Mellemrum eller Enter vælger)

--- a/linuxApp/i18n/en/wingmate.ftl
+++ b/linuxApp/i18n/en/wingmate.ftl
@@ -163,6 +163,7 @@ display-button-scale = Button size
 display-input-scale = Input field size
 access-selection-timing = Selection timing
 access-selection-sound = Play a sound when selected
+access-speech-policy = Speech when selecting
 access-auditory-cue = Play a cue while exploring choices
 access-switch-scanning = Switch scanning
 access-enable-scanning = Enable scanning (Space or Enter selects)

--- a/linuxApp/src/main.rs
+++ b/linuxApp/src/main.rs
@@ -261,6 +261,7 @@ struct Settings {
     pointer_emphasis_scale: f32,
     selection_sound_enabled: bool,
     auditory_fishing_enabled: bool,
+    speech_policy: String,
     selection_highlight_millis: i64,
     selection_debounce_millis: i64,
     startup_board_set_id: Option<String>,
@@ -310,6 +311,7 @@ impl Default for Settings {
             pointer_emphasis_scale: 1.5,
             selection_sound_enabled: false,
             auditory_fishing_enabled: false,
+            speech_policy: "Immediate".into(),
             selection_highlight_millis: 0,
             selection_debounce_millis: 0,
             startup_board_set_id: None,
@@ -663,6 +665,8 @@ enum AccessTarget {
     Recording(String),
     BoardButton(String, String),
     Category(Option<String>),
+    /// Sentence-only composition: append text to the draft without speaking.
+    Insert(String),
 }
 
 fn access_target_id(target: &AccessTarget) -> String {
@@ -2195,6 +2199,7 @@ impl cosmic::Application for Wingmate {
                     "selectKeyBinding" => self.settings.select_key_binding = value.clone(),
                     "restModeKeyBinding" => self.settings.rest_mode_key_binding = value.clone(),
                     "pointerEmphasisStyle" => self.settings.pointer_emphasis_style = value.clone(),
+                    "speechPolicy" => self.settings.speech_policy = value.clone(),
                     _ => {}
                 }
                 return self.api.patch_setting(key, serde_json::json!(value)).map(cosmic::Action::App);
@@ -3043,6 +3048,37 @@ impl Wingmate {
         }
     }
 
+    /// Compose silently: append text to the draft with word spacing.
+    fn compose_phrase(&mut self, text: &str) {
+        let text = text.trim();
+        if text.is_empty() {
+            return;
+        }
+        if !self.draft.is_empty() && !self.draft.ends_with(' ') {
+            self.draft.push(' ');
+        }
+        self.draft.push_str(text);
+    }
+
+    /// Resolve a phrase's access target, honoring the global speech policy.
+    /// Sentence-only mode composes silently instead of speaking on selection;
+    /// linked-board phrases always navigate.
+    fn phrase_access_target(&self, phrase: &Phrase) -> AccessTarget {
+        if let Some(id) = phrase.linked_board_id.clone() {
+            return AccessTarget::Category(Some(id));
+        }
+        let spoken = phrase.name.clone().unwrap_or_else(|| phrase.text.clone());
+        if self.settings.speech_policy == "SentenceOnly" {
+            AccessTarget::Insert(spoken)
+        } else {
+            phrase
+                .recording_path
+                .clone()
+                .map(AccessTarget::Recording)
+                .unwrap_or_else(|| AccessTarget::Speak(spoken))
+        }
+    }
+
     fn activate_access(&mut self, target: AccessTarget) -> Task<cosmic::Action<Message>> {
         let debounce = Duration::from_millis(self.settings.selection_debounce_millis.max(0) as u64);
         if self
@@ -3066,6 +3102,11 @@ impl Wingmate {
             AccessTarget::Recording(path) => {
                 self.status = fl!("status-playing-recording");
                 play_audio_file(path).map(cosmic::Action::App)
+            }
+            AccessTarget::Insert(text) => {
+                self.compose_phrase(&text);
+                self.partner.update_text(self.draft.clone());
+                Task::none()
             }
             AccessTarget::BoardButton(board_id, button_id) => self
                 .api
@@ -3099,20 +3140,7 @@ impl Wingmate {
                 }
                 if self.settings.scan_phrase_grid_enabled {
                     targets.extend(self.phrases.iter().filter(|phrase| !phrase.is_hidden).map(
-                        |phrase| {
-                            phrase
-                                .linked_board_id
-                                .clone()
-                                .map(|id| AccessTarget::Category(Some(id)))
-                                .or_else(|| {
-                                    phrase.recording_path.clone().map(AccessTarget::Recording)
-                                })
-                                .unwrap_or_else(|| {
-                                    AccessTarget::Speak(
-                                        phrase.name.clone().unwrap_or_else(|| phrase.text.clone()),
-                                    )
-                                })
-                        },
+                        |phrase| self.phrase_access_target(phrase),
                     ));
                 }
                 targets
@@ -3451,13 +3479,7 @@ impl Wingmate {
             let mut grid_row = row![].spacing(10);
             for phrase in chunk {
                 let label = phrase.text.clone();
-                let spoken = phrase.name.clone().unwrap_or_else(|| phrase.text.clone());
-                let access_target = phrase
-                    .linked_board_id
-                    .clone()
-                    .map(|id| AccessTarget::Category(Some(id)))
-                    .or_else(|| phrase.recording_path.clone().map(AccessTarget::Recording))
-                    .unwrap_or_else(|| AccessTarget::Speak(spoken));
+                let access_target = self.phrase_access_target(phrase);
                 let show_symbol = phrase.image_url.is_some() && self.settings.show_symbols;
                 let show_label = self.settings.show_labels || !show_symbol;
                 let mut phrase_content = column![]
@@ -5227,6 +5249,16 @@ impl Wingmate {
                     )
                     .step(100)
                     .width(240)
+                ]
+                .spacing(10),
+                row![
+                    text(fl!("access-speech-policy")).width(Fill),
+                    pick_list(
+                        vec!["Immediate".to_string(), "SentenceOnly".to_string()],
+                        Some(self.settings.speech_policy.clone()),
+                        |value| Message::SettingString("speechPolicy", value),
+                    )
+                    .width(180),
                 ]
                 .spacing(10),
                 checkbox(self.settings.selection_sound_enabled)

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -46,6 +46,7 @@ import io.github.jdreioe.wingmate.domain.obf.resolveBoardSettings
 import io.github.jdreioe.wingmate.domain.obf.resolveObfLocalizedString
 import io.github.jdreioe.wingmate.domain.obf.shouldAddBoardSelection
 import io.github.jdreioe.wingmate.domain.obf.shouldSpeakBoardSelection
+import io.github.jdreioe.wingmate.domain.obf.shouldSpeakSelectionImmediately
 import io.github.jdreioe.wingmate.domain.obf.BoardActivationBehavior
 import io.github.jdreioe.wingmate.domain.obf.BoardReturnBehavior
 import io.github.jdreioe.wingmate.domain.obf.BoardSettingsOverrides
@@ -336,6 +337,11 @@ class KotlinBridge(private val port: Int = 8765) {
                 jsonObj["selectionHighlightMillis"]?.jsonPrimitive?.longOrNull?.let { newSettings = newSettings.copy(selectionHighlightMillis = it.coerceAtLeast(0)) }
                 jsonObj["selectionSoundEnabled"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(selectionSoundEnabled = it) }
                 jsonObj["auditoryFishingEnabled"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(auditoryFishingEnabled = it) }
+                jsonObj["speechPolicy"]?.jsonPrimitive?.contentOrNull?.let { value ->
+                    newSettings = newSettings.copy(speechPolicy = runCatching {
+                        io.github.jdreioe.wingmate.domain.SpeechPolicy.valueOf(value)
+                    }.getOrDefault(newSettings.speechPolicy))
+                }
                 jsonObj["usageLoggingEnabled"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(usageLoggingEnabled = it) }
                 jsonObj["historyVisible"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(historyVisible = it) }
                 jsonObj["boardShowMessageBar"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(boardShowMessageBar = it) }
@@ -1185,7 +1191,10 @@ class KotlinBridge(private val port: Int = 8765) {
                             }
                             if (
                                 text.isNotEmpty() &&
-                                shouldSpeakBoardSelection(resolved.activationBehavior)
+                                shouldSpeakSelectionImmediately(
+                                    appSettings.speechPolicy,
+                                    resolved.activationBehavior
+                                )
                             ) {
                                 speakText = text
                             }

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
@@ -22,6 +22,7 @@ import io.github.jdreioe.wingmate.domain.SpeechServiceConfigStatus
 import io.github.jdreioe.wingmate.domain.SpeechTextProcessor
 import io.github.jdreioe.wingmate.domain.SpeechSegment
 import io.github.jdreioe.wingmate.domain.Settings
+import io.github.jdreioe.wingmate.domain.SpeechPolicy
 import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.domain.PointerEmphasisStyle
 import io.github.jdreioe.wingmate.domain.Voice
@@ -51,6 +52,7 @@ import io.github.jdreioe.wingmate.domain.obf.joinSentenceText
 import io.github.jdreioe.wingmate.domain.obf.buttonSpeechPart
 import io.github.jdreioe.wingmate.domain.obf.shouldAddBoardSelection
 import io.github.jdreioe.wingmate.domain.obf.shouldSpeakBoardSelection
+import io.github.jdreioe.wingmate.domain.obf.shouldSpeakSelectionImmediately
 import io.github.jdreioe.wingmate.domain.obf.applyBoardReturnBehavior
 import io.github.jdreioe.wingmate.domain.obf.buildResolvedSentence
 import io.github.jdreioe.wingmate.domain.obf.backspaceSentenceSelection
@@ -212,6 +214,19 @@ class KoinBridge : KoinComponent {
     suspend fun updateSelectionSoundEnabled(enabled: Boolean) = updateSettings { it.copy(selectionSoundEnabled = enabled) }
     suspend fun updateAuditoryFishingEnabled(enabled: Boolean) = updateSettings { it.copy(auditoryFishingEnabled = enabled) }
     suspend fun updateSelectionHighlightMillis(millis: Long) = updateSettings { it.copy(selectionHighlightMillis = millis.coerceIn(0, 5_000)) }
+    suspend fun updateSpeechPolicy(policy: String) = updateSettings {
+        it.copy(speechPolicy = runCatching { SpeechPolicy.valueOf(policy) }.getOrDefault(SpeechPolicy.Immediate))
+    }
+    /**
+     * Whether a single selection should speak immediately, given the global
+     * speech policy and the resolved board activation behavior. Sentence-only
+     * never speaks during composition.
+     */
+    fun speechPolicySpeaksSelection(policy: String, behavior: String): Boolean =
+        shouldSpeakSelectionImmediately(
+            policy = runCatching { SpeechPolicy.valueOf(policy) }.getOrDefault(SpeechPolicy.Immediate),
+            behavior = behavior.toBoardActivationBehavior()
+        )
 
     fun accessInputEnter(targetId: String): IosAccessInputResult {
         accessInput.targetEntered(targetId, nowMillis())


### PR DESCRIPTION
## Summary

- Add Immediate and Sentence Only speech policies to shared settings.
- Apply the policy consistently across Android, iOS, and Linux phrase and board selection.
- Add localized settings controls and shared policy coverage tests.

## Testing

- Added shared `SpeechPolicyTest` coverage for policy behavior, defaults, and JSON round-tripping.
- Not run: Android, iOS, and Linux builds.