### PR TITLE
#119 Polish cross-platform rest mode controls

### DIFF
--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/InteractionInput.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/InteractionInput.kt
@@ -2,6 +2,7 @@ package io.github.jdreioe.wingmate.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -27,6 +28,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
@@ -161,30 +163,53 @@ fun InteractionInputRoot(settings: Settings, enabled: Boolean = true, content: @
                     }
                 }
         ) {
+            var showRestNotice by remember { mutableStateOf(false) }
+            val inputPaused = host.state.isPaused
+            LaunchedEffect(inputPaused) {
+                if (inputPaused) {
+                    showRestNotice = true
+                    delay(10_000)
+                    showRestNotice = false
+                } else {
+                    showRestNotice = false
+                }
+            }
             content()
             if (enabled && (settings.dwellToSelectMillis > 0 || settings.selectKeyBinding.isNotBlank())) {
                 Button(
                     onClick = host::togglePause,
                     modifier = Modifier
-                        .align(Alignment.TopStart)
+                        .align(Alignment.BottomStart)
                         .padding(8.dp)
-                        .sizeIn(minWidth = 56.dp, minHeight = 56.dp)
+                        .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
                         .semantics { liveRegion = LiveRegionMode.Polite }
                 ) {
-                    Icon(if (host.state.isPaused) Icons.Default.PlayArrow else Icons.Default.Pause, contentDescription = null)
-                    Text(if (host.state.isPaused) resumeLabel else restLabel, Modifier.padding(start = 8.dp))
+                    Icon(
+                        if (inputPaused) Icons.Default.PlayArrow else Icons.Default.Pause,
+                        contentDescription = if (inputPaused) resumeLabel else restLabel
+                    )
                 }
-                if (host.state.isPaused) {
+                if (inputPaused && showRestNotice) {
                     Row(
                         Modifier
-                            .align(Alignment.TopCenter)
-                            .padding(top = 72.dp)
-                            .background(MaterialTheme.colorScheme.inverseSurface, RoundedCornerShape(12.dp))
-                            .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(12.dp))
+                            .align(Alignment.BottomCenter)
+                            .padding(bottom = 76.dp)
+                            .clip(RoundedCornerShape(14.dp))
+                            .background(MaterialTheme.colorScheme.inverseSurface, RoundedCornerShape(14.dp))
+                            .border(2.dp, MaterialTheme.colorScheme.primary, RoundedCornerShape(14.dp))
                             .padding(horizontal = 16.dp, vertical = 10.dp)
+                            .clickable { host.togglePause() }
                             .semantics { liveRegion = LiveRegionMode.Assertive },
                         verticalAlignment = Alignment.CenterVertically,
-                    ) { Text(pausedStatus, color = MaterialTheme.colorScheme.inverseOnSurface) }
+                    ) {
+                        Text(pausedStatus, color = MaterialTheme.colorScheme.inverseOnSurface)
+                        Icon(
+                            Icons.Default.PlayArrow,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.inverseOnSurface,
+                            modifier = Modifier.padding(start = 8.dp)
+                        )
+                    }
                 }
             }
         }

--- a/docs/HEAD_EYE_TRACKING.md
+++ b/docs/HEAD_EYE_TRACKING.md
@@ -16,8 +16,10 @@ settings tabs) to configure:
 - **Pointer emphasis**: keep the system pointer or emphasize the current target
   with a larger high-contrast ring or outline.
 
-The Rest mode control remains at the edge of the workspace. While resting,
+The Rest mode control stays at the bottom edge of the workspace. While resting,
 ordinary taps and clicks continue to work, and resuming starts a fresh hover timer.
+The paused status appears as a notification next to the control and goes away on
+its own after a few seconds; the control itself remains available to resume.
 
 ## iPhone and iPad Eye Tracking
 

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
     @State private var showPronunciationSheet = false
     @State private var showSettingsPanel = false
     @State private var editingPhrase: Shared.Phrase? = nil
+    @State private var restBannerVisible = false
 
     @State private var recorder = AudioRecorder()
     @State private var recordingForPhraseId: String? = nil
@@ -197,28 +198,45 @@ struct ContentView: View {
                     }
                 }
             }
-            .overlay(alignment: .topLeading) {
+            .overlay(alignment: .bottomLeading) {
                 if !shouldShowWelcomeFlow && (model.dwellToSelectMillis > 0 || !model.selectKeyBinding.isEmpty) {
                     Button(action: model.toggleInputPause) {
-                        Label(model.inputIsPaused ? "interaction.resume" : "interaction.rest_mode",
-                              systemImage: model.inputIsPaused ? "play.fill" : "pause.fill")
-                            .frame(minWidth: 56, minHeight: 56)
+                        Image(systemName: model.inputIsPaused ? "play.fill" : "pause.fill")
+                            .frame(width: 44, height: 44)
                     }
                     .buttonStyle(.borderedProminent)
-                    .padding(8)
-                    .accessibilityAddTraits(.isButton)
+                    .clipShape(Circle())
+                    .padding(12)
+                    .accessibilityLabel(Text(model.inputIsPaused ? "interaction.resume" : "interaction.rest_mode"))
                 }
             }
-            .overlay(alignment: .top) {
+            .overlay(alignment: .bottom) {
+                if model.inputIsPaused && restBannerVisible {
+                    HStack(spacing: 12) {
+                        Text("interaction.paused_status")
+                            .font(.subheadline.weight(.semibold))
+                        Button(action: model.toggleInputPause) {
+                            Text("interaction.resume")
+                                .font(.subheadline.weight(.semibold))
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+                    .overlay(RoundedRectangle(cornerRadius: 16, style: .continuous).stroke(Color.accentColor, lineWidth: 2))
+                    .padding(.bottom, 84)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .accessibilityAddTraits(.updatesFrequently)
+                }
+            }
+            .task(id: model.inputIsPaused) {
                 if model.inputIsPaused {
-                    Text("interaction.paused_status")
-                        .font(.headline)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .background(.regularMaterial, in: Capsule())
-                        .overlay(Capsule().stroke(Color.accentColor, lineWidth: 2))
-                        .padding(.top, 72)
-                        .accessibilityAddTraits(.updatesFrequently)
+                    withAnimation(.easeInOut(duration: 0.2)) { restBannerVisible = true }
+                    try? await Task.sleep(nanoseconds: 10_000_000_000)
+                    withAnimation(.easeInOut(duration: 0.2)) { restBannerVisible = false }
+                } else {
+                    withAnimation(.easeInOut(duration: 0.2)) { restBannerVisible = false }
                 }
             }
         }

--- a/linuxApp/src/main.rs
+++ b/linuxApp/src/main.rs
@@ -695,6 +695,9 @@ struct AccessInputResponse {
     activation_target_id: Option<String>,
     is_paused: bool,
     current_target_id: Option<String>,
+    // Kept on the response; the transient rest-mode notice intentionally no
+    // longer renders a dwell percentage.
+    #[allow(dead_code)]
     dwell_progress: f32,
 }
 
@@ -794,8 +797,8 @@ struct Wingmate {
     scan_index: usize,
     last_scan_advance: Instant,
     input_is_paused: bool,
+    rest_notice_visible: bool,
     current_access_target_id: Option<String>,
-    access_dwell_progress: f32,
     known_access_targets: HashMap<String, AccessTarget>,
     window_width: f32,
     window_height: f32,
@@ -903,6 +906,7 @@ enum Message {
     SettingFloat(&'static str, f32),
     SettingString(&'static str, String),
     ToggleInputPause,
+    HideRestNotice,
     GridColumnsChanged(i32),
     StartupBoardSetChanged(String),
     StartupModeChanged(String),
@@ -1149,8 +1153,8 @@ impl cosmic::Application for Wingmate {
             scan_index: 0,
             last_scan_advance: Instant::now(),
             input_is_paused: false,
+            rest_notice_visible: false,
             current_access_target_id: None,
-            access_dwell_progress: 0.0,
             known_access_targets: HashMap::new(),
             window_width: 1024.0,
             window_height: 768.0,
@@ -1197,6 +1201,11 @@ impl cosmic::Application for Wingmate {
             subscriptions.push(
                 cosmic::iced::time::every(Duration::from_millis(200))
                     .map(|_| Message::PollPresetProgress),
+            );
+        }
+        if self.rest_notice_visible {
+            subscriptions.push(
+                cosmic::iced::time::every(Duration::from_secs(10)).map(|_| Message::HideRestNotice),
             );
         }
         Subscription::batch(subscriptions)
@@ -1647,9 +1656,14 @@ impl cosmic::Application for Wingmate {
             Message::AccessActivate(target) => return self.activate_access(target),
             Message::AccessInputUpdated(result) => {
                 if let Ok(state) = result {
+                    let was_paused = self.input_is_paused;
                     self.input_is_paused = state.is_paused;
                     self.current_access_target_id = state.current_target_id;
-                    self.access_dwell_progress = state.dwell_progress;
+                    if state.is_paused && !was_paused {
+                        self.rest_notice_visible = true;
+                    } else if !state.is_paused {
+                        self.rest_notice_visible = false;
+                    }
                     if let Some(id) = state.activation_target_id {
                         if let Some(target) = self.known_access_targets.get(&id).cloned() {
                             return self.activate_access(target);
@@ -2206,6 +2220,10 @@ impl cosmic::Application for Wingmate {
             }
             Message::ToggleInputPause => {
                 return self.api.access_input("togglePause", None, None).map(cosmic::Action::App);
+            }
+            Message::HideRestNotice => {
+                self.rest_notice_visible = false;
+                return Task::none();
             }
             Message::GridColumnsChanged(v) => {
                 self.settings.grid_columns = v;
@@ -2863,11 +2881,11 @@ impl cosmic::Application for Wingmate {
         };
 
         column![
-            self.interaction_status_view(),
             container(content)
                 .padding(content_padding)
                 .width(Fill)
                 .height(Fill),
+            self.interaction_bottom_control(),
             self.status_view(),
         ]
         .height(Fill)
@@ -2876,27 +2894,41 @@ impl cosmic::Application for Wingmate {
 }
 
 impl Wingmate {
-    fn interaction_status_view(&self) -> Element<'_, Message> {
+    fn interaction_bottom_control(&self) -> Element<'_, Message> {
         let enabled = matches!(self.page, Page::Communicate | Page::Screens)
             && (self.settings.dwell_to_select_millis > 0 || !self.settings.select_key_binding.is_empty());
         if !enabled {
             return Space::new().height(0).into();
         }
-        let action = button(text(if self.input_is_paused { "Resume input" } else { "Rest mode" }).size(18))
+        let toggle = button(text(if self.input_is_paused { "Resume input" } else { "Rest mode" }).size(14))
             .on_press(Message::ToggleInputPause)
-            .padding([14, 20]);
-        let status = if self.input_is_paused {
-            "Rest mode — hover selection and the Select key are paused".to_string()
-        } else if self.access_dwell_progress > 0.0 {
-            format!("Pointer input active · Hover selection {}%", (self.access_dwell_progress * 100.0).round() as i32)
-        } else {
-            "Pointer input active".to_string()
-        };
-        container(row![action, text(status).size(16).width(Fill)].spacing(14).align_y(cosmic::iced::alignment::Alignment::Center))
-            .padding([8, 24])
-            .width(Fill)
-            .class(if self.input_is_paused { cosmic::theme::iced::Container::Primary } else { cosmic::theme::iced::Container::Secondary })
+            .padding([8, 14]);
+        let notice: Element<'_, Message> = if self.rest_notice_visible && self.input_is_paused {
+            container(
+                row![
+                    text("Rest mode — hover selection and the Select key are paused").size(15),
+                    button(text("Resume input").size(14))
+                        .on_press(Message::ToggleInputPause)
+                        .padding([6, 12]),
+                ]
+                .spacing(12)
+                .align_y(cosmic::iced::alignment::Alignment::Center),
+            )
+            .padding([10, 12])
+            .class(cosmic::theme::iced::Container::Primary)
             .into()
+        } else {
+            Space::new().height(0).into()
+        };
+        column![
+            container(notice).align_x(cosmic::iced::alignment::Alignment::Center),
+            container(toggle)
+                .align_x(cosmic::iced::alignment::Alignment::Start)
+                .padding([0, 0, 0, 8]),
+        ]
+        .spacing(6)
+        .width(Fill)
+        .into()
     }
 
     fn status_view(&self) -> Element<'_, Message> {


### PR DESCRIPTION
## Summary

- Move rest mode controls to the bottom of the workspace across Android, iOS, and Linux.
- Show a temporary paused-status notification with a direct resume action.
- Remove the unused word-type color configuration and related OBF metadata.
- Update accessibility documentation and localized strings.

## Testing

- Not run.