### PR TITLE
Add automatic word-type colors and improve pause control

### DIFF
--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetDialogs.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetDialogs.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
 import io.github.jdreioe.wingmate.domain.obf.ObfButtonShape
 import io.github.jdreioe.wingmate.domain.obf.ObfKeyboardLayout
+import io.github.jdreioe.wingmate.domain.obf.WordType
 import io.github.jdreioe.wingmate.application.KeyboardPreset
 import io.github.jdreioe.wingmate.domain.PhraseRecordingService
 import io.github.jdreioe.wingmate.infrastructure.ImageCacher
@@ -58,6 +59,16 @@ private fun ObfButtonShape.labelRes(): Int = when (this) {
     ObfButtonShape.Pill -> R.string.board_dialog_shape_pill
     ObfButtonShape.Speech -> R.string.board_dialog_shape_speech
     ObfButtonShape.Thought -> R.string.board_dialog_shape_thought
+}
+
+@StringRes
+private fun WordType.labelRes(): Int = when (this) {
+    WordType.Pronoun -> R.string.board_dialog_word_type_pronoun
+    WordType.Verb -> R.string.board_dialog_word_type_verb
+    WordType.Descriptor -> R.string.board_dialog_word_type_descriptor
+    WordType.Noun -> R.string.board_dialog_word_type_noun
+    WordType.Social -> R.string.board_dialog_word_type_social
+    WordType.Other -> R.string.board_dialog_word_type_other
 }
 
 /** Small, literal previews make the authoring choice understandable without
@@ -276,6 +287,7 @@ internal fun EditBoardCellDialog(
     initialMathMode: Boolean = false,
     initialHidden: Boolean = false,
     initialShape: ObfButtonShape = ObfButtonShape.Rounded,
+    initialWordType: WordType? = null,
     isKeyboardBoard: Boolean = false,
     showMathMode: Boolean = true,
     availableBoards: List<ObfBoard> = emptyList(),
@@ -296,7 +308,8 @@ internal fun EditBoardCellDialog(
         linkedBoardId: String?,
         action: String?,
         actions: List<String>,
-        shape: ObfButtonShape
+        shape: ObfButtonShape,
+        wordType: WordType?
     ) -> Unit,
     onClearCell: () -> Unit
 ) {
@@ -308,6 +321,7 @@ internal fun EditBoardCellDialog(
     var recordingError by remember { mutableStateOf<String?>(null) }
     var backgroundColor by remember { mutableStateOf(initialBackgroundColor) }
     var shape by remember { mutableStateOf(initialShape) }
+    var wordType by remember { mutableStateOf(initialWordType) }
     var language by remember { mutableStateOf(initialLanguage) }
     var mathMode by remember { mutableStateOf(initialMathMode) }
     var hidden by remember { mutableStateOf(initialHidden) }
@@ -444,6 +458,29 @@ internal fun EditBoardCellDialog(
                         )
                     }
                     Switch(checked = hidden, onCheckedChange = { hidden = it })
+                }
+
+                Text(
+                    stringResource(R.string.board_dialog_word_type),
+                    style = MaterialTheme.typography.labelLarge
+                )
+                FlowRow(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    FilterChip(
+                        selected = wordType == null,
+                        onClick = { wordType = null },
+                        label = { Text(stringResource(R.string.board_dialog_word_type_automatic)) }
+                    )
+                    WordType.entries.forEach { type ->
+                        FilterChip(
+                            selected = wordType == type,
+                            onClick = { wordType = type },
+                            label = { Text(stringResource(type.labelRes())) }
+                        )
+                    }
                 }
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedButton(onClick = { showImageSourcePicker = true }) {
@@ -762,7 +799,8 @@ TextButton(
                                 linkedBoardId.takeIf { opensPage },
                                 normalized.singleOrNull(),
                                 if (normalized.size > 1) normalized else emptyList(),
-                                shape
+                                shape,
+                                wordType
                             )
                         },
                 enabled = label.isNotBlank() && (!opensPage || linkedBoardId != null)

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -100,6 +100,7 @@ import io.github.jdreioe.wingmate.domain.obf.ObfButton
 import io.github.jdreioe.wingmate.domain.obf.ObfButtonActionEffect
 import io.github.jdreioe.wingmate.domain.obf.ObfButtonType
 import io.github.jdreioe.wingmate.domain.obf.ObfButtonShape
+import io.github.jdreioe.wingmate.domain.obf.wordType
 import io.github.jdreioe.wingmate.domain.obf.ObfGrid
 import io.github.jdreioe.wingmate.domain.obf.ObfImage
 import io.github.jdreioe.wingmate.domain.obf.ObfKeyboardLayout
@@ -1685,6 +1686,7 @@ private fun BoardSetWorkspaceScreen(
             initialMathMode = target.button?.mathMode == true,
             initialHidden = target.button?.hidden == true,
             initialShape = target.button?.shape ?: ObfButtonShape.Rounded,
+            initialWordType = target.button?.wordType,
             isKeyboardBoard = activeBoard.isKeyboard,
             showMathMode = supportsMathMode(settings.ttsEngine),
             availableBoards = activeGraph.boards.filterNot { it.id == activeBoard.id },
@@ -1694,7 +1696,7 @@ private fun BoardSetWorkspaceScreen(
             hasExistingValue = target.button != null,
             onDismiss = { editingCell = null },
             onSave = { label, vocalization, imageUrl, recordingPath, backgroundColor, language, mathMode, hidden, linkedBoardId,
-                       action, actions, shape ->
+                       action, actions, shape, wordType ->
                 val session = editSession ?: return@EditBoardCellDialog
                 editSession = session.apply(
                     updateDraftCell(
@@ -1713,7 +1715,8 @@ private fun BoardSetWorkspaceScreen(
                         linkedBoardId = linkedBoardId,
                         action = action,
                         actions = actions,
-                        shape = shape
+                        shape = shape,
+                        wordType = wordType
                     )
                 )
                 editingCell = null

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/InteractionInput.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/InteractionInput.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material3.Button
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -163,22 +163,24 @@ fun InteractionInputRoot(settings: Settings, enabled: Boolean = true, content: @
         ) {
             content()
             if (enabled && (settings.dwellToSelectMillis > 0 || settings.selectKeyBinding.isNotBlank())) {
-                Button(
+                FloatingActionButton(
                     onClick = host::togglePause,
                     modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(8.dp)
+                        .align(Alignment.BottomEnd)
+                        .padding(16.dp)
                         .sizeIn(minWidth = 56.dp, minHeight = 56.dp)
                         .semantics { liveRegion = LiveRegionMode.Polite }
                 ) {
-                    Icon(if (host.state.isPaused) Icons.Default.PlayArrow else Icons.Default.Pause, contentDescription = null)
-                    Text(if (host.state.isPaused) resumeLabel else restLabel, Modifier.padding(start = 8.dp))
+                    Icon(
+                        if (host.state.isPaused) Icons.Default.PlayArrow else Icons.Default.Pause,
+                        contentDescription = if (host.state.isPaused) resumeLabel else restLabel,
+                    )
                 }
                 if (host.state.isPaused) {
                     Row(
                         Modifier
                             .align(Alignment.TopCenter)
-                            .padding(top = 72.dp)
+                            .padding(top = 16.dp)
                             .background(MaterialTheme.colorScheme.inverseSurface, RoundedCornerShape(12.dp))
                             .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(12.dp))
                             .padding(horizontal = 16.dp, vertical = 10.dp)

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -99,6 +99,7 @@ import io.github.jdreioe.wingmate.domain.AacLogger
 import io.github.jdreioe.wingmate.domain.Base64Decoder
 import io.github.jdreioe.wingmate.domain.SpeechService
 import io.github.jdreioe.wingmate.domain.withLanguageOverride
+import io.github.jdreioe.wingmate.domain.obf.resolvedBackgroundColor
 import io.github.jdreioe.wingmate.application.VoiceUseCase
 import org.koin.compose.koinInject
 import kotlinx.coroutines.delay
@@ -1106,10 +1107,15 @@ fun ObfButtonItem(
     val highContrastContainer = if (MaterialTheme.colorScheme.surface == Color.Black || settings.forceDarkTheme == true) Color.Black else Color.White
     val highContrastContent = if (highContrastContainer == Color.Black) Color.White else Color.Black
     
+    val resolvedBackgroundColor = button.resolvedBackgroundColor(
+        settings.wordTypeColorScheme,
+        locale,
+        displayLabel
+    )
     val bgColor = if (settings.highContrastMode) {
         highContrastContainer
     } else {
-        button.backgroundColor?.let { runCatching { parseHexToColor(it) }.getOrNull() } 
+        resolvedBackgroundColor?.let { runCatching { parseHexToColor(it) }.getOrNull() }
             ?: MaterialTheme.colorScheme.surfaceVariant
     }
     
@@ -1121,7 +1127,7 @@ fun ObfButtonItem(
     
     val contentColor = when {
         settings.highContrastMode -> highContrastContent
-        button.backgroundColor != null -> contrastingContentColor(bgColor)
+        resolvedBackgroundColor != null -> contrastingContentColor(bgColor)
         else -> MaterialTheme.colorScheme.onSurface
     }
     val buttonShape = button.shape.toShape()

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
@@ -46,6 +46,7 @@ import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.domain.StartupMode
 import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.domain.PointerEmphasisStyle
+import io.github.jdreioe.wingmate.domain.WordTypeColorScheme
 import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
 import io.github.jdreioe.wingmate.domain.obf.BoardActivationBehavior
@@ -122,6 +123,7 @@ fun SettingsScreen(
     var boardReturnBehavior by remember { mutableStateOf(BoardReturnBehavior.Stay) }
     var gridColumns by remember { mutableStateOf(3) }
     var highContrastMode by remember { mutableStateOf(false) }
+    var wordTypeColorScheme by remember { mutableStateOf(WordTypeColorScheme.None) }
 
     // --- Accessibility section state ---
     var holdToSelectMillis by remember { mutableStateOf(0L) }
@@ -220,6 +222,7 @@ fun SettingsScreen(
         holdToSelectMillis = s.holdToSelectMillis
         gridColumns = s.gridColumns
         highContrastMode = s.highContrastMode
+        wordTypeColorScheme = s.wordTypeColorScheme
         dwellToSelectMillis = s.dwellToSelectMillis
         selectionSoundEnabled = s.selectionSoundEnabled
         auditoryFishingEnabled = s.auditoryFishingEnabled
@@ -511,7 +514,12 @@ fun SettingsScreen(
                                         onGridColumnsChange = { gridColumns = it },
                                         onGridColumnsChangeFinished = { updateSettings { it.copy(gridColumns = gridColumns) } },
                                         highContrastMode = highContrastMode,
-                                        onHighContrastModeChange = { checked -> highContrastMode = checked; updateSettings { it.copy(highContrastMode = checked) } }
+                                        onHighContrastModeChange = { checked -> highContrastMode = checked; updateSettings { it.copy(highContrastMode = checked) } },
+                                        wordTypeColorScheme = wordTypeColorScheme,
+                                        onWordTypeColorSchemeChange = { scheme ->
+                                            wordTypeColorScheme = scheme
+                                            updateSettings { it.copy(wordTypeColorScheme = scheme) }
+                                        }
                                     )
                                     SettingsTab.Accessibility -> AccessibilitySection(
                                         holdToSelectMillis = holdToSelectMillis,
@@ -1298,7 +1306,9 @@ private fun DisplaySection(
     onGridColumnsChange: (Int) -> Unit,
     onGridColumnsChangeFinished: () -> Unit,
     highContrastMode: Boolean,
-    onHighContrastModeChange: (Boolean) -> Unit
+    onHighContrastModeChange: (Boolean) -> Unit,
+    wordTypeColorScheme: WordTypeColorScheme,
+    onWordTypeColorSchemeChange: (WordTypeColorScheme) -> Unit
 ) {
     SettingsGroup(title = stringResource(R.string.ui_settings_grid_layout)) {
         SettingsSwitch(
@@ -1335,6 +1345,17 @@ private fun DisplaySection(
             checked = highContrastMode,
             onCheckedChange = onHighContrastModeChange,
             title = stringResource(R.string.ui_settings_high_contrast_title)
+        )
+        SettingsGroupDivider()
+        SettingsSwitch(
+            checked = wordTypeColorScheme == WordTypeColorScheme.Fitzgerald,
+            onCheckedChange = {
+                onWordTypeColorSchemeChange(
+                    if (it) WordTypeColorScheme.Fitzgerald else WordTypeColorScheme.None
+                )
+            },
+            title = stringResource(R.string.ui_settings_word_type_colors_title),
+            description = stringResource(R.string.ui_settings_word_type_colors_desc)
         )
     }
 

--- a/androidApp/src/main/res/values-da-rDK/strings.xml
+++ b/androidApp/src/main/res/values-da-rDK/strings.xml
@@ -511,6 +511,16 @@
     <string name="ui_settings_hold_to_select_desc">Forhindrer utilsigtede tryk. Sæt til 0 for at deaktivere.</string>
     <string name="ui_settings_grid_columns_title">Gitterkolonner</string>
     <string name="ui_settings_high_contrast_title">Højkontrast-tilstand</string>
+    <string name="ui_settings_word_type_colors_title">Ordtypefarver</string>
+    <string name="ui_settings_word_type_colors_desc">Anvend automatisk Fitzgerald-farver, når en knap ikke har en brugerdefineret farve</string>
+    <string name="board_dialog_word_type">Ordtype</string>
+    <string name="board_dialog_word_type_automatic">Automatisk</string>
+    <string name="board_dialog_word_type_pronoun">Stedord</string>
+    <string name="board_dialog_word_type_verb">Udsagnsord</string>
+    <string name="board_dialog_word_type_descriptor">Beskrivende ord</string>
+    <string name="board_dialog_word_type_noun">Navneord</string>
+    <string name="board_dialog_word_type_social">Socialt ord</string>
+    <string name="board_dialog_word_type_other">Andet</string>
     <string name="phrase_edit_hidden_title">Skjult</string>
     <string name="phrase_edit_hidden_desc">Skjul denne frase fra gitteret</string>
     <string name="ui_settings_dwell_to_select_title">Dwell-valg (ms)</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -197,6 +197,14 @@
     <string name="board_dialog_hidden_description">Keep this button available for editing but hide it during normal communication.</string>
     <string name="board_dialog_clear_image">Clear image</string>
     <string name="board_dialog_color">Field color</string>
+    <string name="board_dialog_word_type">Word type</string>
+    <string name="board_dialog_word_type_automatic">Automatic</string>
+    <string name="board_dialog_word_type_pronoun">Pronoun</string>
+    <string name="board_dialog_word_type_verb">Verb</string>
+    <string name="board_dialog_word_type_descriptor">Descriptor</string>
+    <string name="board_dialog_word_type_noun">Noun</string>
+    <string name="board_dialog_word_type_social">Social word</string>
+    <string name="board_dialog_word_type_other">Other</string>
     <string name="board_dialog_pick_color">Pick</string>
     <string name="board_dialog_shape">Button shape</string>
     <string name="board_dialog_shape_rounded">Rounded</string>
@@ -388,6 +396,8 @@
     <string name="phrase_add_cd">Add phrase</string>
 
     <string name="ui_settings_title">Settings</string>
+    <string name="ui_settings_word_type_colors_title">Word-type colors</string>
+    <string name="ui_settings_word_type_colors_desc">Automatically apply Fitzgerald colors when a button has no custom color</string>
     <string name="ui_settings_search">Search settings</string>
     <string name="ui_settings_search_empty">No matching settings</string>
     <string name="ui_settings_speech_title">Speech and language</string>

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/model.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/model.kt
@@ -52,6 +52,12 @@ enum class PointerEmphasisStyle {
 }
 
 @Serializable
+enum class WordTypeColorScheme {
+    None,
+    Fitzgerald
+}
+
+@Serializable
 data class Settings(
     val language: String = "en-US",
     val voice: String = "default",
@@ -106,6 +112,9 @@ data class Settings(
     val holdToSelectMillis: Long = 0,
     val gridColumns: Int = 3,
     val highContrastMode: Boolean = false,
+    // Automatically color vocabulary buttons by grammatical word type. Explicit
+    // author colors always take precedence.
+    val wordTypeColorScheme: WordTypeColorScheme = WordTypeColorScheme.None,
     val dwellToSelectMillis: Long = 0,
     // Interaction shortcuts use portable tokens such as "Space", "Enter", or "F8".
     // Empty disables the shortcut so ordinary typing is never intercepted by default.

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/BoardSessionLogic.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/BoardSessionLogic.kt
@@ -375,7 +375,8 @@ fun updateDraftCell(
     linkedBoardId: String?,
     action: String? = null,
     actions: List<String> = emptyList(),
-    shape: ObfButtonShape = ObfButtonShape.Rounded
+    shape: ObfButtonShape = ObfButtonShape.Rounded,
+    wordType: WordType? = null
 ): BoardSetGraph {
     val board = graph.boardsById[boardId] ?: return graph
     val grid = board.grid ?: return graph
@@ -431,7 +432,7 @@ fun updateDraftCell(
         },
         action = action?.trim()?.ifBlank { null },
         actions = actions
-    ).withMathMode(mathMode).withShape(shape)
+    ).withMathMode(mathMode).withShape(shape).withWordType(wordType)
     val buttons = if (existingButton == null) board.buttons + button else board.buttons.map {
         if (it.id == button.id) button else it
     }

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/WordTypeColors.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/WordTypeColors.kt
@@ -1,0 +1,112 @@
+package io.github.jdreioe.wingmate.domain.obf
+
+import io.github.jdreioe.wingmate.domain.WordTypeColorScheme
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+const val OBF_WORD_TYPE_EXTENSION = "ext_wingmate_word_type"
+
+/** Broad AAC vocabulary groups used by Fitzgerald-style color coding. */
+enum class WordType(val wireValue: String, val fitzgeraldColor: String) {
+    Pronoun("pronoun", "#FFF176"),
+    Verb("verb", "#F48FB1"),
+    Descriptor("descriptor", "#81D4FA"),
+    Noun("noun", "#FFB74D"),
+    Social("social", "#A5D6A7"),
+    Other("other", "#E0E0E0")
+}
+
+val ObfButton.wordType: WordType?
+    get() = (extensions[OBF_WORD_TYPE_EXTENSION] as? JsonPrimitive)?.contentOrNull
+        ?.let { value -> WordType.entries.firstOrNull { it.wireValue == value } }
+
+fun ObfButton.withWordType(type: WordType?): ObfButton = copy(
+    extensions = type?.let {
+        extensions + (OBF_WORD_TYPE_EXTENSION to JsonPrimitive(it.wireValue))
+    } ?: (extensions - OBF_WORD_TYPE_EXTENSION)
+)
+
+/**
+ * Returns a conservative classification. Unknown words deliberately return null
+ * instead of receiving a misleading color. A stored [wordType] is always used first.
+ */
+fun ObfButton.resolvedWordType(boardLocale: String? = null, localizedLabel: String? = null): WordType? =
+    wordType ?: inferWordType(localizedLabel ?: label ?: vocalization, locale ?: boardLocale)
+
+/** Explicit OBF colors have precedence over generated colors. */
+fun ObfButton.resolvedBackgroundColor(
+    scheme: WordTypeColorScheme,
+    boardLocale: String? = null,
+    localizedLabel: String? = null
+): String? = backgroundColor ?: when (scheme) {
+    WordTypeColorScheme.None -> null
+    WordTypeColorScheme.Fitzgerald -> resolvedWordType(boardLocale, localizedLabel)?.fitzgeraldColor
+}
+
+fun inferWordType(text: String?, locale: String?): WordType? {
+    val word = text
+        ?.trim()
+        ?.lowercase()
+        ?.trim { !it.isLetter() && it != '\'' && it != '-' }
+        ?.takeIf { it.isNotEmpty() && it.none(Char::isWhitespace) }
+        ?: return null
+    val language = locale?.substringBefore('-')?.substringBefore('_')?.lowercase()
+    val lexicon = when (language) {
+        "da" -> danishWords
+        "en", null, "" -> englishWords
+        else -> return null
+    }
+    return lexicon[word] ?: inferBySuffix(word, language)
+}
+
+private fun inferBySuffix(word: String, language: String?): WordType? = when (language) {
+    "en", null, "" -> when {
+        word.endsWith("ly") -> WordType.Descriptor
+        word.endsWith("ing") || word.endsWith("ed") -> WordType.Verb
+        else -> null
+    }
+    "da" -> when {
+        word.endsWith("ligt") -> WordType.Descriptor
+        else -> null
+    }
+    else -> null
+}
+
+private fun words(type: WordType, value: String): Map<String, WordType> =
+    value.split(' ').associateWith { type }
+
+private val englishWords = buildMap {
+    putAll(words(WordType.Pronoun, "i me my mine you your yours he him his she her hers it its we us our ours they them their theirs who what where when why"))
+    putAll(words(WordType.Verb, "am is are was were be being been have has had do does did can could will would shall should may might must want need like go come make get put take give see hear say tell eat drink play help stop open close turn look feel think know"))
+    putAll(words(WordType.Descriptor, "good bad big small hot cold happy sad angry tired sick more less fast slow loud quiet yes no red orange yellow green blue purple black white"))
+    putAll(words(WordType.Social, "hello hi goodbye bye please thanks thank sorry okay ok"))
+    putAll(words(WordType.Other, "a an the and or but if in on at to from with without for of this that these those"))
+    putAll(words(WordType.Noun, "person people family mother father mom dad sister brother friend home school work food water drink toilet bathroom pain medicine doctor nurse book music game phone computer car bus dog cat"))
+}
+
+private val danishWords = buildMap {
+    putAll(words(WordType.Pronoun, "jeg mig min mit mine du dig din dit dine han ham hans hun hende hendes den det vi os vores i jer jeres hvem hvad hvor hvornår hvorfor"))
+    putAll(words(WordType.Verb, "er var være har havde gør gjorde kan kunne vil ville skal skulle må ønsker behøver lide gå komme lave få sætte tage give se høre sige fortælle spise drikke lege hjælpe stop åbne lukke føle tænke vide"))
+    putAll(words(WordType.Descriptor, "god dårlig stor lille varm kold glad ked vred træt syg mere mindre hurtig langsom høj stille ja nej rød orange gul grøn blå lilla sort hvid"))
+    putAll(words(WordType.Social, "hej farvel tak undskyld okay"))
+    putAll(words(WordType.Other, "en et den det og eller men hvis i på til fra med uden for af denne dette disse"))
+    putAll(words(WordType.Noun, "person mennesker familie mor far søster bror ven hjem skole arbejde mad vand drik toilet badeværelse smerte medicin læge sygeplejerske bog musik spil telefon computer bil bus hund kat"))
+}
+
+/** WCAG contrast ratio for tests and non-native export/rendering surfaces. */
+fun contrastRatio(foregroundHex: String, backgroundHex: String): Double {
+    val foreground = relativeLuminance(foregroundHex)
+    val background = relativeLuminance(backgroundHex)
+    val lighter = maxOf(foreground, background)
+    val darker = minOf(foreground, background)
+    return (lighter + 0.05) / (darker + 0.05)
+}
+
+private fun relativeLuminance(hex: String): Double {
+    val value = hex.removePrefix("#").takeLast(6).padStart(6, '0')
+    fun component(offset: Int): Double {
+        val channel = value.substring(offset, offset + 2).toInt(16) / 255.0
+        return if (channel <= 0.04045) channel / 12.92 else ((channel + 0.055) / 1.055).let { it * it * it }
+    }
+    return 0.2126 * component(0) + 0.7152 * component(2) + 0.0722 * component(4)
+}

--- a/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/WordTypeColorsTest.kt
+++ b/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/WordTypeColorsTest.kt
@@ -1,0 +1,47 @@
+package io.github.jdreioe.wingmate.domain.obf
+
+import io.github.jdreioe.wingmate.domain.WordTypeColorScheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WordTypeColorsTest {
+    @Test
+    fun classifiesSupportedLanguagesAndLeavesUnknownLanguagesUncolored() {
+        assertEquals(WordType.Verb, inferWordType("go", "en-US"))
+        assertEquals(WordType.Noun, inferWordType("vand", "da-DK"))
+        assertNull(inferWordType("boire", "fr-FR"))
+        assertNull(inferWordType("madeupword", "en-US"))
+    }
+
+    @Test
+    fun manualWordTypeOverridesInferenceAndRoundTripsThroughExtension() {
+        val corrected = ObfButton(id = "ambiguous", label = "play").withWordType(WordType.Noun)
+        assertEquals(WordType.Noun, corrected.wordType)
+        assertEquals(WordType.Noun, corrected.resolvedWordType("en-US"))
+        assertNull(corrected.withWordType(null).wordType)
+    }
+
+    @Test
+    fun explicitColorOverridesGeneratedColorAndSchemeCanBeDisabled() {
+        val automatic = ObfButton(id = "verb", label = "go")
+        assertEquals("#F48FB1", automatic.resolvedBackgroundColor(WordTypeColorScheme.Fitzgerald, "en-US"))
+        assertNull(automatic.resolvedBackgroundColor(WordTypeColorScheme.None, "en-US"))
+        assertEquals(
+            "#123456",
+            automatic.copy(backgroundColor = "#123456")
+                .resolvedBackgroundColor(WordTypeColorScheme.Fitzgerald, "en-US")
+        )
+    }
+
+    @Test
+    fun generatedPaletteMeetsNormalTextContrastAgainstBlack() {
+        WordType.entries.forEach { type ->
+            assertTrue(
+                contrastRatio("#000000", type.fitzgeraldColor) >= 4.5,
+                "${type.name} ${type.fitzgeraldColor} must meet WCAG AA"
+            )
+        }
+    }
+}

--- a/docs/word-type-colors.md
+++ b/docs/word-type-colors.md
@@ -1,0 +1,17 @@
+# Word-type colors
+
+Wingmate can automatically apply Fitzgerald-style colors to Screen buttons. The
+feature is off by default, so existing boards keep their appearance until it is
+enabled in Display settings.
+
+Color precedence is deliberately simple:
+
+1. A button's explicit OBF `background_color` always wins.
+2. A manually selected word type (`ext_wingmate_word_type`) is used next.
+3. Otherwise Wingmate conservatively infers the type from the button label and
+   locale. English and Danish are supported; unknown words and locales retain the
+   normal theme color.
+
+Manual word types and explicit colors are stored in OBF/OBZ exports. Inferred
+colors are presentation-only, so enabling a scheme never rewrites author data.
+The generated palette uses black text and meets WCAG AA contrast for normal text.

--- a/iosApp/iosApp/Base.lproj/Localizable.strings
+++ b/iosApp/iosApp/Base.lproj/Localizable.strings
@@ -213,6 +213,15 @@
 "settings.display.label_top" = "Put Labels at the Top";
 "settings.display.columns" = "Grid Columns";
 "settings.display.high_contrast" = "High Contrast Mode";
+"settings.display.word_type_colors" = "Automatic Fitzgerald word-type colors";
+"boardset.cell.word_type" = "Word type";
+"boardset.cell.word_type.automatic" = "Automatic";
+"boardset.cell.word_type.pronoun" = "Pronoun";
+"boardset.cell.word_type.verb" = "Verb";
+"boardset.cell.word_type.descriptor" = "Descriptor";
+"boardset.cell.word_type.noun" = "Noun";
+"boardset.cell.word_type.social" = "Social word";
+"boardset.cell.word_type.other" = "Other";
 "settings.display.interface_size" = "Interface Size";
 "settings.accessibility.touch_timing" = "Touch & Timing";
 "settings.accessibility.hold" = "Hold to Select";

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -197,15 +197,17 @@ struct ContentView: View {
                     }
                 }
             }
-            .overlay(alignment: .topLeading) {
+            .overlay(alignment: .bottomTrailing) {
                 if !shouldShowWelcomeFlow && (model.dwellToSelectMillis > 0 || !model.selectKeyBinding.isEmpty) {
                     Button(action: model.toggleInputPause) {
-                        Label(model.inputIsPaused ? "interaction.resume" : "interaction.rest_mode",
-                              systemImage: model.inputIsPaused ? "play.fill" : "pause.fill")
+                        Image(systemName: model.inputIsPaused ? "play.fill" : "pause.fill")
+                            .font(.title2.weight(.semibold))
                             .frame(minWidth: 56, minHeight: 56)
                     }
                     .buttonStyle(.borderedProminent)
-                    .padding(8)
+                    .buttonBorderShape(.circle)
+                    .padding(16)
+                    .accessibilityLabel(Text(model.inputIsPaused ? "interaction.resume" : "interaction.rest_mode"))
                     .accessibilityAddTraits(.isButton)
                 }
             }
@@ -217,7 +219,7 @@ struct ContentView: View {
                         .padding(.vertical, 10)
                         .background(.regularMaterial, in: Capsule())
                         .overlay(Capsule().stroke(Color.accentColor, lineWidth: 2))
-                        .padding(.top, 72)
+                        .padding(.top, 16)
                         .accessibilityAddTraits(.updatesFrequently)
                 }
             }

--- a/iosApp/iosApp/ViewModels/IosViewModel.swift
+++ b/iosApp/iosApp/ViewModels/IosViewModel.swift
@@ -20,6 +20,8 @@ struct BoardCellInfo: Identifiable, Equatable {
     var label: String?
     var vocalization: String?
     var backgroundColor: String?
+    var resolvedBackgroundColor: String?
+    var wordType: String?
     var borderColor: String?
     var linkedBoardId: String?
     var imageId: String?
@@ -136,6 +138,7 @@ final class IosViewModel: ObservableObject {
     @Published var labelAtTop: Bool = false
     @Published var preferredGridColumns: Int = 3
     @Published var highContrastMode: Bool = false
+    @Published var wordTypeColorScheme: String = "None"
     @Published var holdToSelectMillis: Double = 0
     @Published var dwellToSelectMillis: Double = 0
     @Published var selectionDebounceMillis: Double = 0
@@ -470,6 +473,7 @@ final class IosViewModel: ObservableObject {
                 self.labelAtTop = settings.labelAtTop
                 self.preferredGridColumns = min(max(Int(settings.gridColumns), 1), 6)
                 self.highContrastMode = settings.highContrastMode
+                self.wordTypeColorScheme = settings.wordTypeColorScheme.name
                 self.holdToSelectMillis = Double(settings.holdToSelectMillis)
                 self.dwellToSelectMillis = Double(settings.dwellToSelectMillis)
                 self.selectionDebounceMillis = Double(settings.selectionDebounceMillis)
@@ -933,6 +937,14 @@ final class IosViewModel: ObservableObject {
     func setHighContrastMode(_ enabled: Bool) {
         highContrastMode = enabled
         Task { _ = try? await bridge.updateHighContrastMode(enabled: enabled) }
+    }
+
+    func setWordTypeColorsEnabled(_ enabled: Bool) {
+        wordTypeColorScheme = enabled ? "Fitzgerald" : "None"
+        Task {
+            _ = try? await bridge.updateWordTypeColorScheme(scheme: wordTypeColorScheme)
+            await refreshBoardCells()
+        }
     }
 
     func setHoldToSelectMillis(_ value: Double) {
@@ -1769,6 +1781,8 @@ final class IosViewModel: ObservableObject {
                     label: cell.label,
                     vocalization: cell.vocalization,
                     backgroundColor: cell.backgroundColor,
+                    resolvedBackgroundColor: cell.resolvedBackgroundColor,
+                    wordType: cell.wordType,
                     borderColor: cell.borderColor,
                     linkedBoardId: cell.linkedBoardId,
                     imageId: cell.imageId,
@@ -1804,7 +1818,8 @@ final class IosViewModel: ObservableObject {
         linkedBoardId: String?,
         imageUrl: String?,
         clearImage: Bool,
-        actions: [String]
+        actions: [String],
+        wordType: String?
     ) async {
         guard let boardId = selectedBoardId else {
             boardStatusMessage = NSLocalizedString("boardset.error.no_board", comment: "")
@@ -1834,7 +1849,8 @@ final class IosViewModel: ObservableObject {
                 linkedBoardId: normalizedLink,
                 imageUrl: normalizedImageUrl,
                 clearImage: clearImage,
-                actions: actions
+                actions: actions,
+                wordType: normalizedOptionalText(wordType)
             ) else {
                 boardStatusMessage = NSLocalizedString("boardset.error.cell_update_failed", comment: "")
                 return

--- a/iosApp/iosApp/Views/SettingsView.swift
+++ b/iosApp/iosApp/Views/SettingsView.swift
@@ -316,6 +316,10 @@ private struct DisplaySettingsView: View {
                 Toggle("settings.display.high_contrast", isOn: Binding(
                     get: { model.highContrastMode }, set: { model.setHighContrastMode($0) }
                 ))
+                Toggle("settings.display.word_type_colors", isOn: Binding(
+                    get: { model.wordTypeColorScheme == "Fitzgerald" },
+                    set: { model.setWordTypeColorsEnabled($0) }
+                ))
                 Toggle("settings.display.message_bar", isOn: Binding(
                     get: { model.boardShowMessageBar }, set: { model.setBoardShowMessageBar($0) }
                 ))

--- a/iosApp/iosApp/Views/SymbolBoardWorkspaceView.swift
+++ b/iosApp/iosApp/Views/SymbolBoardWorkspaceView.swift
@@ -171,6 +171,7 @@ struct SymbolBoardWorkspaceView: View {
     @State private var editingActions: [String] = []
     @State private var editingInsertedTextFollowsLabel = false
     @State private var editingBackgroundPickerColor: Color = Color(.tertiarySystemBackground)
+    @State private var editingWordType: String = ""
     @State private var editingBorderPickerColor: Color = Color(.separator)
     @State private var useCustomBackgroundColor: Bool = false
     @State private var useCustomBorderColor: Bool = false
@@ -959,13 +960,13 @@ struct SymbolBoardWorkspaceView: View {
             if let linkedBoardId = trimmed(cell?.linkedBoardId) {
                 Label(model.boardDisplayName(id: linkedBoardId), systemImage: "arrowshape.turn.up.right")
                     .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(contrastingColor(for: cell?.resolvedBackgroundColor, fallback: Color.secondary))
                     .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else if let vocalization = trimmed(cell?.vocalization), vocalization != trimmed(cell?.label) {
                 Text(vocalization)
                     .font(.caption2)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(contrastingColor(for: cell?.resolvedBackgroundColor, fallback: Color.secondary))
                     .lineLimit(1)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
@@ -974,12 +975,12 @@ struct SymbolBoardWorkspaceView: View {
         .frame(width: width, height: height, alignment: .topLeading)
         .background(
             RoundedRectangle(cornerRadius: 10)
-                .fill(model.highContrastMode ? Color(.systemBackground) : colorFromHex(cell?.backgroundColor, fallback: Color(.tertiarySystemBackground)))
+                .fill(model.highContrastMode ? Color(.systemBackground) : colorFromHex(cell?.resolvedBackgroundColor, fallback: Color(.tertiarySystemBackground)))
         )
         .overlay(
             RoundedRectangle(cornerRadius: 10)
                 .stroke(isHighlighted
-                    ? (model.highContrastMode ? Color.white : Color.accentColor)
+                    ? (model.highContrastMode ? Color.white : contrastingColor(for: cell?.resolvedBackgroundColor, fallback: Color.accentColor))
                     : (model.highContrastMode ? Color.primary : colorFromHex(cell?.borderColor, fallback: isLinked ? .accentColor : Color(.separator))),
                     lineWidth: isHighlighted ? 4 : (model.highContrastMode ? 2 : (isLinked ? 1.5 : 1)))
         )
@@ -991,7 +992,7 @@ struct SymbolBoardWorkspaceView: View {
             .font(.subheadline)
             .fontWeight(cell == nil ? .regular : .semibold)
             .lineLimit(2)
-            .foregroundStyle(.primary)
+            .foregroundStyle(model.highContrastMode ? Color.primary : contrastingColor(for: cell?.resolvedBackgroundColor, fallback: Color.primary))
             .frame(maxWidth: .infinity, alignment: .leading)
             .scaleEffect(fontScale, anchor: .leading)
     }
@@ -1415,6 +1416,15 @@ struct SymbolBoardWorkspaceView: View {
                         ColorPicker("boardset.cell.border_picker", selection: $editingBorderPickerColor, supportsOpacity: true)
                     }
                 }
+
+                Section("boardset.cell.word_type") {
+                    Picker("boardset.cell.word_type", selection: $editingWordType) {
+                        Text("boardset.cell.word_type.automatic").tag("")
+                        ForEach(["pronoun", "verb", "descriptor", "noun", "social", "other"], id: \.self) { type in
+                            Text(LocalizedStringKey("boardset.cell.word_type.\(type)")).tag(type)
+                        }
+                    }
+                }
             }
             .navigationTitle(Text("boardset.cell.edit_title"))
             .toolbar {
@@ -1441,7 +1451,8 @@ struct SymbolBoardWorkspaceView: View {
                                 linkedBoardId: editingLinkedBoardId,
                                 imageUrl: editingSelectedSymbolUrl,
                                 clearImage: shouldClearEditingSymbol,
-                                actions: actions
+                                actions: actions,
+                                wordType: editingWordType
                             )
                             if case .custom(let span) = editingSpan, editingCellHasButton {
                                 await model.resizeSelectedBoardField(
@@ -1688,6 +1699,7 @@ struct SymbolBoardWorkspaceView: View {
             editingBorderPickerColor = Color(.separator)
         }
         editingLinkedBoardId = existing?.linkedBoardId ?? ""
+        editingWordType = existing?.wordType ?? ""
         editingSelectedSymbolUrl = existing?.imageUrl
         shouldClearEditingSymbol = false
         editingSymbolQuery = ""
@@ -1732,6 +1744,22 @@ struct SymbolBoardWorkspaceView: View {
         }
 
         return fallback
+    }
+
+    private func contrastingColor(for hex: String?, fallback: Color) -> Color {
+        var value = (hex ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if value.hasPrefix("#") { value.removeFirst() }
+        guard value.count == 6, let parsed = UInt64(value, radix: 16) else { return fallback }
+        func linear(_ channel: UInt64) -> Double {
+            let value = Double(channel) / 255.0
+            return value <= 0.04045 ? value / 12.92 : pow((value + 0.055) / 1.055, 2.4)
+        }
+        let luminance = 0.2126 * linear((parsed >> 16) & 0xFF)
+            + 0.7152 * linear((parsed >> 8) & 0xFF)
+            + 0.0722 * linear(parsed & 0xFF)
+        let blackContrast = (luminance + 0.05) / 0.05
+        let whiteContrast = 1.05 / (luminance + 0.05)
+        return blackContrast >= whiteContrast ? .black : .white
     }
 
     private func hexFromColor(_ color: Color) -> String {

--- a/iosApp/iosApp/da.lproj/Localizable.strings
+++ b/iosApp/iosApp/da.lproj/Localizable.strings
@@ -405,6 +405,15 @@
 "settings.display.label_top" = "Placér tekst øverst";
 "settings.display.columns" = "Gitterkolonner";
 "settings.display.high_contrast" = "Høj kontrast";
+"settings.display.word_type_colors" = "Automatiske Fitzgerald-ordtypefarver";
+"boardset.cell.word_type" = "Ordtype";
+"boardset.cell.word_type.automatic" = "Automatisk";
+"boardset.cell.word_type.pronoun" = "Stedord";
+"boardset.cell.word_type.verb" = "Udsagnsord";
+"boardset.cell.word_type.descriptor" = "Beskrivende ord";
+"boardset.cell.word_type.noun" = "Navneord";
+"boardset.cell.word_type.social" = "Socialt ord";
+"boardset.cell.word_type.other" = "Andet";
 "settings.display.interface_size" = "Brugerfladens størrelse";
 "settings.accessibility.touch_timing" = "Berøring og timing";
 "settings.accessibility.hold" = "Hold for at vælge";

--- a/linuxApp/i18n/da/wingmate.ftl
+++ b/linuxApp/i18n/da/wingmate.ftl
@@ -157,6 +157,7 @@ display-appearance-help = System følger skrivebordets udseendeportal. Vælg Lys
 display-show-labels = Vis etiketter
 display-show-symbols = Vis symboler
 display-high-contrast = Høj kontrast
+display-word-type-colors = Automatiske Fitzgerald-ordtypefarver
 display-message-bar = Vis beskedlinje på kommunikationstavler
 display-font-scale = Tekststørrelse
 display-button-scale = Knapstørrelse

--- a/linuxApp/i18n/en/wingmate.ftl
+++ b/linuxApp/i18n/en/wingmate.ftl
@@ -157,6 +157,7 @@ display-appearance-help = System follows the desktop appearance portal. Choose L
 display-show-labels = Show labels
 display-show-symbols = Show symbols
 display-high-contrast = High contrast
+display-word-type-colors = Automatic Fitzgerald word-type colors
 display-message-bar = Show message bar on communication boards
 display-font-scale = Text size
 display-button-scale = Button size

--- a/linuxApp/src/main.rs
+++ b/linuxApp/src/main.rs
@@ -253,6 +253,7 @@ struct Settings {
     label_at_top: bool,
     grid_columns: i32,
     high_contrast_mode: bool,
+    word_type_color_scheme: String,
     hold_to_select_millis: i64,
     dwell_to_select_millis: i64,
     select_key_binding: String,
@@ -302,6 +303,7 @@ impl Default for Settings {
             label_at_top: false,
             grid_columns: 3,
             high_contrast_mode: false,
+            word_type_color_scheme: "None".into(),
             hold_to_select_millis: 0,
             dwell_to_select_millis: 0,
             select_key_binding: String::new(),
@@ -625,6 +627,18 @@ struct BoardButton {
     action: Option<String>,
     #[serde(default)]
     actions: Vec<String>,
+    #[serde(default)]
+    extensions: HashMap<String, serde_json::Value>,
+}
+
+impl BoardButton {
+    fn rendered_background_color(&self) -> Option<&str> {
+        self.background_color.as_deref().or_else(|| {
+            self.extensions
+                .get("ext_wingmate_resolved_background_color")
+                .and_then(serde_json::Value::as_str)
+        })
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -764,6 +778,7 @@ struct Wingmate {
     cell_vocalization: String,
     cell_image_url: Option<String>,
     cell_background_color: String,
+    cell_word_type: String,
     cell_hidden: bool,
     cell_linked_board_id: Option<String>,
     cell_actions: String,
@@ -958,6 +973,7 @@ enum Message {
     CellLocalImage,
     CellLocalImageImported(Result<ImportedImage, String>),
     CellBackgroundChanged(String),
+    CellWordTypeChanged(String),
     CellHiddenChanged(bool),
     CellLinkedBoardChanged(String),
     CellActionsChanged(String),
@@ -1119,6 +1135,7 @@ impl cosmic::Application for Wingmate {
             cell_vocalization: String::new(),
             cell_image_url: None,
             cell_background_color: String::new(),
+            cell_word_type: "Automatic".into(),
             cell_hidden: false,
             cell_linked_board_id: None,
             cell_actions: String::new(),
@@ -2112,6 +2129,13 @@ impl cosmic::Application for Wingmate {
                     "showSymbols" => self.settings.show_symbols = enabled,
                     "labelAtTop" => self.settings.label_at_top = enabled,
                     "highContrastMode" => self.settings.high_contrast_mode = enabled,
+                    "wordTypeColorScheme" => {
+                        self.settings.word_type_color_scheme = if enabled {
+                            "Fitzgerald".into()
+                        } else {
+                            "None".into()
+                        }
+                    }
                     "selectionSoundEnabled" => self.settings.selection_sound_enabled = enabled,
                     "auditoryFishingEnabled" => self.settings.auditory_fishing_enabled = enabled,
                     "usageLoggingEnabled" => self.settings.usage_logging_enabled = enabled,
@@ -2127,26 +2151,31 @@ impl cosmic::Application for Wingmate {
                     "scanTopBarEnabled" => self.settings.scan_top_bar_enabled = enabled,
                     _ => {}
                 }
+                let setting_value = if key == "wordTypeColorScheme" {
+                    serde_json::Value::String(self.settings.word_type_color_scheme.clone())
+                } else {
+                    serde_json::Value::Bool(enabled)
+                };
                 let save = if matches!(
                     key,
-                    "showLabels" | "showSymbols" | "labelAtTop" | "boardShowMessageBar"
+                    "showLabels" | "showSymbols" | "labelAtTop" | "boardShowMessageBar" | "wordTypeColorScheme"
                 ) {
                     self.board_graph.as_ref().map_or_else(
                         || {
                             self.api
-                                .patch_setting(key, serde_json::Value::Bool(enabled))
+                                .patch_setting(key, setting_value.clone())
                         },
                         |graph| {
                             self.api.patch_setting_and_reload_board(
                                 key,
-                                serde_json::Value::Bool(enabled),
+                                setting_value.clone(),
                                 graph.board_set.id.clone(),
                             )
                         },
                     )
                 } else {
                     self.api
-                        .patch_setting(key, serde_json::Value::Bool(enabled))
+                        .patch_setting(key, setting_value)
                 };
                 if key == "highContrastMode" {
                     let theme = theme_for_preference(
@@ -2631,6 +2660,7 @@ impl cosmic::Application for Wingmate {
                 self.cell_vocalization.clear();
                 self.cell_image_url = None;
                 self.cell_background_color.clear();
+                self.cell_word_type = "Automatic".into();
                 self.cell_hidden = false;
                 self.cell_linked_board_id = None;
                 self.cell_actions.clear();
@@ -2671,6 +2701,9 @@ impl cosmic::Application for Wingmate {
                         button.vocalization.clone().unwrap_or_default(),
                         image_url,
                         button.background_color.clone().unwrap_or_default(),
+                        button.extensions.get("ext_wingmate_word_type")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("Automatic").to_string(),
                         button.hidden,
                         button.load_board.as_ref().map(|target| target.id.clone()),
                         if button.actions.is_empty() {
@@ -2680,13 +2713,22 @@ impl cosmic::Application for Wingmate {
                         },
                     )
                 });
-                if let Some((label, vocalization, image_url, background, hidden, linked, actions)) =
-                    details
+                if let Some((
+                    label,
+                    vocalization,
+                    image_url,
+                    background,
+                    word_type,
+                    hidden,
+                    linked,
+                    actions,
+                )) = details
                 {
                     self.cell_label = label;
                     self.cell_vocalization = vocalization;
                     self.cell_image_url = image_url;
                     self.cell_background_color = background;
+                    self.cell_word_type = word_type;
                     self.cell_hidden = hidden;
                     self.cell_linked_board_id = linked;
                     self.cell_actions = actions;
@@ -2767,6 +2809,7 @@ impl cosmic::Application for Wingmate {
                 Err(error) => self.status = format!("Image import failed: {error}"),
             },
             Message::CellBackgroundChanged(value) => self.cell_background_color = value,
+            Message::CellWordTypeChanged(value) => self.cell_word_type = value,
             Message::CellHiddenChanged(value) => self.cell_hidden = value,
             Message::CellLinkedBoardChanged(value) => {
                 self.cell_linked_board_id = if value == "No page link" {
@@ -2799,6 +2842,7 @@ impl cosmic::Application for Wingmate {
                             self.cell_vocalization.clone(),
                             self.cell_image_url.clone(),
                             self.cell_background_color.clone(),
+                            self.cell_word_type.clone(),
                             self.cell_hidden,
                             self.cell_linked_board_id.clone(),
                             self.cell_actions
@@ -2857,8 +2901,7 @@ impl cosmic::Application for Wingmate {
             24
         };
 
-        column![
-            self.interaction_status_view(),
+        let page_content: Element<'_, Message> = column![
             container(content)
                 .padding(content_padding)
                 .width(Fill)
@@ -2866,33 +2909,55 @@ impl cosmic::Application for Wingmate {
             self.status_view(),
         ]
         .height(Fill)
-        .into()
+        .into();
+        let enabled = matches!(self.page, Page::Communicate | Page::Screens)
+            && (self.settings.dwell_to_select_millis > 0 || !self.settings.select_key_binding.is_empty());
+        if !enabled {
+            return page_content;
+        }
+
+        let fab_label = if self.input_is_paused {
+            "Resume input"
+        } else {
+            "Rest mode"
+        };
+        let fab = aac_toolbar_button(
+            if self.input_is_paused {
+                "media-playback-start-symbolic"
+            } else {
+                "media-playback-pause-symbolic"
+            },
+            fab_label,
+            Message::ToggleInputPause,
+        );
+        let fab_layer = container(fab)
+            .width(Fill)
+            .height(Fill)
+            .align_x(cosmic::iced::alignment::Horizontal::Right)
+            .align_y(cosmic::iced::alignment::Vertical::Bottom)
+            .padding(Padding {
+                top: 0.0,
+                right: 24.0,
+                bottom: 24.0,
+                left: 0.0,
+            });
+        let mut layers = vec![page_content, fab_layer.into()];
+        if self.input_is_paused {
+            layers.push(
+                container(text("Rest mode — hover selection and the Select key are paused").size(16))
+                    .width(Fill)
+                    .height(Fill)
+                    .align_x(cosmic::iced::alignment::Horizontal::Center)
+                    .align_y(cosmic::iced::alignment::Vertical::Top)
+                    .padding(16)
+                    .into(),
+            );
+        }
+        stack(layers).width(Fill).height(Fill).into()
     }
 }
 
 impl Wingmate {
-    fn interaction_status_view(&self) -> Element<'_, Message> {
-        let enabled = matches!(self.page, Page::Communicate | Page::Screens)
-            && (self.settings.dwell_to_select_millis > 0 || !self.settings.select_key_binding.is_empty());
-        if !enabled {
-            return Space::new().height(0).into();
-        }
-        let action = button(text(if self.input_is_paused { "Resume input" } else { "Rest mode" }).size(18))
-            .on_press(Message::ToggleInputPause)
-            .padding([14, 20]);
-        let status = if self.input_is_paused {
-            "Rest mode — hover selection and the Select key are paused".to_string()
-        } else if self.access_dwell_progress > 0.0 {
-            format!("Pointer input active · Hover selection {}%", (self.access_dwell_progress * 100.0).round() as i32)
-        } else {
-            "Pointer input active".to_string()
-        };
-        container(row![action, text(status).size(16).width(Fill)].spacing(14).align_y(cosmic::iced::alignment::Alignment::Center))
-            .padding([8, 24])
-            .width(Fill)
-            .class(if self.input_is_paused { cosmic::theme::iced::Container::Primary } else { cosmic::theme::iced::Container::Secondary })
-            .into()
-    }
 
     fn status_view(&self) -> Element<'_, Message> {
         let status_text = if self.status.trim().is_empty() {
@@ -4089,6 +4154,22 @@ impl Wingmate {
                         text_input(&fl!("board-background-color"), &self.cell_background_color)
                             .on_input(Message::CellBackgroundChanged)
                             .padding(12),
+                        pick_list(
+                            vec![
+                                "Automatic",
+                                "pronoun",
+                                "verb",
+                                "descriptor",
+                                "noun",
+                                "social",
+                                "other",
+                            ]
+                            .into_iter()
+                            .map(str::to_string)
+                            .collect::<Vec<_>>(),
+                            Some(self.cell_word_type.clone()),
+                            Message::CellWordTypeChanged,
+                        ),
                         pick_list(page_options, selected_page, Message::CellLinkedBoardChanged),
                         checkbox(self.cell_hidden)
                             .label(fl!("board-hidden-run"))
@@ -4260,9 +4341,13 @@ impl Wingmate {
             let label_size = ((field_height * 0.18).clamp(22.0, 38.0)
                 * self.settings.font_size_scale)
                 .clamp(18.0, 48.0);
-            let field_color = button_data
-                .and_then(|button| button.background_color.as_deref())
-                .and_then(parse_hex_color);
+            let field_color = if self.settings.high_contrast_mode {
+                None
+            } else {
+                button_data
+                    .and_then(BoardButton::rendered_background_color)
+                    .and_then(parse_hex_color)
+            };
             let label_color = field_color.map(contrasting_foreground);
             let has_symbol = symbol_source.is_some();
             let show_symbol = has_symbol && show_symbols;
@@ -5036,6 +5121,9 @@ impl Wingmate {
                 checkbox(self.settings.high_contrast_mode)
                     .label(fl!("display-high-contrast"))
                     .on_toggle(|enabled| Message::SettingBool("highContrastMode", enabled)),
+                checkbox(self.settings.word_type_color_scheme == "Fitzgerald")
+                    .label(fl!("display-word-type-colors"))
+                    .on_toggle(|enabled| Message::SettingBool("wordTypeColorScheme", enabled)),
                 checkbox(self.settings.board_show_message_bar)
                     .label(fl!("display-message-bar"))
                     .on_toggle(|enabled| Message::SettingBool("boardShowMessageBar", enabled)),
@@ -6416,6 +6504,7 @@ impl Api {
         vocalization: String,
         image_url: Option<String>,
         background_color: String,
+        word_type: String,
         hidden: bool,
         linked_board_id: Option<String>,
         actions: Vec<String>,
@@ -6436,6 +6525,7 @@ impl Api {
                         "vocalization": vocalization,
                         "imageUrl": image_url,
                         "backgroundColor": background_color,
+                        "wordType": if word_type == "Automatic" { None } else { Some(word_type) },
                         "hidden": hidden,
                         "linkedBoardId": linked_board_id,
                         "actions": actions,

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -28,6 +28,7 @@ import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.domain.VoiceRepository
 import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.StartupMode
+import io.github.jdreioe.wingmate.domain.WordTypeColorScheme
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
 import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
 import io.github.jdreioe.wingmate.domain.obf.ObfButtonActionEffect
@@ -50,6 +51,8 @@ import io.github.jdreioe.wingmate.domain.obf.BoardActivationBehavior
 import io.github.jdreioe.wingmate.domain.obf.BoardReturnBehavior
 import io.github.jdreioe.wingmate.domain.obf.BoardSettingsOverrides
 import io.github.jdreioe.wingmate.domain.obf.withPageSettingsOverrides
+import io.github.jdreioe.wingmate.domain.obf.WordType
+import io.github.jdreioe.wingmate.domain.obf.resolvedBackgroundColor
 import io.github.jdreioe.wingmate.infrastructure.OpenSymbolsClient
 import io.github.jdreioe.wingmate.infrastructure.SymbolSearchClient
 import io.github.jdreioe.wingmate.application.BoardSetUseCase
@@ -322,6 +325,11 @@ class KotlinBridge(private val port: Int = 8765) {
                 jsonObj["labelAtTop"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(labelAtTop = it) }
                 jsonObj["gridColumns"]?.jsonPrimitive?.intOrNull?.let { newSettings = newSettings.copy(gridColumns = it.coerceIn(1, 12)) }
                 jsonObj["highContrastMode"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(highContrastMode = it) }
+                jsonObj["wordTypeColorScheme"]?.jsonPrimitive?.contentOrNull?.let { value ->
+                    newSettings = newSettings.copy(wordTypeColorScheme = runCatching {
+                        WordTypeColorScheme.valueOf(value)
+                    }.getOrDefault(WordTypeColorScheme.None))
+                }
                 jsonObj["holdToSelectMillis"]?.jsonPrimitive?.longOrNull?.let { newSettings = newSettings.copy(holdToSelectMillis = it.coerceAtLeast(0)) }
                 jsonObj["dwellToSelectMillis"]?.jsonPrimitive?.longOrNull?.let { newSettings = newSettings.copy(dwellToSelectMillis = it.coerceAtLeast(0)) }
                 jsonObj["selectKeyBinding"]?.jsonPrimitive?.contentOrNull?.let { newSettings = newSettings.copy(selectKeyBinding = it) }
@@ -931,11 +939,28 @@ class KotlinBridge(private val port: Int = 8765) {
                     // absolute paths avoids one HTTP request plus base64 encode/decode
                     // for every symbol when a large page opens.
                     val renderBoards = responseBoards.map { board ->
-                        board.copy(images = board.images.map { image ->
+                        board.copy(
+                            buttons = board.buttons.map { button ->
+                                val generated = button.resolvedBackgroundColor(
+                                    appSettings.wordTypeColorScheme,
+                                    board.locale ?: appSettings.primaryLanguage,
+                                    resolveObfLocalizedString(
+                                        board.strings,
+                                        appSettings.primaryLanguage,
+                                        button.label,
+                                    ),
+                                ).takeIf { button.backgroundColor == null }
+                                if (generated == null) button else button.copy(
+                                    extensions = button.extensions +
+                                        ("ext_wingmate_resolved_background_color" to JsonPrimitive(generated))
+                                )
+                            },
+                            images = board.images.map { image ->
                             val path = image.path
                             if (path.isNullOrBlank() || path.startsWith('/')) image
                             else image.copy(path = localImageFile(path)?.absolutePath ?: path)
-                        })
+                            }
+                        )
                     }
                     call.respondText(
                         json.encodeToString(
@@ -1077,6 +1102,9 @@ class KotlinBridge(private val port: Int = 8765) {
                     body["linkedBoardId"]?.jsonPrimitive?.contentOrNull ?: existing?.loadBoard?.id,
                     body["actions"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull }
                         ?: existing?.let { it.actions.ifEmpty { listOfNotNull(it.action) } }.orEmpty(),
+                    (body["wordType"] as? JsonPrimitive)?.contentOrNull?.let { value ->
+                        WordType.entries.firstOrNull { it.wireValue == value }
+                    },
                 ) ?: return@put call.respond(HttpStatusCode.BadRequest)
                 call.respond(board)
             }

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
@@ -24,6 +24,7 @@ import io.github.jdreioe.wingmate.domain.SpeechSegment
 import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.domain.PointerEmphasisStyle
+import io.github.jdreioe.wingmate.domain.WordTypeColorScheme
 import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.domain.Phrase
 import io.github.jdreioe.wingmate.domain.SaidTextRepository
@@ -37,6 +38,10 @@ import io.github.jdreioe.wingmate.domain.obf.ObfGrid
 import io.github.jdreioe.wingmate.domain.obf.ObfImage
 import io.github.jdreioe.wingmate.domain.obf.ObfLoadBoard
 import io.github.jdreioe.wingmate.domain.obf.ObfKeyboardLayout
+import io.github.jdreioe.wingmate.domain.obf.WordType
+import io.github.jdreioe.wingmate.domain.obf.resolvedBackgroundColor
+import io.github.jdreioe.wingmate.domain.obf.wordType
+import io.github.jdreioe.wingmate.domain.obf.withWordType
 import io.github.jdreioe.wingmate.domain.obf.BoardSettingsOverrides
 import io.github.jdreioe.wingmate.domain.obf.BoardActivationBehavior
 import io.github.jdreioe.wingmate.domain.obf.BoardReturnBehavior
@@ -198,6 +203,10 @@ class KoinBridge : KoinComponent {
     suspend fun updateLabelAtTop(enabled: Boolean) = updateSettings { it.copy(labelAtTop = enabled) }
     suspend fun updateGridColumns(columns: Int) = updateSettings { it.copy(gridColumns = columns.coerceIn(1, 6)) }
     suspend fun updateHighContrastMode(enabled: Boolean) = updateSettings { it.copy(highContrastMode = enabled) }
+    suspend fun updateWordTypeColorScheme(scheme: String) = updateSettings {
+        it.copy(wordTypeColorScheme = runCatching { WordTypeColorScheme.valueOf(scheme) }
+            .getOrDefault(WordTypeColorScheme.None))
+    }
     suspend fun updateHoldToSelectMillis(millis: Long) = updateSettings { it.copy(holdToSelectMillis = millis.coerceIn(0, 2_000)) }
     suspend fun updateDwellToSelectMillis(millis: Long) = updateSettings { it.copy(dwellToSelectMillis = millis.coerceIn(0, 5_000)) }
     suspend fun updateSelectKeyBinding(binding: String) = updateSettings { it.copy(selectKeyBinding = binding) }
@@ -488,16 +497,25 @@ class KoinBridge : KoinComponent {
         val grid = board.grid ?: return emptyList()
         val buttons = board.buttons.associateBy { it.id }
         val images = board.images.associateBy { it.id }
-        val locale = get<SettingsUseCase>().get().primaryLanguage
+        val settings = get<SettingsUseCase>().get()
+        val locale = settings.primaryLanguage
         return grid.order.flatMapIndexed { row, columns ->
             columns.mapIndexedNotNull { col, buttonId ->
                 val id = buttonId ?: return@mapIndexedNotNull null
                 val button = buttons[id] ?: return@mapIndexedNotNull null
+                val localizedLabel = resolveObfLocalizedString(board.strings, locale, button.label)
                 IosBoardCell(
                     row, col, id,
-                    resolveObfLocalizedString(board.strings, locale, button.label),
+                    localizedLabel,
                     resolveObfLocalizedString(board.strings, locale, button.vocalization),
-                    button.backgroundColor, button.borderColor, button.loadBoard?.id,
+                    button.backgroundColor,
+                    button.resolvedBackgroundColor(
+                        settings.wordTypeColorScheme,
+                        board.locale ?: locale,
+                        localizedLabel,
+                    ),
+                    button.wordType?.wireValue,
+                    button.borderColor, button.loadBoard?.id,
                     button.imageId, button.imageId?.let { images[it]?.url }, button.hidden,
                     button.resolvedActions(),
                     button.soundId,
@@ -596,7 +614,7 @@ class KoinBridge : KoinComponent {
     suspend fun upsertBoardCellButton(
         boardId: String, row: Int, col: Int, label: String?, vocalization: String?,
         backgroundColor: String?, borderColor: String?, linkedBoardId: String?,
-        imageUrl: String?, clearImage: Boolean, actions: List<String>
+        imageUrl: String?, clearImage: Boolean, actions: List<String>, wordType: String?
     ): ObfBoard? {
         val repo = get<BoardRepository>()
         val board = repo.getBoard(boardId) ?: return null
@@ -618,7 +636,7 @@ class KoinBridge : KoinComponent {
             loadBoard = linkedBoardId?.let { ObfLoadBoard(id = it) },
             action = actions.singleOrNull(),
             actions = if (actions.size > 1) actions else emptyList()
-        )
+        ).withWordType(wordType?.let { value -> WordType.entries.firstOrNull { it.wireValue == value } })
         val buttons = board.buttons.filterNot { it.id == buttonId } + button
         val order = grid.order.mapIndexed { r, columns ->
             columns.mapIndexed { c, id -> if (r == row && c == col) buttonId else id }
@@ -883,6 +901,8 @@ data class IosBoardCell(
     val label: String?,
     val vocalization: String?,
     val backgroundColor: String?,
+    val resolvedBackgroundColor: String?,
+    val wordType: String?,
     val borderColor: String?,
     val linkedBoardId: String?,
     val imageId: String?,

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/BoardSetUseCase.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/BoardSetUseCase.kt
@@ -11,6 +11,8 @@ import io.github.jdreioe.wingmate.domain.obf.ObfGrid
 import io.github.jdreioe.wingmate.domain.obf.ObfImage
 import io.github.jdreioe.wingmate.domain.obf.ObfKeyboardLayout
 import io.github.jdreioe.wingmate.domain.obf.ObfLoadBoard
+import io.github.jdreioe.wingmate.domain.obf.WordType
+import io.github.jdreioe.wingmate.domain.obf.withWordType
 import io.github.jdreioe.wingmate.domain.obf.OBF_SCREEN_SETTINGS_EXTENSION
 import io.github.jdreioe.wingmate.domain.obf.encodeBoardSettings
 import kotlinx.serialization.encodeToString
@@ -370,6 +372,7 @@ class BoardSetUseCase(
         hidden: Boolean = false,
         linkedBoardId: String? = null,
         actions: List<String> = emptyList(),
+        wordType: WordType? = null,
     ): ObfBoard? {
         val boardSet = boardSetRepository.getBoardSet(boardSetId) ?: return null
         if (boardSet.isLocked) return null
@@ -423,7 +426,7 @@ class BoardSetUseCase(
             loadBoard = linkedBoardId?.takeIf { it in boardSet.boardIds }?.let { ObfLoadBoard(id = it) },
             action = actions.singleOrNull(),
             actions = if (actions.size > 1) actions else emptyList(),
-        )
+        ).withWordType(wordType)
 
         val updatedButtons = if (existingButton == null) {
             board.buttons + updatedButton

--- a/shared/src/commonTest/kotlin/ObzExporterTest.kt
+++ b/shared/src/commonTest/kotlin/ObzExporterTest.kt
@@ -6,6 +6,10 @@ import io.github.jdreioe.wingmate.domain.obf.ObfBoard
 import io.github.jdreioe.wingmate.domain.obf.ObfButton
 import io.github.jdreioe.wingmate.domain.obf.ObfButtonShape
 import io.github.jdreioe.wingmate.domain.obf.OBF_BUTTON_STYLE_EXTENSION
+import io.github.jdreioe.wingmate.domain.obf.OBF_WORD_TYPE_EXTENSION
+import io.github.jdreioe.wingmate.domain.obf.WordType
+import io.github.jdreioe.wingmate.domain.obf.withWordType
+import io.github.jdreioe.wingmate.domain.obf.wordType
 import io.github.jdreioe.wingmate.domain.obf.ObfImage
 import io.github.jdreioe.wingmate.domain.obf.ObfKeyboardLayout
 import io.github.jdreioe.wingmate.domain.obf.ObfLicense
@@ -40,6 +44,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import kotlin.test.assertIs
 
@@ -389,6 +394,22 @@ class ObzExporterTest {
             "speech",
             reparsed.buttons.first { it.id == "b1" }.extensions[OBF_BUTTON_STYLE_EXTENSION]?.jsonPrimitive?.content
         )
+    }
+
+    @Test
+    fun manualWordTypeRoundTripsWithoutPersistingGeneratedColor() {
+        val board = ObfBoard(
+            format = "open-board-0.1",
+            id = "word-type-board",
+            buttons = listOf(ObfButton(id = "b1", label = "play").withWordType(WordType.Noun))
+        )
+
+        val serialized = exporter.serializeBoard(board)
+        assertTrue(serialized.contains(OBF_WORD_TYPE_EXTENSION))
+
+        val reparsed = ObfParser().parseBoard(serialized).getOrThrow()
+        assertEquals(WordType.Noun, reparsed.buttons.single().wordType)
+        assertNull(reparsed.buttons.single().backgroundColor)
     }
 
     @Test

--- a/shared/src/commonTest/kotlin/SettingsModelTest.kt
+++ b/shared/src/commonTest/kotlin/SettingsModelTest.kt
@@ -1,6 +1,7 @@
 import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.domain.PointerEmphasisStyle
+import io.github.jdreioe.wingmate.domain.WordTypeColorScheme
 import io.github.jdreioe.wingmate.domain.obf.BoardActivationBehavior
 import io.github.jdreioe.wingmate.domain.obf.BoardReturnBehavior
 import kotlinx.serialization.json.Json
@@ -25,6 +26,7 @@ class SettingsModelTest {
         assertEquals(true, settings.boardShowMessageBar)
         assertEquals(BoardActivationBehavior.SpeakAndAdd, settings.boardActivationBehavior)
         assertEquals(BoardReturnBehavior.Stay, settings.boardReturnBehavior)
+        assertEquals(WordTypeColorScheme.None, settings.wordTypeColorScheme)
     }
 
     @Test
@@ -71,6 +73,16 @@ class SettingsModelTest {
         val encoded = json.encodeToString(Settings(historyVisible = false))
         val decoded = json.decodeFromString<Settings>(encoded)
         assertEquals(false, decoded.historyVisible)
+    }
+
+    @Test
+    fun wordTypeColorSchemeIsOffForExistingSettingsAndRoundTripsWhenEnabled() {
+        assertEquals(
+            WordTypeColorScheme.None,
+            json.decodeFromString<Settings>("{}").wordTypeColorScheme
+        )
+        val enabled = Settings(wordTypeColorScheme = WordTypeColorScheme.Fitzgerald)
+        assertEquals(enabled, json.decodeFromString<Settings>(json.encodeToString(enabled)))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add optional Fitzgerald-style word-type colors with manual overrides and English/Danish inference.
- Persist word types across OBF/OBZ exports and expose matching controls across Android, iOS, and Linux.
- Improve pause/resume controls with platform-native floating or circular buttons.
- Add localization, documentation, contrast tests, and settings coverage.

## Testing

- Added `WordTypeColorsTest` coverage for classification, overrides, color precedence, and WCAG contrast.
- Not run: Gradle, Android, iOS, or Linux build verification.