### PR TITLE
#154 Make square buttons the cross-platform default

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -79,7 +79,7 @@ The following list is taken from the OpenAAC [AAC App Development](https://www.o
 - [x] 💜 **customizable keyboards**
   Some AAC apps user the built-in keyboard for spelling purposes, but depending on the user these keyboards may not be accessible. Additionally, some users may need larger buttons and a full keyboard doesn't fit on a single screen, or QWERTY may not be the most intuitive layout, so custom keyboards can provide value for different users.
 - [x] 💜 **options for different-shaped buttons**
-  Android authors can choose the rounded default, square, pill, speech bubble, or thought bubble per button. Shapes preserve the full rectangular touch target and round-trip with shared OBF/OBZ vocabulary data.
+  Android authors can choose the square default, rounded, pill, speech bubble, or thought bubble per button. Shapes preserve the full rectangular touch target and round-trip with shared OBF/OBZ vocabulary data.
 
 </details>
 

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetDialogs.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetDialogs.kt
@@ -286,7 +286,7 @@ internal fun EditBoardCellDialog(
     initialLanguage: String? = null,
     initialMathMode: Boolean = false,
     initialHidden: Boolean = false,
-    initialShape: ObfButtonShape = ObfButtonShape.Rounded,
+    initialShape: ObfButtonShape = ObfButtonShape.Square,
     initialWordType: WordType? = null,
     isKeyboardBoard: Boolean = false,
     showMathMode: Boolean = true,

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -1688,7 +1688,7 @@ private fun BoardSetWorkspaceScreen(
             initialLanguage = target.button?.locale,
             initialMathMode = target.button?.mathMode == true,
             initialHidden = target.button?.hidden == true,
-            initialShape = target.button?.shape ?: ObfButtonShape.Rounded,
+            initialShape = target.button?.shape ?: ObfButtonShape.Square,
             initialWordType = target.button?.wordType,
             isKeyboardBoard = activeBoard.isKeyboard,
             showMathMode = supportsMathMode(settings.ttsEngine),

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/ButtonShapes.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/ButtonShapes.kt
@@ -15,7 +15,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 /**
- * Corner radius (in dp) used for the rounded default button shape.
+ * Corner radius (in dp) used for the rounded button shape.
  */
 internal val ButtonDefaultCornerRadius = 12.dp
 

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -725,7 +725,7 @@ internal fun SpanningBoardGrid(
                             focus.first in item.row until item.row + item.rowSpan &&
                                 focus.second in item.column until item.column + item.columnSpan
                         } == true && item.button != null
-                        val ringShape = item.button?.shape?.toShape() ?: roundedShape()
+                        val ringShape = item.button?.shape?.toShape() ?: squareShape()
                         Box(
                             modifier = Modifier
                                 .fillMaxSize()

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/BoardSessionLogic.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/BoardSessionLogic.kt
@@ -390,7 +390,7 @@ fun updateDraftCell(
     linkedBoardId: String?,
     action: String? = null,
     actions: List<String> = emptyList(),
-    shape: ObfButtonShape = ObfButtonShape.Rounded,
+    shape: ObfButtonShape = ObfButtonShape.Square,
     wordType: WordType? = null
 ): BoardSetGraph {
     val board = graph.boardsById[boardId] ?: return graph

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfModels.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfModels.kt
@@ -26,7 +26,7 @@ enum class ObfButtonType(val wireValue: String) {
 /**
  * Visual shapes a button field can render as. Stored per-button in the
  * `ext_wingmate_button_style` extension so it round-trips through OBF/OBZ and
- * falls back to the default ([Rounded]) for consumers that do not know a value.
+ * falls back to the default ([Square]) for consumers that do not know a value.
  */
 enum class ObfButtonShape(val wireValue: String) {
     Rounded("rounded"),
@@ -180,17 +180,17 @@ data class ObfButton(
     )
 
     /**
-     * The visual shape of this button, falling back to [ObfButtonShape.Rounded]
+     * The visual shape of this button, falling back to [ObfButtonShape.Square]
      * when the extension is missing, non-string, or holds an unknown value so
      * forward-compatible OBF/OBZ imports never crash.
      */
     val shape: ObfButtonShape
         get() = ObfButtonShape.entries.firstOrNull {
             it.wireValue == (extensions[OBF_BUTTON_STYLE_EXTENSION] as? JsonPrimitive)?.contentOrNull
-        } ?: ObfButtonShape.Rounded
+        } ?: ObfButtonShape.Square
 
     fun withShape(shape: ObfButtonShape): ObfButton = copy(
-        extensions = if (shape == ObfButtonShape.Rounded) {
+        extensions = if (shape == ObfButtonShape.Square) {
             extensions - OBF_BUTTON_STYLE_EXTENSION
         } else {
             extensions + (OBF_BUTTON_STYLE_EXTENSION to JsonPrimitive(shape.wireValue))

--- a/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfButtonShapeTest.kt
+++ b/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/ObfButtonShapeTest.kt
@@ -14,7 +14,7 @@ class ObfButtonShapeTest {
         ObfButtonShape.entries.forEach { expected ->
             val button = ObfButton(id = "b").withShape(expected)
             assertEquals(expected, button.shape)
-            if (expected == ObfButtonShape.Rounded) {
+            if (expected == ObfButtonShape.Square) {
                 // Default shape is not persisted as an extension.
                 assertNull(button.extensions[OBF_BUTTON_STYLE_EXTENSION])
             } else {
@@ -27,33 +27,33 @@ class ObfButtonShapeTest {
     }
 
     @Test
-    fun defaultIsRoundedAndClearsExtension() {
+    fun defaultIsSquareAndClearsExtension() {
         val button = ObfButton(id = "b")
-        assertEquals(ObfButtonShape.Rounded, button.shape)
+        assertEquals(ObfButtonShape.Square, button.shape)
         assertNull(button.extensions[OBF_BUTTON_STYLE_EXTENSION])
 
-        val defaulted = ObfButton(id = "b").withShape(ObfButtonShape.Pill).withShape(ObfButtonShape.Rounded)
-        assertEquals(ObfButtonShape.Rounded, defaulted.shape)
+        val defaulted = ObfButton(id = "b").withShape(ObfButtonShape.Pill).withShape(ObfButtonShape.Square)
+        assertEquals(ObfButtonShape.Square, defaulted.shape)
         assertNull(defaulted.extensions[OBF_BUTTON_STYLE_EXTENSION])
     }
 
     @Test
-    fun unknownWireValueFallsBackToRounded() {
+    fun unknownWireValueFallsBackToSquare() {
         val button = ObfButton(
             id = "b",
             extensions = mapOf(OBF_BUTTON_STYLE_EXTENSION to JsonPrimitive("hexagon"))
         )
-        assertEquals(ObfButtonShape.Rounded, button.shape)
+        assertEquals(ObfButtonShape.Square, button.shape)
         assertFalse(button.extensions.containsKey("ext_wingmate_does_not_exist"))
     }
 
     @Test
-    fun nonStringValueFallsBackToRounded() {
+    fun nonStringValueFallsBackToSquare() {
         val button = ObfButton(
             id = "b",
             extensions = mapOf(OBF_BUTTON_STYLE_EXTENSION to JsonPrimitive(42))
         )
-        assertEquals(ObfButtonShape.Rounded, button.shape)
+        assertEquals(ObfButtonShape.Square, button.shape)
     }
 
     @Test

--- a/iosApp/iosApp/ViewModels/IosViewModel.swift
+++ b/iosApp/iosApp/ViewModels/IosViewModel.swift
@@ -30,6 +30,7 @@ struct BoardCellInfo: Identifiable, Equatable {
     var actions: [String]
     var soundId: String? = nil
     var soundDataUrl: String? = nil
+    var shape: String
 
     var id: String { "\(row):\(col)" }
 }
@@ -1809,7 +1810,8 @@ final class IosViewModel: ObservableObject {
                     hidden: cell.hidden,
                     actions: cell.actions,
                     soundId: cell.soundId,
-                    soundDataUrl: cell.soundDataUrl
+                    soundDataUrl: cell.soundDataUrl,
+                    shape: cell.shape
                 )
             }
             boardFieldItems = fields.map { field in

--- a/iosApp/iosApp/Views/SymbolBoardWorkspaceView.swift
+++ b/iosApp/iosApp/Views/SymbolBoardWorkspaceView.swift
@@ -794,6 +794,7 @@ struct SymbolBoardWorkspaceView: View {
 
     private func boardCellButton(row: Int, col: Int, isEditMode: Bool, width: CGFloat, height: CGFloat, rowSpan: Int = 1, columnSpan: Int = 1) -> some View {
         let cell = model.cellAt(row: row, col: col)
+        let cornerRadius = boardCellCornerRadius(cell, width: width, height: height)
         let isLinked = trimmed(cell?.linkedBoardId) != nil
         let sourceCellId = "\(row):\(col)"
         let hiddenInRunMode = !model.boardButtonIsVisible(
@@ -856,14 +857,14 @@ struct SymbolBoardWorkspaceView: View {
             .overlay {
                 let targetId = "board:\(cell?.buttonId ?? sourceCellId)"
                 if !isEditMode && model.accessTargetId == targetId && model.pointerEmphasisStyle != "System" {
-                    RoundedRectangle(cornerRadius: model.pointerEmphasisStyle == "Ring" ? 20 : 2)
+                    RoundedRectangle(cornerRadius: cornerRadius)
                         .stroke(Color.accentColor, lineWidth: 3 * model.pointerEmphasisScale)
                         .padding(6 / model.pointerEmphasisScale)
                         .accessibilityHidden(true)
                         .allowsHitTesting(false)
                 }
                 if !isEditMode && model.accessTargetId == targetId && model.accessDwellProgress > 0 {
-                    RoundedRectangle(cornerRadius: 10)
+                    RoundedRectangle(cornerRadius: cornerRadius)
                         .trim(from: 0, to: model.accessDwellProgress)
                         .stroke(Color.accentColor, style: StrokeStyle(lineWidth: 5, lineCap: .round))
                         .accessibilityHidden(true)
@@ -913,10 +914,10 @@ struct SymbolBoardWorkspaceView: View {
         if cell == nil && isEditMode {
             return AnyView(
                 ZStack {
-                    RoundedRectangle(cornerRadius: 10)
+                    RoundedRectangle(cornerRadius: 0)
                         .fill(Color.clear)
                         .overlay(
-                            RoundedRectangle(cornerRadius: 10)
+                            RoundedRectangle(cornerRadius: 0)
                                 .strokeBorder(Color(.separator), style: StrokeStyle(lineWidth: 1, dash: [4]))
                         )
                     Image(systemName: "plus")
@@ -974,17 +975,25 @@ struct SymbolBoardWorkspaceView: View {
         .padding(8)
         .frame(width: width, height: height, alignment: .topLeading)
         .background(
-            RoundedRectangle(cornerRadius: 10)
+            RoundedRectangle(cornerRadius: boardCellCornerRadius(cell, width: width, height: height))
                 .fill(model.highContrastMode ? Color(.systemBackground) : colorFromHex(cell?.resolvedBackgroundColor, fallback: Color(.tertiarySystemBackground)))
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 10)
+            RoundedRectangle(cornerRadius: boardCellCornerRadius(cell, width: width, height: height))
                 .stroke(isHighlighted
                     ? (model.highContrastMode ? Color.white : contrastingColor(for: cell?.resolvedBackgroundColor, fallback: Color.accentColor))
                     : (model.highContrastMode ? Color.primary : colorFromHex(cell?.borderColor, fallback: isLinked ? .accentColor : Color(.separator))),
                     lineWidth: isHighlighted ? 4 : (model.highContrastMode ? 2 : (isLinked ? 1.5 : 1)))
         )
         )
+    }
+
+    private func boardCellCornerRadius(_ cell: BoardCellInfo?, width: CGFloat, height: CGFloat) -> CGFloat {
+        switch cell?.shape {
+        case "rounded", "speech", "thought": return 10
+        case "pill": return min(width, height) / 2
+        default: return 0
+        }
     }
 
     private func boardCellLabel(_ cell: BoardCellInfo?, fontScale: CGFloat = 1) -> some View {

--- a/linuxApp/src/main.rs
+++ b/linuxApp/src/main.rs
@@ -4381,6 +4381,7 @@ impl Wingmate {
                     .and_then(BoardButton::rendered_background_color)
                     .and_then(parse_hex_color)
             };
+            let field_radius = button_data.map(board_button_radius).unwrap_or(0.0);
             let label_color = field_color.map(contrasting_foreground);
             let has_symbol = symbol_source.is_some();
             let show_symbol = has_symbol && show_symbols;
@@ -4421,15 +4422,12 @@ impl Wingmate {
                 .align_x(cosmic::iced::alignment::Horizontal::Center)
                 .align_y(cosmic::iced::alignment::Vertical::Center);
             let field_widget: Element<'_, Message> = if self.board_edit_mode {
-                let mut field_button = button(centered_content)
+                button(centered_content)
                     .on_press(action)
                     .width(cosmic::iced::Length::Fixed(field_width))
                     .height(field_height)
-                    .class(cosmic::theme::iced::Button::Secondary);
-                if let Some(color) = field_color {
-                    field_button = field_button.class(colored_button_class(color));
-                }
-                field_button.into()
+                    .class(board_button_class(field_color, field_radius, false))
+                    .into()
             } else if button_data.is_none() {
                 button(centered_content)
                     .width(cosmic::iced::Length::Fixed(field_width))
@@ -4439,18 +4437,13 @@ impl Wingmate {
             } else {
                 let button_data = button_data.expect("checked above");
                 let target = AccessTarget::BoardButton(board.id.clone(), button_data.id.clone());
+                let highlighted = self.access_highlighted(&target);
                 let mut field_button = button(centered_content)
                     .width(cosmic::iced::Length::Fixed(field_width))
                     .height(field_height)
-                    .class(cosmic::theme::iced::Button::Secondary);
-                if let Some(color) = field_color {
-                    field_button = field_button.class(colored_button_class(color));
-                }
+                    .class(board_button_class(field_color, field_radius, highlighted));
                 if self.settings.hold_to_select_millis == 0 {
                     field_button = field_button.on_press(Message::AccessActivate(target.clone()));
-                }
-                if self.access_highlighted(&target) {
-                    field_button = field_button.class(cosmic::theme::iced::Button::Positive);
                 }
                 self.access_widget(field_button.into(), target)
             };
@@ -6736,16 +6729,43 @@ fn status_is_error(status: &str) -> bool {
     .any(|needle| normalized.contains(needle))
 }
 
-fn colored_button_class(color: cosmic::iced::Color) -> cosmic::theme::iced::Button {
-    cosmic::theme::iced::Button::Custom(Box::new(move |_theme, _status| {
-        let foreground = contrasting_foreground(color);
-        cosmic::iced::widget::button::Style {
-            background: Some(color.into()),
-            text_color: foreground,
-            icon_color: Some(foreground),
-            border_radius: 12.0.into(),
-            ..Default::default()
+fn board_button_radius(button: &BoardButton) -> f32 {
+    match button
+        .extensions
+        .get("ext_wingmate_button_style")
+        .and_then(serde_json::Value::as_str)
+    {
+        Some("rounded" | "speech" | "thought") => 12.0,
+        Some("pill") => 999.0,
+        _ => 0.0,
+    }
+}
+
+fn board_button_class(
+    color: Option<cosmic::iced::Color>,
+    radius: f32,
+    highlighted: bool,
+) -> cosmic::theme::iced::Button {
+    cosmic::theme::iced::Button::Custom(Box::new(move |theme, status| {
+        let base_class = if highlighted {
+            cosmic::theme::iced::Button::Positive
+        } else {
+            cosmic::theme::iced::Button::Secondary
+        };
+        let mut style = <cosmic::Theme as cosmic::iced::widget::button::Catalog>::style(
+            theme,
+            &base_class,
+            status,
+        );
+        if let Some(color) = color.filter(|_| !highlighted) {
+            let foreground = contrasting_foreground(color);
+            style.background = Some(color.into());
+            style.text_color = foreground;
+            style.icon_color = Some(foreground);
         }
+        style.border_radius = radius.into();
+        style.border.radius = radius.into();
+        style
     }))
 }
 

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
@@ -536,7 +536,8 @@ class KoinBridge : KoinComponent {
                     button.soundId,
                     board.sounds.firstOrNull { it.id == button.soundId }?.let { sound ->
                         sound.dataUrl ?: sound.data?.let { "data:audio;base64,$it" } ?: sound.url
-                    }
+                    },
+                    button.shape.wireValue
                 )
             }
         }
@@ -926,6 +927,7 @@ data class IosBoardCell(
     val actions: List<String>,
     val soundId: String? = null,
     val soundDataUrl: String? = null,
+    val shape: String = "square",
 )
 
 data class IosSettingsFlags(

--- a/shared/src/commonTest/kotlin/ObzExporterTest.kt
+++ b/shared/src/commonTest/kotlin/ObzExporterTest.kt
@@ -413,9 +413,9 @@ class ObzExporterTest {
     }
 
     @Test
-    fun unknownButtonShapeValueSurvivesImportAndFallsBackToRounded() {
+    fun unknownButtonShapeValueSurvivesImportAndFallsBackToSquare() {
         // A consumer/author that knows about a future shape must not break the
-        // default renderer: the raw value is preserved but resolves to Rounded.
+        // default renderer: the raw value is preserved but resolves to Square.
         val board = ObfBoard(
             format = "open-board-0.1",
             id = "unknown-shape",
@@ -428,7 +428,7 @@ class ObzExporterTest {
 
         val serialized = exporter.serializeBoard(board)
         val reparsed = ObfParser().parseBoard(serialized).getOrThrow()
-        assertEquals(ObfButtonShape.Rounded, reparsed.buttons.single().shape)
+        assertEquals(ObfButtonShape.Square, reparsed.buttons.single().shape)
         assertEquals(
             "zigzag_squiggly",
             reparsed.buttons.single().extensions[OBF_BUTTON_STYLE_EXTENSION]?.jsonPrimitive?.content


### PR DESCRIPTION
## Summary

- Make square buttons the default shape across Android, iOS, and Linux.
- Preserve explicit rounded, pill, speech, and thought button shapes.
- Update OBF/OBZ fallback behavior and shape tests for the new default.

## Testing

- Updated `ObfButtonShapeTest` expectations for square defaults and fallbacks.
- Updated `ObzExporterTest` for unknown-shape fallback behavior.
- Not run: full Android, iOS, and Linux builds.