### PR TITLE
#164 Surface explicit Android load and operation failures

### DIFF
--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/App.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/App.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.application.FeatureUsageEvents
 import io.github.jdreioe.wingmate.application.FeatureUsageReporter
 import io.github.jdreioe.wingmate.application.reportEvent
@@ -19,8 +20,10 @@ import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.StartupMode
 import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.application.CompleteBackupManager
+import io.github.jdreioe.wingmate.application.SettingsStateManager
 import org.koin.compose.koinInject
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.launch
 
@@ -33,6 +36,7 @@ fun App() {
     val featureUsageReporter = koinInject<FeatureUsageReporter>()
     val voiceUseCase = koinInject<VoiceUseCase>()
     val backupManager = koinInject<CompleteBackupManager>()
+    val settingsStateManager = koinInject<SettingsStateManager>()
     val restoreRevision by backupManager.restoreRevision.collectAsState()
     val reactiveSettings by rememberReactiveSettings()
 
@@ -43,6 +47,8 @@ fun App() {
         ) {
             var welcomeCompleted by remember { mutableStateOf<Boolean?>(null) }
             var currentScreen by remember { mutableStateOf<Screen?>(null) }
+            var startupLoadState by remember { mutableStateOf<StartupLoadState>(StartupLoadState.Loading) }
+            var startupRetryKey by remember { mutableIntStateOf(0) }
             var createBoardSetOnLaunch by remember { mutableStateOf(false) }
             var startupBoardSetId by remember { mutableStateOf<String?>(null) }
             val scope = rememberCoroutineScope()
@@ -53,33 +59,42 @@ fun App() {
             }
 
             fun completeWelcomeAndNavigate(mode: StartupMode, createScreen: Boolean, analyticsEnabled: Boolean) {
-                scope.launch(Dispatchers.Default) {
-                    val currentSettings = runCatching { settingsRepository.get() }.getOrNull() ?: Settings()
-                    settingsRepository.update(
-                        currentSettings.copy(
+                scope.launch {
+                    val savedSettings = try {
+                        withContext(Dispatchers.Default) {
+                            settingsRepository.update(
+                                settingsStateManager.getCurrentSettings().copy(
                             welcomeFlowCompleted = true,
                             startupMode = mode,
                             featureUsageReportingEnabled = analyticsEnabled
                         )
-                    )
-                }
-                createBoardSetOnLaunch = mode == StartupMode.Screens && createScreen
-                startupBoardSetId = null
-                featureUsageReporter.setEnabled(analyticsEnabled)
-                if (analyticsEnabled) {
+                            )
+                        }
+                    } catch (failure: CancellationException) {
+                        throw failure
+                    } catch (_: Exception) {
+                        startupLoadState = StartupLoadState.Failed
+                        return@launch
+                    }
+                    settingsStateManager.applyLoadedSettings(savedSettings)
+                    createBoardSetOnLaunch = mode == StartupMode.Screens && createScreen
+                    startupBoardSetId = null
+                    featureUsageReporter.setEnabled(analyticsEnabled)
+                    if (analyticsEnabled) {
+                        featureUsageReporter.reportEvent(
+                            FeatureUsageEvents.ANALYTICS_CONSENT_CHANGED,
+                            "enabled" to "true",
+                            "source" to "welcome_flow"
+                        )
+                    }
+                    val target = routeFor(mode)
+                    currentScreen = target
                     featureUsageReporter.reportEvent(
-                        FeatureUsageEvents.ANALYTICS_CONSENT_CHANGED,
-                        "enabled" to "true",
-                        "source" to "welcome_flow"
+                        FeatureUsageEvents.WELCOME_COMPLETED,
+                        "target" to target.name,
+                        "startup_mode" to mode.name.lowercase()
                     )
                 }
-                val target = routeFor(mode)
-                currentScreen = target
-                featureUsageReporter.reportEvent(
-                    FeatureUsageEvents.WELCOME_COMPLETED,
-                    "target" to target.name,
-                    "startup_mode" to mode.name.lowercase()
-                )
             }
 
             fun showWelcomeFlow() {
@@ -99,34 +114,46 @@ fun App() {
                 }
             }
 
-            LaunchedEffect(Unit) {
-                val settings = withContext(Dispatchers.Default) {
-                    runCatching { settingsRepository.get() }.getOrNull()
+            LaunchedEffect(startupRetryKey) {
+                startupLoadState = StartupLoadState.Loading
+                val loaded = withContext(Dispatchers.Default) {
+                    loadStartupState(settingsRepository::get, voiceUseCase::selected)
                 }
-                val hasSelectedVoice = withContext(Dispatchers.Default) {
-                    runCatching { voiceUseCase.selected() }.getOrNull() != null
+                startupLoadState = loaded
+                if (loaded is StartupLoadState.Ready) {
+                    val settings = loaded.settings
+                    settingsStateManager.applyLoadedSettings(settings)
+                    val hasSelectedVoice = loaded.selectedVoice != null
+                    welcomeCompleted = settings.welcomeFlowCompleted
+                    startupBoardSetId = settings.startupBoardSetId
+                    currentScreen = if (hasSelectedVoice) routeFor(settings.startupMode) else Screen.Welcome
+                    featureUsageReporter.reportEvent(
+                        FeatureUsageEvents.APP_STARTED,
+                        "welcome_completed" to welcomeCompleted.toString(),
+                        "voice_selected" to hasSelectedVoice.toString()
+                    )
                 }
-                welcomeCompleted = settings?.welcomeFlowCompleted ?: false
-                startupBoardSetId = settings?.startupBoardSetId
-                currentScreen = if (hasSelectedVoice) routeFor(settings?.startupMode ?: StartupMode.Keyboard) else Screen.Welcome
-                featureUsageReporter.reportEvent(
-                    FeatureUsageEvents.APP_STARTED,
-                    "welcome_completed" to (welcomeCompleted == true).toString(),
-                    "voice_selected" to hasSelectedVoice.toString()
-                )
             }
 
             LaunchedEffect(restoreRevision) {
                 if (restoreRevision == 0L) return@LaunchedEffect
-                val settings = withContext(Dispatchers.Default) { settingsRepository.get() }
-                val hasSelectedVoice = withContext(Dispatchers.Default) {
-                    voiceUseCase.selected() != null
+                startupLoadState = StartupLoadState.Loading
+                val loaded = withContext(Dispatchers.Default) {
+                    loadStartupState(settingsRepository::get, voiceUseCase::selected)
                 }
-                createBoardSetOnLaunch = false
-                startupBoardSetId = settings.startupBoardSetId
-                welcomeCompleted = settings.welcomeFlowCompleted
-                featureUsageReporter.setEnabled(settings.featureUsageReportingEnabled)
-                currentScreen = if (hasSelectedVoice) routeFor(settings.startupMode) else Screen.Welcome
+                startupLoadState = loaded
+                if (loaded is StartupLoadState.Ready) {
+                    settingsStateManager.applyLoadedSettings(loaded.settings)
+                    createBoardSetOnLaunch = false
+                    startupBoardSetId = loaded.settings.startupBoardSetId
+                    welcomeCompleted = loaded.settings.welcomeFlowCompleted
+                    featureUsageReporter.setEnabled(loaded.settings.featureUsageReportingEnabled)
+                    currentScreen = if (loaded.selectedVoice != null) {
+                        routeFor(loaded.settings.startupMode)
+                    } else {
+                        Screen.Welcome
+                    }
+                }
             }
 
             LaunchedEffect(currentScreen) {
@@ -151,7 +178,31 @@ fun App() {
             ) {
                 Box(modifier = Modifier.fillMaxSize().safeDrawingPadding()) {
                     key(restoreRevision) {
-                        when (currentScreen) {
+                        when {
+                            startupLoadState is StartupLoadState.Failed -> {
+                                Column(
+                                    modifier = Modifier.fillMaxSize().padding(24.dp),
+                                    horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
+                                    verticalArrangement = Arrangement.Center,
+                                ) {
+                                    Text(
+                                        text = androidx.compose.ui.res.stringResource(com.hojmoseit.wingmate.R.string.startup_load_failed),
+                                        style = MaterialTheme.typography.bodyLarge,
+                                    )
+                                    Spacer(Modifier.height(16.dp))
+                                    Button(onClick = { startupRetryKey++ }) {
+                                        Text(androidx.compose.ui.res.stringResource(com.hojmoseit.wingmate.R.string.common_retry))
+                                    }
+                                }
+                            }
+                            startupLoadState is StartupLoadState.Loading -> {
+                                Box(modifier = Modifier.fillMaxSize()) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.align(androidx.compose.ui.Alignment.Center)
+                                    )
+                                }
+                            }
+                            else -> when (currentScreen) {
                             Screen.Welcome -> {
                                 WelcomeScreen(
                                     onComplete = ::completeWelcomeAndNavigate,
@@ -186,6 +237,7 @@ fun App() {
                                     )
                                 }
                             }
+                        }
                         }
                     }
                 }

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/StartupLoadState.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/StartupLoadState.kt
@@ -1,0 +1,25 @@
+package io.github.jdreioe.wingmate
+
+import io.github.jdreioe.wingmate.domain.Settings
+import io.github.jdreioe.wingmate.domain.Voice
+import kotlinx.coroutines.CancellationException
+
+internal sealed interface StartupLoadState {
+    data object Loading : StartupLoadState
+    data class Ready(val settings: Settings, val selectedVoice: Voice?) : StartupLoadState
+    data object Failed : StartupLoadState
+}
+
+internal suspend fun loadStartupState(
+    loadSettings: suspend () -> Settings,
+    loadSelectedVoice: suspend () -> Voice?,
+): StartupLoadState = try {
+    StartupLoadState.Ready(
+        settings = loadSettings(),
+        selectedVoice = loadSelectedVoice(),
+    )
+} catch (error: CancellationException) {
+    throw error
+} catch (_: Exception) {
+    StartupLoadState.Failed
+}

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -144,6 +145,7 @@ import io.github.jdreioe.wingmate.domain.obf.withFieldSpan
 import io.github.jdreioe.wingmate.domain.obf.resized
 import io.github.jdreioe.wingmate.domain.obf.moveOrSwapField
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -240,9 +242,10 @@ fun BoardSetManagerScreen(
     fun refreshBoardSets() {
         scope.launch {
             isLoading = true
+            statusMessage = null
             runCatching { useCase.listBoardSets() }
                 .onSuccess { boardSets = it }
-                .onFailure { statusMessage = it.message ?: loadError }
+                .onFailure { statusMessage = loadError }
             isLoading = false
         }
     }
@@ -260,7 +263,7 @@ fun BoardSetManagerScreen(
                     statusMessage = deletedMessage
                     refreshBoardSets()
                 }
-                .onFailure { statusMessage = it.message ?: deleteError }
+                .onFailure { statusMessage = deleteError }
         }
     }
 
@@ -289,6 +292,7 @@ fun BoardSetManagerScreen(
             onBack = onBack,
             onOpenSettings = { showSettings = true },
             onCreate = { showCreateDialog = true },
+            onRetry = ::refreshBoardSets,
             onImport = boardImportService?.let { importService -> {
                 scope.launch {
                     when (val result = importService.importBoardSetResult()) {
@@ -301,7 +305,7 @@ fun BoardSetManagerScreen(
                         }
                         BoardImportResult.Cancelled -> Unit
                         is BoardImportResult.Failure -> {
-                            statusMessage = result.context.ifBlank { importError }
+                            statusMessage = importError
                         }
                     }
                 }
@@ -315,14 +319,14 @@ fun BoardSetManagerScreen(
                             statusMessage = duplicatedMessage
                             refreshBoardSets()
                         }
-                        .onFailure { statusMessage = it.message ?: duplicateError }
+                        .onFailure { statusMessage = duplicateError }
                 }
             },
             onToggleLock = { boardSet ->
                 scope.launch {
                     runCatching { useCase.toggleLocked(boardSet.id) }
                         .onSuccess { refreshBoardSets() }
-                        .onFailure { statusMessage = it.message ?: lockError }
+                        .onFailure { statusMessage = lockError }
                 }
             },
             onDelete = { deleteTarget = it }
@@ -363,7 +367,7 @@ fun BoardSetManagerScreen(
                                 showCreatedBoardSet(created)
                                 route = BoardSetRoute.Workspace(created.id, BoardWorkspaceMode.Run)
                             }
-                            is BoardImportResult.Failure -> statusMessage = result.context
+                            is BoardImportResult.Failure -> statusMessage = importError
                             BoardImportResult.Cancelled -> Unit
                         }
                         isQuickCoreImporting = false
@@ -389,7 +393,7 @@ fun BoardSetManagerScreen(
                                 else -> Unit
                             }
                         }
-                        .onFailure { statusMessage = it.message ?: createError }
+                        .onFailure { statusMessage = createError }
                     isCreating = false
                 }
             },
@@ -462,6 +466,7 @@ private fun BoardSetLibraryScreen(
     onBack: () -> Unit,
     onOpenSettings: () -> Unit,
     onCreate: () -> Unit,
+    onRetry: () -> Unit,
     onImport: (() -> Unit)?,
     onOpen: (ObfBoardSet) -> Unit,
     onEdit: (ObfBoardSet) -> Unit,
@@ -542,7 +547,11 @@ private fun BoardSetLibraryScreen(
                         Text(it, color = MaterialTheme.colorScheme.error)
                     }
                     Spacer(Modifier.height(16.dp))
-                    Button(onClick = onCreate) { Text(stringResource(R.string.board_sets_create)) }
+                    if (statusMessage != null) {
+                        Button(onClick = onRetry) { Text(stringResource(R.string.common_retry)) }
+                    } else {
+                        Button(onClick = onCreate) { Text(stringResource(R.string.board_sets_create)) }
+                    }
                 }
                 else -> LazyColumn(
                     modifier = Modifier.fillMaxSize(),
@@ -652,6 +661,7 @@ private fun BoardSetWorkspaceScreen(
     var highlightedButtonId by remember(boardSetId) { mutableStateOf<String?>(null) }
     var highlightGeneration by remember(boardSetId) { mutableLongStateOf(0L) }
     var isLoading by remember(boardSetId) { mutableStateOf(true) }
+    var loadRetryKey by remember(boardSetId) { mutableIntStateOf(0) }
     var statusMessage by remember(boardSetId) { mutableStateOf<String?>(null) }
     var nativeKeyboardDraft by remember(boardSetId) { mutableStateOf<String?>(null) }
     var showAddBoardDialog by remember { mutableStateOf(false) }
@@ -669,6 +679,7 @@ private fun BoardSetWorkspaceScreen(
     var appBarMenuExpanded by remember(boardSetId) { mutableStateOf(false) }
     val unlockToEditMessage = stringResource(R.string.board_workspace_unlock_to_edit)
     val saveErrorMessage = stringResource(R.string.board_workspace_save_error)
+    val exportErrorMessage = stringResource(R.string.board_workspace_export_error)
     // Placeholder substituted in click handler (stringResource formatting is composition-only).
     val unsupportedActionTemplate = stringResource(R.string.board_workspace_unsupported_action, "%ACTION%")
 
@@ -708,11 +719,17 @@ private fun BoardSetWorkspaceScreen(
     // they may be the first communication surface a user opens.
     LaunchedEffect(predictionService, saidTextRepository, settings.primaryLanguage) {
         val service = predictionService ?: return@LaunchedEffect
-        runCatching {
+        try {
             val history = saidTextRepository.list()
             val nGramService = service as? io.github.jdreioe.wingmate.infrastructure.SimpleNGramPredictionService
             if (nGramService != null) {
-                val dictionary = dictionaryLoader?.loadDictionary(settings.primaryLanguage).orEmpty()
+                val dictionary = try {
+                    dictionaryLoader?.loadDictionary(settings.primaryLanguage).orEmpty()
+                } catch (failure: CancellationException) {
+                    throw failure
+                } catch (_: Exception) {
+                    emptyList()
+                }
                 if (dictionary.isNotEmpty()) {
                     nGramService.setBaseLanguage(dictionary)
                     nGramService.train(history, clear = false)
@@ -722,26 +739,40 @@ private fun BoardSetWorkspaceScreen(
             } else {
                 service.train(history)
             }
+        } catch (failure: CancellationException) {
+            throw failure
+        } catch (_: Exception) {
+            // Prediction training is optional; the communication surface stays intact.
         }
     }
 
-    LaunchedEffect(boardSetId) {
+    LaunchedEffect(boardSetId, loadRetryKey) {
         isLoading = true
-        val loaded = withContext(Dispatchers.Default) { useCase.loadBoardSetGraph(boardSetId) }
-        val normalized = loaded?.withHomeFieldsBottomLeft()
-        savedGraph = normalized
-        selectedBoardId = normalized?.boardSet?.rootBoardId
-        if (normalized != null && initialMode == BoardWorkspaceMode.Edit && !normalized.boardSet.isLocked) {
-            if (editingAccessController?.requiresUnlock() == true) {
+        statusMessage = null
+        try {
+            val loaded = withContext(Dispatchers.Default) { useCase.loadBoardSetGraph(boardSetId) }
+                ?: error("Screen not found")
+            val normalized = loaded.withHomeFieldsBottomLeft()
+            savedGraph = normalized
+            selectedBoardId = normalized.boardSet.rootBoardId
+            if (initialMode == BoardWorkspaceMode.Edit && !normalized.boardSet.isLocked) {
+                if (editingAccessController?.requiresUnlock() == true) {
+                    mode = BoardWorkspaceMode.Run
+                    showEditingAccessDialog = true
+                } else {
+                    editSession = BoardSetEditSession(normalized, normalized)
+                }
+            } else if (normalized.boardSet.isLocked) {
                 mode = BoardWorkspaceMode.Run
-                showEditingAccessDialog = true
-            } else {
-                editSession = BoardSetEditSession(normalized, normalized)
             }
-        } else if (normalized?.boardSet?.isLocked == true) {
-            mode = BoardWorkspaceMode.Run
+        } catch (failure: CancellationException) {
+            throw failure
+        } catch (_: Exception) {
+            savedGraph = null
+            selectedBoardId = null
+        } finally {
+            isLoading = false
         }
-        isLoading = false
     }
 
     // #120: expire the selection highlight after the configured duration. Re-activating a
@@ -886,7 +917,7 @@ private fun BoardSetWorkspaceScreen(
             try {
                 val graph = activeGraph
                 if (graph == null) {
-                    statusMessage = "Export failed: no board set loaded"
+                    statusMessage = exportErrorMessage
                 } else {
                     when (val export = useCase.exportBoardSetAsObzResult(graph.boardSet.id)) {
                         is ObzExportResult.Success -> {
@@ -904,16 +935,14 @@ private fun BoardSetWorkspaceScreen(
                             }
                         }
                         is ObzExportResult.Failure -> {
-                            val resources = export.resources
-                                .takeIf { it.isNotEmpty() }
-                                ?.joinToString(prefix = ": ")
-                                .orEmpty()
-                            statusMessage = "Export failed: ${export.context}$resources"
+                            statusMessage = exportErrorMessage
                     }
                     }
                 }
-            } catch (e: Exception) {
-                statusMessage = "Export failed: ${e.message ?: "unknown error"}"
+            } catch (failure: CancellationException) {
+                throw failure
+            } catch (_: Exception) {
+                statusMessage = exportErrorMessage
             } finally {
                 isExporting = false
             }
@@ -1338,6 +1367,9 @@ private fun BoardSetWorkspaceScreen(
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     Text(stringResource(R.string.board_workspace_load_error))
+                    TextButton(onClick = { loadRetryKey++ }) {
+                        Text(stringResource(R.string.common_retry))
+                    }
                     TextButton(onClick = onExitToLibrary) {
                         Text(stringResource(R.string.board_workspace_back_to_library))
                     }
@@ -1750,17 +1782,22 @@ private fun BoardSetWorkspaceScreen(
                     // Persist on an application-scoped scope so leaving this screen can't
                     // cancel the write halfway; branch back to the main thread for state updates.
                     val appScope = koin.get<CoroutineScope>()
-                    appScope.launch(Dispatchers.Main) {
-                        withContext(Dispatchers.Default) {
+                    appScope.launch {
+                        val result = withContext(Dispatchers.Default) {
                             useCase.saveBoardSetGraph(graph)
-                        }.onSuccess { saved ->
-                            savedGraph = saved
-                        }.onFailure { error ->
-                            // Persistence failed: drop back into editing with the draft intact
-                            // so the user does not lose their work.
-                            mode = BoardWorkspaceMode.Edit
-                            editSession = session
-                            statusMessage = error.message ?: saveErrorMessage
+                        }
+                        // UI updates remain tied to this screen's lifecycle even though the
+                        // persistence itself is allowed to finish after navigation.
+                        scope.launch {
+                            result.onSuccess { saved ->
+                                savedGraph = saved
+                            }.onFailure {
+                                // Persistence failed: drop back into editing with the draft intact
+                                // so the user does not lose their work.
+                                mode = BoardWorkspaceMode.Edit
+                                editSession = session
+                                statusMessage = saveErrorMessage
+                            }
                         }
                     }
                 }) { Text(stringResource(R.string.board_workspace_save_changes)) }

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/ImportOptionsScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/ImportOptionsScreen.kt
@@ -23,6 +23,7 @@ fun ImportOptionsScreen(
     onImportModern: () -> Unit,
     onCreateFromScratch: () -> Unit,
     onSkip: () -> Unit,
+    errorMessage: String? = null,
     showClassic: Boolean = true,
     showModern: Boolean = true,
     showCreateFromScratch: Boolean = true
@@ -83,6 +84,15 @@ fun ImportOptionsScreen(
             }
 
             Spacer(modifier = Modifier.height(32.dp))
+
+            errorMessage?.let {
+                Text(
+                    text = it,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+            }
 
             TextButton(onClick = onSkip) {
                 Text(stringResource(R.string.import_options_skip))

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/PhraseScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/PhraseScreen.kt
@@ -268,13 +268,19 @@ fun PhraseScreen(
                     val ngramService = predictionService as? io.github.jdreioe.wingmate.infrastructure.SimpleNGramPredictionService
                     if (ngramService != null) {
                         if (dictionaryLoader != null) {
-                            val dictWords = dictionaryLoader.loadDictionary(primaryLanguageState.value)
+                            val dictWords = try {
+                                dictionaryLoader.loadDictionary(primaryLanguageState.value)
+                            } catch (failure: kotlinx.coroutines.CancellationException) {
+                                throw failure
+                            } catch (_: Exception) {
+                                emptyList()
+                            }
                             if (dictWords.isNotEmpty()) {
                                 ngramService.setBaseLanguage(dictWords)
                                 // History trained on TOP of dictionary, so don't clear
                                 ngramService.train(list, clear = false)
                             } else {
-                                // No dictionary (or failed), so standard train (clears old data)
+                                // Unsupported/unavailable dictionaries fall back to private local history.
                                 ngramService.train(list)
                             }
                         } else {
@@ -286,8 +292,10 @@ fun PhraseScreen(
                         predictionService.train(list)
                         predictionModelVersion++
                     }
-                } catch (e: Throwable) {
-                    historyItems = emptyList()
+                } catch (failure: kotlinx.coroutines.CancellationException) {
+                    throw failure
+                } catch (_: Exception) {
+                    // Preserve the currently visible history if a refresh fails.
                 }
             }
             

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
@@ -56,6 +56,7 @@ import io.github.jdreioe.wingmate.infrastructure.ArasaacDownloadProgress
 import io.github.jdreioe.wingmate.infrastructure.ArasaacSymbolDownloadService
 import io.github.jdreioe.wingmate.infrastructure.ImageCacher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
@@ -160,6 +161,11 @@ fun SettingsScreen(
     var dictionaryEntries by remember { mutableStateOf<List<PronunciationEntry>>(emptyList()) }
 
     var loading by remember { mutableStateOf(true) }
+    var settingsError by remember { mutableStateOf<String?>(null) }
+    var settingsRetryKey by remember { mutableIntStateOf(0) }
+    val settingsLoadFailed = stringResource(R.string.settings_load_failed)
+    val settingsSaveFailed = stringResource(R.string.settings_save_failed)
+    val voiceReadFailed = stringResource(R.string.voice_load_failed)
     val scope = rememberCoroutineScope()
     val settingsUpdateMutex = remember { Mutex() }
 
@@ -179,23 +185,39 @@ fun SettingsScreen(
     // Helper to update settings reactively
     fun updateSettings(update: (Settings) -> Settings) {
         scope.launch {
-            settingsUpdateMutex.withLock {
-                if (settingsStateManager != null) {
-                    settingsStateManager.updateSettings(update)
-                } else {
-                    settingsUseCase?.let { useCase ->
+            try {
+                settingsUpdateMutex.withLock {
+                    if (settingsStateManager != null) {
+                        settingsStateManager.updateSettings(update)
+                    } else {
+                        val useCase = checkNotNull(settingsUseCase) { "Settings are unavailable" }
                         withContext(Dispatchers.Default) {
-                            val current = runCatching { useCase.get() }.getOrNull() ?: Settings()
-                            useCase.update(update(current))
+                            useCase.update(update(useCase.get()))
                         }
                     }
                 }
+            } catch (failure: CancellationException) {
+                throw failure
+            } catch (_: Exception) {
+                settingsError = settingsSaveFailed
             }
         }
     }
 
+    suspend fun selectedVoiceOrReport(): Voice? = try {
+        voiceUseCase?.selected()
+    } catch (failure: CancellationException) {
+        throw failure
+    } catch (_: Exception) {
+        settingsError = voiceReadFailed
+        null
+    }
+
     // Load all settings on first composition
-    LaunchedEffect(Unit) {
+    LaunchedEffect(settingsRetryKey) {
+        loading = true
+        settingsError = null
+        try {
         val cfg = withContext(Dispatchers.Default) { configRepo?.getSpeechConfigStatus() }
         cfg?.let {
             endpoint = it.endpoint
@@ -203,7 +225,7 @@ fun SettingsScreen(
         }
 
         val s = withContext(Dispatchers.Default) {
-            runCatching { settingsUseCase?.get() }.getOrNull() ?: Settings()
+            checkNotNull(settingsUseCase) { "Settings are unavailable" }.get()
         }
         ttsEngine = s.ttsEngine
         virtualMic = s.virtualMicEnabled
@@ -213,7 +235,7 @@ fun SettingsScreen(
         startupMode = s.startupMode
         startupBoardSetId = s.startupBoardSetId
         availableBoardSets = withContext(Dispatchers.Default) {
-            runCatching { boardSetUseCase?.listBoardSets().orEmpty() }.getOrDefault(emptyList())
+            checkNotNull(boardSetUseCase) { "Screen storage is unavailable" }.listBoardSets()
         }
         showLabels = s.showLabels
         showSymbols = s.showSymbols
@@ -243,7 +265,13 @@ fun SettingsScreen(
         inputFieldScale = s.inputFieldScale
         featureUsageReporter?.setEnabled(s.featureUsageReportingEnabled)
         cachedArasaacSymbols = runCatching { arasaacDownloader?.cachedCount() ?: 0 }.getOrDefault(0)
-        loading = false
+        } catch (failure: CancellationException) {
+            throw failure
+        } catch (_: Exception) {
+            settingsError = settingsLoadFailed
+        } finally {
+            loading = false
+        }
     }
 
     // Load pronunciation entries when opening the dictionary
@@ -327,6 +355,17 @@ fun SettingsScreen(
                         Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                             CircularProgressIndicator()
                         }
+                    } else if (settingsError != null) {
+                        Column(
+                            modifier = Modifier.align(Alignment.Center).padding(24.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            Text(settingsError.orEmpty(), color = MaterialTheme.colorScheme.error)
+                            Button(onClick = { settingsRetryKey++ }) {
+                                Text(stringResource(R.string.common_retry))
+                            }
+                        }
                     } else if (showPronunciationDictionary) {
                         DictionaryScreen(
                             entries = dictionaryEntries,
@@ -355,7 +394,7 @@ fun SettingsScreen(
                             },
                             onTestEntry = { word, phoneme, alphabet ->
                                 scope.launch {
-                                    val voice = runCatching { voiceUseCase?.selected() }.getOrNull()
+                                    val voice = selectedVoiceOrReport()
                                     val pronunciationMarkup = if (alphabet == "text") {
                                         "<sub alias=\"$phoneme\">$word</sub>"
                                     } else {
@@ -370,7 +409,7 @@ fun SettingsScreen(
                                 }
                             },
                             onGuessPronunciation = { word ->
-                                val voice = runCatching { voiceUseCase?.selected() }.getOrNull()
+                                val voice = selectedVoiceOrReport()
                                 speechService?.guessPronunciation(
                                     word,
                                     voice?.selectedLanguage ?: voice?.primaryLanguage ?: "en"
@@ -1623,6 +1662,8 @@ private fun BackupSettingsGroup() {
     val exported = stringResource(R.string.backup_exported)
     val restored = stringResource(R.string.backup_restored)
     val cancelled = stringResource(R.string.backup_cancelled)
+    val backupPickerFailed = stringResource(R.string.backup_picker_failed)
+    val backupCreateFailed = stringResource(R.string.backup_create_failed)
 
     SettingsGroup(title = stringResource(R.string.backup_title)) {
         Text(
@@ -1637,11 +1678,20 @@ private fun BackupSettingsGroup() {
                 onClick = {
                     backupWorking = true
                     backupScope.launch {
-                        backupStatus = runCatching {
+                        try {
                             val bytes = checkNotNull(backupManager).exportBackup()
-                            if (checkNotNull(backupShareService).shareFile("wingmate-${Clock.System.now().toEpochMilliseconds()}.wingmate-backup", bytes)) exported else cancelled
-                        }.getOrElse { it.message ?: "Backup failed" }
-                        backupWorking = false
+                            backupStatus = if (checkNotNull(backupShareService).shareFile("wingmate-${Clock.System.now().toEpochMilliseconds()}.wingmate-backup", bytes)) {
+                                exported
+                            } else {
+                                cancelled
+                            }
+                        } catch (failure: CancellationException) {
+                            throw failure
+                        } catch (_: Exception) {
+                            backupStatus = backupCreateFailed
+                        } finally {
+                            backupWorking = false
+                        }
                     }
                 }
             ) { Text(stringResource(R.string.backup_create)) }
@@ -1649,10 +1699,17 @@ private fun BackupSettingsGroup() {
                 enabled = !backupWorking && backupManager != null && backupFilePicker != null,
                 onClick = {
                     backupScope.launch {
-                        pendingRestorePath = backupFilePicker?.pickFile(
-                            title = "Restore Wingmate backup",
-                            extensions = listOf("wingmate-backup", "zip")
-                        )
+                        backupStatus = null
+                        try {
+                            pendingRestorePath = backupFilePicker?.pickFile(
+                                title = "Restore Wingmate backup",
+                                extensions = listOf("wingmate-backup", "zip")
+                            )
+                        } catch (failure: CancellationException) {
+                            throw failure
+                        } catch (_: Exception) {
+                            backupStatus = backupPickerFailed
+                        }
                     }
                 }
             ) { Text(stringResource(R.string.backup_restore)) }
@@ -1969,6 +2026,7 @@ internal fun VoiceSelectionPage(
     var loading by remember { mutableStateOf(true) }
     var voices by remember { mutableStateOf<List<Voice>>(emptyList()) }
     var error by remember { mutableStateOf<String?>(null) }
+    var operationError by remember { mutableStateOf<String?>(null) }
     var selected by remember { mutableStateOf<Voice?>(null) }
     var showVoiceSettings by remember { mutableStateOf(false) }
     var editingVoice by remember { mutableStateOf<Voice?>(null) }
@@ -1978,30 +2036,43 @@ internal fun VoiceSelectionPage(
     var availableLanguages by remember { mutableStateOf<List<String>>(emptyList()) }
     var voiceSearch by remember { mutableStateOf("") }
     var genderFilter by remember { mutableStateOf<String?>(null) }
+    var retryKey by remember { mutableIntStateOf(0) }
     val scope = rememberCoroutineScope()
 
     val systemVoiceProvider = remember(koin) { koin.getOrNull<io.github.jdreioe.wingmate.infrastructure.SystemVoiceProvider>() }
 
-    LaunchedEffect(Unit) {
-        if (settingsUseCase != null) {
-            val settings = withContext(Dispatchers.Default) {
-                runCatching { settingsUseCase.get() }.getOrNull()
-            }
-            ttsEngine = settings?.ttsEngine ?: TtsEngine.SYSTEM
-        }
+    val voiceLoadFailed = stringResource(R.string.voice_load_failed)
+    val voiceSaveFailed = stringResource(R.string.voice_save_failed)
+
+    LaunchedEffect(retryKey) {
         loading = true
+        error = null
         try {
+            val settings = checkNotNull(settingsUseCase) { "Settings are unavailable" }
+                .let { withContext(Dispatchers.Default) { it.get() } }
+            ttsEngine = settings.ttsEngine
             if (ttsEngine == TtsEngine.SYSTEM) {
                 val allSystemVoices = systemVoiceProvider?.getSystemVoices() ?: listOf(
                     Voice(name = "system-default", displayName = "System Default", primaryLanguage = "en-US", gender = "Unknown")
                 )
                 systemVoices = allSystemVoices
                 availableLanguages = allSystemVoices.mapNotNull { it.primaryLanguage }.distinct().sorted()
-                selected = try { useCase.selected() } catch (e: Exception) { null }
+                selected = useCase.selected()
             } else {
-                val fromCloud = withContext(Dispatchers.Default) { useCase.refreshFromAzure() }
+                var cloudRefreshFailed = false
+                val fromCloud = try {
+                    withContext(Dispatchers.Default) { useCase.refreshFromAzure() }
+                } catch (failure: CancellationException) {
+                    throw failure
+                } catch (_: Exception) {
+                    cloudRefreshFailed = true
+                    emptyList()
+                }
                 val local = withContext(Dispatchers.Default) { useCase.list() }
                 val allVoices = (fromCloud + local).distinctBy { it.name }
+                if (allVoices.isEmpty() && cloudRefreshFailed) {
+                    error("No cached voices were available after refresh failed")
+                }
                 voices = allVoices
                 availableLanguages = allVoices
                     .flatMap { voice -> listOfNotNull(voice.primaryLanguage) + (voice.supportedLanguages ?: emptyList()) }
@@ -2009,10 +2080,13 @@ internal fun VoiceSelectionPage(
                     .sorted()
                 selected = useCase.selected()
             }
-        } catch (t: Throwable) {
-            error = t.message
+        } catch (failure: CancellationException) {
+            throw failure
+        } catch (_: Exception) {
+            error = voiceLoadFailed
+        } finally {
+            loading = false
         }
-        loading = false
     }
 
     val queryTerms = remember(voiceSearch) {
@@ -2108,10 +2182,17 @@ internal fun VoiceSelectionPage(
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
 
+        operationError?.let {
+            Text(it, color = MaterialTheme.colorScheme.error)
+        }
+
         if (loading) {
             Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
         } else if (error != null) {
-            Text(stringResource(R.string.voice_error, error ?: ""))
+            Text(error.orEmpty(), color = MaterialTheme.colorScheme.error)
+            TextButton(onClick = { retryKey++ }) {
+                Text(stringResource(R.string.common_retry))
+            }
         } else {
             val filteredVoices = if (ttsEngine == TtsEngine.SYSTEM) filteredSystemVoices else filteredAzureVoices
             val titleRes = if (ttsEngine == TtsEngine.SYSTEM) {
@@ -2137,6 +2218,7 @@ internal fun VoiceSelectionPage(
                             showSettings = ttsEngine != TtsEngine.SYSTEM,
                             onSelect = {
                                 scope.launch {
+                                    operationError = null
                                     try {
                                         useCase.select(v)
                                         val primary = if (ttsEngine == TtsEngine.SYSTEM) (v.primaryLanguage ?: "") else v.selectedLanguage.ifBlank { v.primaryLanguage ?: "" }
@@ -2144,10 +2226,13 @@ internal fun VoiceSelectionPage(
                                             val current = settingsUseCase.get()
                                             settingsUseCase.update(current.copy(primaryLanguage = primary))
                                         }
-                                    } catch (t: Throwable) {
-                                        println("Failed to select voice ${v.name}: $t")
+                                        selected = v
+                                        onVoiceSelected?.invoke() ?: onBack()
+                                    } catch (failure: CancellationException) {
+                                        throw failure
+                                    } catch (_: Exception) {
+                                        operationError = voiceSaveFailed
                                     }
-                                    onVoiceSelected?.invoke() ?: onBack()
                                 }
                             },
                             onSettings = {
@@ -2171,6 +2256,7 @@ internal fun VoiceSelectionPage(
             onDismiss = { showVoiceSettings = false },
             onSave = { updated ->
                 scope.launch {
+                    operationError = null
                     try {
                         useCase.select(updated)
                         val primary = updated.selectedLanguage.ifBlank { updated.primaryLanguage ?: "" }
@@ -2178,14 +2264,14 @@ internal fun VoiceSelectionPage(
                             val current = settingsUseCase.get()
                             settingsUseCase.update(current.copy(primaryLanguage = primary))
                         }
-                    } catch (t: Throwable) {
-                        println("Failed to save updated voice: $t")
-                    }
-                    showVoiceSettings = false
-                    try {
+                        showVoiceSettings = false
                         voices = (useCase.refreshFromAzure() + useCase.list()).distinctBy { it.name }
                         selected = useCase.selected()
-                    } catch (_: Throwable) {}
+                    } catch (failure: CancellationException) {
+                        throw failure
+                    } catch (_: Exception) {
+                        operationError = voiceSaveFailed
+                    }
                 }
             }
         )
@@ -2299,25 +2385,53 @@ internal fun LanguageSelectionPage(
     var secondary by remember { mutableStateOf("") }
     var selectedVoiceIsMultilingual by remember { mutableStateOf(false) }
     var useSecondaryLanguage by remember { mutableStateOf(false) }
+    var loading by remember { mutableStateOf(true) }
+    var loadError by remember { mutableStateOf<String?>(null) }
+    var operationError by remember { mutableStateOf<String?>(null) }
+    var retryKey by remember { mutableIntStateOf(0) }
+    val languageLoadFailed = stringResource(R.string.language_load_failed)
+    val languageSaveFailed = stringResource(R.string.language_save_failed)
 
-    LaunchedEffect(Unit) {
-        val settings = runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
-        primary = settings.primaryLanguage
-        secondary = settings.secondaryLanguage
-        val sel = runCatching { voiceUseCase.selected() }.getOrNull()
-        selectedVoiceIsMultilingual = sel?.supportedLanguages
-            ?.map { it.trim() }
-            ?.filter { it.isNotEmpty() }
-            ?.distinct()
-            ?.size
-            ?.let { it > 1 }
-            ?: false
-        useSecondaryLanguage = selectedVoiceIsMultilingual &&
-            settings.secondaryLanguage.isNotBlank() &&
-            settings.secondaryLanguage != settings.primaryLanguage
-        available = (sel?.supportedLanguages ?: emptyList())
-            .ifEmpty { listOf(settings.primaryLanguage, settings.secondaryLanguage, "en-US").filter { it.isNotBlank() } }
-            .distinct()
+    LaunchedEffect(retryKey) {
+        loading = true
+        loadError = null
+        try {
+            val settings = settingsUseCase.get()
+            val sel = voiceUseCase.selected()
+            primary = settings.primaryLanguage
+            secondary = settings.secondaryLanguage
+            selectedVoiceIsMultilingual = sel?.supportedLanguages
+                ?.map { it.trim() }
+                ?.filter { it.isNotEmpty() }
+                ?.distinct()
+                ?.size
+                ?.let { it > 1 }
+                ?: false
+            useSecondaryLanguage = selectedVoiceIsMultilingual &&
+                settings.secondaryLanguage.isNotBlank() &&
+                settings.secondaryLanguage != settings.primaryLanguage
+            available = (sel?.supportedLanguages ?: emptyList())
+                .ifEmpty { listOf(settings.primaryLanguage, settings.secondaryLanguage, "en-US").filter { it.isNotBlank() } }
+                .distinct()
+        } catch (failure: CancellationException) {
+            throw failure
+        } catch (_: Exception) {
+            loadError = languageLoadFailed
+        } finally {
+            loading = false
+        }
+    }
+
+    if (loading) {
+        Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
+        return
+    }
+    loadError?.let { message ->
+        Column(modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Text(message, color = MaterialTheme.colorScheme.error)
+            Button(onClick = { retryKey++ }) { Text(stringResource(R.string.common_retry)) }
+        }
+        return
     }
 
     val normalizedAvailable = remember(available) {
@@ -2344,8 +2458,11 @@ internal fun LanguageSelectionPage(
 
     fun updateLanguage(target: String, value: String) {
         scope.launch {
+            operationError = null
+            var previous: Settings? = null
             try {
-                val current = runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
+                val current = settingsUseCase.get()
+                previous = current
                 val updated = if (target == "primary") current.copy(primaryLanguage = value) else current.copy(secondaryLanguage = value)
                 settingsUseCase.update(updated)
                 featureUsageReporter.reportEvent(
@@ -2354,14 +2471,27 @@ internal fun LanguageSelectionPage(
                     "value" to value
                 )
                 if (target == "primary") {
-                    try {
-                        val vuse = runCatching { voiceUseCase.selected() }.getOrNull()
-                        if (vuse != null) {
-                            runCatching { voiceUseCase.select(vuse.copy(selectedLanguage = value)) }
-                        }
-                    } catch (_: Throwable) {}
+                    voiceUseCase.selected()?.let { voiceUseCase.select(it.copy(selectedLanguage = value)) }
                 }
-            } catch (_: Throwable) {}
+            } catch (failure: CancellationException) {
+                throw failure
+            } catch (_: Exception) {
+                val persisted = try {
+                    settingsUseCase.get()
+                } catch (failure: CancellationException) {
+                    throw failure
+                } catch (_: Exception) {
+                    previous
+                }
+                persisted?.let {
+                    primary = it.primaryLanguage
+                    secondary = it.secondaryLanguage
+                    useSecondaryLanguage = selectedVoiceIsMultilingual &&
+                        it.secondaryLanguage.isNotBlank() &&
+                        it.secondaryLanguage != it.primaryLanguage
+                }
+                operationError = languageSaveFailed
+            }
         }
     }
 
@@ -2371,6 +2501,10 @@ internal fun LanguageSelectionPage(
             .padding(top = 24.dp, bottom = 32.dp),
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
+        operationError?.let {
+            Text(it, color = MaterialTheme.colorScheme.error)
+        }
+
         OutlinedTextField(
             value = filter,
             onValueChange = { filter = it },

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/VoiceSelectionDialog.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/VoiceSelectionDialog.kt
@@ -16,6 +16,7 @@ import io.github.jdreioe.wingmate.application.SettingsUseCase
 import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.domain.TtsEngine
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.launch
 import androidx.compose.ui.res.stringResource
@@ -33,6 +34,7 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
     var loading by remember { mutableStateOf(true) }
     var voices by remember { mutableStateOf<List<Voice>>(emptyList()) }
     var error by remember { mutableStateOf<String?>(null) }
+    var operationError by remember { mutableStateOf<String?>(null) }
     var selected by remember { mutableStateOf<Voice?>(null) }
     var showVoiceSettings by remember { mutableStateOf(false) }
     var editingVoice by remember { mutableStateOf<Voice?>(null) }
@@ -44,21 +46,20 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
     var showGenderFilter by remember { mutableStateOf(false) }
     var voiceSearch by remember { mutableStateOf("") }
     var genderFilter by remember { mutableStateOf<String?>(null) }
+    var retryKey by remember { mutableIntStateOf(0) }
     val scope = rememberCoroutineScope()
+    val voiceLoadFailed = stringResource(R.string.voice_load_failed)
+    val voiceSaveFailed = stringResource(R.string.voice_save_failed)
 
     val systemVoiceProvider = remember(koin) { koin.getOrNull<io.github.jdreioe.wingmate.infrastructure.SystemVoiceProvider>() }
 
-    LaunchedEffect(Unit) {
-        // Check TTS preference first
-        if (settingsUseCase != null) {
-            val settings = withContext(Dispatchers.Default) { 
-                runCatching { settingsUseCase.get() }.getOrNull() 
-            }
-            ttsEngine = settings?.ttsEngine ?: TtsEngine.SYSTEM
-        }
-        
+    LaunchedEffect(retryKey) {
         loading = true
+        error = null
         try {
+            val settings = checkNotNull(settingsUseCase) { "Settings are unavailable" }
+                .let { withContext(Dispatchers.Default) { it.get() } }
+            ttsEngine = settings.ttsEngine
             if (ttsEngine == TtsEngine.SYSTEM) {
                 // Load system voices
                 val allSystemVoices = systemVoiceProvider?.getSystemVoices() ?: listOf(
@@ -78,12 +79,23 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
                     .sorted()
                 
                 // Get currently selected voice if any
-                selected = try { useCase.selected() } catch (e: Exception) { null }
+                selected = useCase.selected()
             } else {
                 // Load Azure voices
-                val fromCloud = withContext(Dispatchers.Default) { useCase.refreshFromAzure() }
+                var cloudRefreshFailed = false
+                val fromCloud = try {
+                    withContext(Dispatchers.Default) { useCase.refreshFromAzure() }
+                } catch (failure: CancellationException) {
+                    throw failure
+                } catch (_: Exception) {
+                    cloudRefreshFailed = true
+                    emptyList()
+                }
                 val local = withContext(Dispatchers.Default) { useCase.list() }
                 val allVoices = (fromCloud + local).distinctBy { it.name }
+                if (allVoices.isEmpty() && cloudRefreshFailed) {
+                    error("No cached voices were available after refresh failed")
+                }
                 voices = allVoices
                 
                 // Extract available languages from Azure voices
@@ -96,10 +108,13 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
                 
                 selected = useCase.selected()
             }
-        } catch (t: Throwable) {
-            error = t.message
+        } catch (failure: CancellationException) {
+            throw failure
+        } catch (_: Exception) {
+            error = voiceLoadFailed
+        } finally {
+            loading = false
         }
-        loading = false
     }
 
     val queryTerms = remember(voiceSearch) {
@@ -161,6 +176,10 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
         title = { Text(stringResource(R.string.voice_select_title)) },
         text = {
             Column(Modifier.fillMaxWidth()) {
+                operationError?.let {
+                    Text(it, color = MaterialTheme.colorScheme.error)
+                    Spacer(Modifier.height(8.dp))
+                }
                 // Voice search and filter section.
                 if (!loading && error == null) {
                     val showKeyboard = rememberShowKeyboardOnFocus()
@@ -281,7 +300,10 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
                 if (loading) {
                     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) { CircularProgressIndicator() }
                 } else if (error != null) {
-                    Text(stringResource(R.string.voice_error, error ?: ""))
+                    Text(error.orEmpty(), color = MaterialTheme.colorScheme.error)
+                    TextButton(onClick = { retryKey++ }) {
+                        Text(stringResource(R.string.common_retry))
+                    }
                 } else if (ttsEngine == TtsEngine.SYSTEM) {
                     // Show system voices
                     Text(
@@ -308,24 +330,23 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
                                     .fillMaxWidth()
                                     .clickable {
                                         scope.launch {
+                                            operationError = null
                                             try {
-                                                println("User selected system voice: ${v.name}")
                                                 useCase.select(v)
                                                 // Update settings if needed
                                                 val primary = v.primaryLanguage ?: ""
                                                 if (primary.isNotBlank() && settingsUseCase != null) {
-                                                    try {
-                                                        val current = settingsUseCase.get()
-                                                        val updated = current.copy(primaryLanguage = primary)
-                                                        settingsUseCase.update(updated)
-                                                    } catch (t: Throwable) {
-                                                        println("Failed to persist primaryLanguage: $t")
-                                                    }
+                                                    val current = settingsUseCase.get()
+                                                    val updated = current.copy(primaryLanguage = primary)
+                                                    settingsUseCase.update(updated)
                                                 }
-                                            } catch (t: Throwable) {
-                                                println("Failed to select system voice ${v.name}: $t")
+                                                selected = v
+                                                onDismiss()
+                                            } catch (failure: CancellationException) {
+                                                throw failure
+                                            } catch (_: Exception) {
+                                                operationError = voiceSaveFailed
                                             }
-                                            onDismiss()
                                         }
                                     }
                                     .padding(8.dp)) {
@@ -370,26 +391,23 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
                                     .fillMaxWidth()
                                     .clickable(enabled = true, onClickLabel = null) {
                                         scope.launch {
+                                            operationError = null
                                             try {
-                                                println("User selected voice: ${v.name} (primary=${v.primaryLanguage}, selected=${v.selectedLanguage})")
                                                 useCase.select(v)
                                                 // also persist UI primary language when selecting a voice
                                                 val primary = v.selectedLanguage.ifBlank { v.primaryLanguage ?: "" }
                                                 if (primary.isNotBlank() && settingsUseCase != null) {
-                                                    try {
-                                                        println("Persisting primaryLanguage='$primary' to Settings")
-                                                        val current = settingsUseCase.get()
-                                                        val updated = current.copy(primaryLanguage = primary)
-                                                        settingsUseCase.update(updated)
-                                                        println("Persisted primaryLanguage='$primary'")
-                                                    } catch (t: Throwable) {
-                                                        println("Failed to persist primaryLanguage: $t")
-                                                    }
+                                                    val current = settingsUseCase.get()
+                                                    val updated = current.copy(primaryLanguage = primary)
+                                                    settingsUseCase.update(updated)
                                                 }
-                                            } catch (t: Throwable) {
-                                                println("Failed to select voice ${v.name}: $t")
+                                                selected = v
+                                                onDismiss()
+                                            } catch (failure: CancellationException) {
+                                                throw failure
+                                            } catch (_: Exception) {
+                                                operationError = voiceSaveFailed
                                             }
-                                            onDismiss()
                                         }
                                     }
                                     .padding(8.dp)) {
@@ -426,31 +444,24 @@ fun VoiceSelectionDialog(show: Boolean, onDismiss: () -> Unit, onOpenWelcomeFlow
             onSave = { updated ->
                 // persist updated voice selection
                 scope2.launch {
+                    operationError = null
                     try {
-                        println("Saving updated voice ${updated.name} (selectedLang=${updated.selectedLanguage}, primary=${updated.primaryLanguage})")
                         useCase.select(updated)
                         // also persist primary language from updated voice if available
-                        try {
-                            val primary = updated.selectedLanguage.ifBlank { updated.primaryLanguage ?: "" }
-                            if (primary.isNotBlank() && settingsUseCase != null) {
-                                println("Persisting primaryLanguage='$primary' from voice settings")
-                                val current = settingsUseCase.get()
-                                val updatedSettings = current.copy(primaryLanguage = primary)
-                                settingsUseCase.update(updatedSettings)
-                                println("Persisted primaryLanguage='$primary' from voice settings")
-                            }
-                        } catch (t: Throwable) {
-                            println("Failed to persist primary language from voice settings: $t")
+                        val primary = updated.selectedLanguage.ifBlank { updated.primaryLanguage ?: "" }
+                        if (primary.isNotBlank() && settingsUseCase != null) {
+                            val current = settingsUseCase.get()
+                            val updatedSettings = current.copy(primaryLanguage = primary)
+                            settingsUseCase.update(updatedSettings)
                         }
-                    } catch (t: Throwable) {
-                        println("Failed to save updated voice: $t")
-                    }
-                    showVoiceSettings = false
-                    // refresh list/selection
-                    try {
+                        showVoiceSettings = false
                         voices = (useCase.refreshFromAzure() + useCase.list()).distinctBy { it.name }
                         selected = useCase.selected()
-                    } catch (_: Throwable) {}
+                    } catch (failure: CancellationException) {
+                        throw failure
+                    } catch (_: Exception) {
+                        operationError = voiceSaveFailed
+                    }
                 }
             },
             onOpenWelcomeFlow = onOpenWelcomeFlow

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/WelcomeScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/WelcomeScreen.kt
@@ -34,6 +34,7 @@ import io.github.jdreioe.wingmate.infrastructure.BoardImportService
 import io.github.jdreioe.wingmate.infrastructure.BoardImportResult
 import io.github.jdreioe.wingmate.platform.FilePicker
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import androidx.compose.ui.res.stringResource
@@ -68,7 +69,19 @@ fun WelcomeScreen(
     
     // Import state
     var isImporting by remember { mutableStateOf(false) }
+    var importError by remember { mutableStateOf<String?>(null) }
+    val importUnreadable = stringResource(R.string.welcome_import_unreadable)
+    val importPersistenceFailed = stringResource(R.string.welcome_import_persistence_failed)
+    val importInvalid = stringResource(R.string.welcome_import_invalid)
+    val importUnexpected = stringResource(R.string.welcome_import_unexpected)
+    val backupPickerFailed = stringResource(R.string.backup_picker_failed)
     val scope = rememberCoroutineScope()
+
+    fun importFailureMessage(result: BoardImportResult.Failure): String = when (result.code) {
+        io.github.jdreioe.wingmate.infrastructure.BoardImportErrorCode.FILE_UNREADABLE -> importUnreadable
+        io.github.jdreioe.wingmate.infrastructure.BoardImportErrorCode.PERSISTENCE_FAILED -> importPersistenceFailed
+        else -> importInvalid
+    }
 
     LaunchedEffect(Unit) {
         featureUsageReporter?.reportEvent(FeatureUsageEvents.WELCOME_STARTED)
@@ -122,10 +135,17 @@ fun WelcomeScreen(
                         enabled = !isRestoring && backupManager != null && backupFilePicker != null,
                         onClick = {
                             scope.launch {
-                                pendingRestorePath = backupFilePicker?.pickFile(
-                                    title = "Restore Wingmate backup",
-                                    extensions = listOf("wingmate-backup", "zip")
-                                )
+                                restoreStatus = null
+                                try {
+                                    pendingRestorePath = backupFilePicker?.pickFile(
+                                        title = "Restore Wingmate backup",
+                                        extensions = listOf("wingmate-backup", "zip")
+                                    )
+                                } catch (failure: CancellationException) {
+                                    throw failure
+                                } catch (_: Exception) {
+                                    restoreStatus = backupPickerFailed
+                                }
                             }
                         }
                     ) {
@@ -190,6 +210,7 @@ fun WelcomeScreen(
                     onImportClassic = { 
                         scope.launch {
                             isImporting = true
+                            importError = null
                             featureUsageReporter?.reportEvent(
                                 FeatureUsageEvents.BOARD_IMPORT_STARTED,
                                 "mode" to "classic"
@@ -205,6 +226,7 @@ fun WelcomeScreen(
                                     step = 3
                                   }
                                   is BoardImportResult.Failure -> {
+                                    importError = importFailureMessage(result)
                                     featureUsageReporter?.reportEvent(
                                         FeatureUsageEvents.BOARD_IMPORT_FAILED,
                                         "mode" to "classic",
@@ -213,13 +235,15 @@ fun WelcomeScreen(
                                   }
                                   BoardImportResult.Cancelled, null -> Unit
                                 }
-                            } catch (e: Throwable) {
+                            } catch (error: CancellationException) {
+                                throw error
+                            } catch (_: Exception) {
+                                importError = importUnexpected
                                 featureUsageReporter?.reportEvent(
                                     FeatureUsageEvents.BOARD_IMPORT_FAILED,
                                     "mode" to "classic",
                                     "reason" to "exception"
                                 )
-                                e.printStackTrace()
                             } finally {
                                 isImporting = false
                             }
@@ -228,6 +252,7 @@ fun WelcomeScreen(
                     onImportModern = {
                          scope.launch {
                             isImporting = true
+                            importError = null
                             featureUsageReporter?.reportEvent(
                                 FeatureUsageEvents.BOARD_IMPORT_STARTED,
                                 "mode" to "modern"
@@ -242,6 +267,7 @@ fun WelcomeScreen(
                                     step = 3
                                   }
                                   is BoardImportResult.Failure -> {
+                                    importError = importFailureMessage(result)
                                     featureUsageReporter?.reportEvent(
                                         FeatureUsageEvents.BOARD_IMPORT_FAILED,
                                         "mode" to "modern",
@@ -250,13 +276,15 @@ fun WelcomeScreen(
                                   }
                                   BoardImportResult.Cancelled, null -> Unit
                                 }
-                            } catch (e: Throwable) {
+                            } catch (error: CancellationException) {
+                                throw error
+                            } catch (_: Exception) {
+                                importError = importUnexpected
                                 featureUsageReporter?.reportEvent(
                                     FeatureUsageEvents.BOARD_IMPORT_FAILED,
                                     "mode" to "modern",
                                     "reason" to "exception"
                                 )
-                                e.printStackTrace()
                             } finally {
                                 isImporting = false
                             }
@@ -277,6 +305,7 @@ fun WelcomeScreen(
                         )
                         step = 3
                     },
+                    errorMessage = importError,
                     showClassic = startupMode == StartupMode.Screens,
                     showModern = startupMode == StartupMode.Keyboard,
                     showCreateFromScratch = startupMode == StartupMode.Screens

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -26,6 +26,19 @@
     <string name="common_back">Back</string>
     <string name="common_continue">Continue</string>
     <string name="common_retry">Retry</string>
+    <string name="startup_load_failed">Wingmate could not load your settings. Your existing configuration has not been changed.</string>
+    <string name="welcome_import_unreadable">The selected file could not be read. Tap the import option to retry.</string>
+    <string name="welcome_import_persistence_failed">The screen could not be saved. Your current screens were kept; tap to retry.</string>
+    <string name="welcome_import_invalid">This screen file is not valid or supported. Choose another file or retry.</string>
+    <string name="welcome_import_unexpected">Unable to import this screen. Tap the import option to retry.</string>
+    <string name="voice_load_failed">Voices could not be loaded. Check your connection or device voice settings, then retry.</string>
+    <string name="voice_save_failed">The voice could not be saved. Your current communication setup was kept; tap the voice to retry.</string>
+    <string name="backup_picker_failed">The file picker could not be opened. Try again.</string>
+    <string name="backup_create_failed">The backup could not be created. Your data was not changed; try again.</string>
+    <string name="language_load_failed">Language settings could not be loaded. Your current settings were not changed.</string>
+    <string name="language_save_failed">The language change could not be completed. Review the current selections, then choose a language to retry.</string>
+    <string name="settings_load_failed">Settings could not be loaded. Your current configuration was not changed.</string>
+    <string name="settings_save_failed">The setting could not be saved. Retry to reload the stored configuration.</string>
 
     <string name="board_sets_title">Screens</string>
     <string name="board_sets_subtitle">Choose a screen to communicate</string>
@@ -116,6 +129,7 @@
     <string name="board_workspace_finish_body">Save your changes before returning to communication mode?</string>
     <string name="board_workspace_saved">Changes saved</string>
     <string name="board_workspace_save_error">Unable to save changes</string>
+    <string name="board_workspace_export_error">The screen could not be exported. Your current screen was not changed; try again.</string>
     <string name="board_workspace_save_phrase">Save to phrases</string>
     <string name="board_workspace_phrase_saved">Saved to All phrases</string>
     <string name="board_workspace_phrase_save_error">Unable to save the sentence to phrases</string>

--- a/androidApp/src/test/java/io/github/jdreioe/wingmate/StartupLoadStateTest.kt
+++ b/androidApp/src/test/java/io/github/jdreioe/wingmate/StartupLoadStateTest.kt
@@ -1,0 +1,44 @@
+package io.github.jdreioe.wingmate
+
+import io.github.jdreioe.wingmate.domain.Settings
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+class StartupLoadStateTest {
+    @Test
+    fun `settings failure is not represented as first launch and retry can recover`() = runBlocking {
+        var shouldFail = true
+        val loadSettings: suspend () -> Settings = {
+            if (shouldFail) error("database unavailable")
+            Settings(welcomeFlowCompleted = true)
+        }
+
+        assertSame(
+            StartupLoadState.Failed,
+            loadStartupState(loadSettings = loadSettings, loadSelectedVoice = { null }),
+        )
+
+        shouldFail = false
+        val recovered = loadStartupState(loadSettings = loadSettings, loadSelectedVoice = { null })
+
+        assertEquals(true, (recovered as StartupLoadState.Ready).settings.welcomeFlowCompleted)
+    }
+
+    @Test
+    fun `voice read failure is not represented as no selected voice`() = runBlocking {
+        val failed = loadStartupState(
+            loadSettings = { Settings(welcomeFlowCompleted = true) },
+            loadSelectedVoice = { error("voice database unavailable") },
+        )
+
+        assertSame(StartupLoadState.Failed, failed)
+
+        val recovered = loadStartupState(
+            loadSettings = { Settings(welcomeFlowCompleted = true) },
+            loadSelectedVoice = { null },
+        )
+        assertEquals(null, (recovered as StartupLoadState.Ready).selectedVoice)
+    }
+}

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlSettingsRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlSettingsRepository.kt
@@ -29,19 +29,12 @@ class AndroidSqlSettingsRepository(private val context: Context) : SettingsRepos
         val db = helper.readableDatabase
         // Removed SLF4J logger for cross-platform compatibility
         val cursor = db.query("ui_settings", arrayOf("data"), "id = 1", null, null, null, null)
-        if (cursor.moveToFirst()) {
-            val text = cursor.getString(cursor.getColumnIndexOrThrow("data"))
-            cursor.close()
-            return@withContext try {
-                val s = json.decodeFromString(Settings.serializer(), text)
-                println("Loaded UI settings from SQLite: {}: ${s}")
-                s
-            } catch (t: Throwable) {
-                println("Failed to decode UI settings from SQLite: ${t}")
-                Settings()
+        cursor.use {
+            if (it.moveToFirst()) {
+                val text = it.getString(it.getColumnIndexOrThrow("data"))
+                return@withContext json.decodeFromString(Settings.serializer(), text)
             }
         }
-        cursor.close()
         return@withContext Settings()
     }
 
@@ -50,7 +43,6 @@ class AndroidSqlSettingsRepository(private val context: Context) : SettingsRepos
         // Removed SLF4J logger for cross-platform compatibility
         val text = json.encodeToString(Settings.serializer(), settings)
         db.execSQL("INSERT OR REPLACE INTO ui_settings (id, data) VALUES (1, ?)", arrayOf(text))
-        println("Saved UI settings to SQLite: {}: ${settings}")
         return@withContext settings
     }
 }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlVoiceRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlVoiceRepository.kt
@@ -15,12 +15,14 @@ class AndroidSqlVoiceRepository(private val context: Context) : VoiceRepository 
     override suspend fun getVoices(): List<Voice> = withContext(Dispatchers.IO) {
         val db = helper.readableDatabase
         val cursor = db.query("voice_catalog", arrayOf("list"), "id = ?", arrayOf("1"), null, null, null)
-        val list = if (cursor.moveToFirst()) {
-            val text = cursor.getString(cursor.getColumnIndexOrThrow("list"))
-            runCatching { json.decodeFromString(ListSerializer(Voice.serializer()), text) }.getOrNull() ?: emptyList()
-        } else emptyList()
-        cursor.close()
-        list
+        cursor.use {
+            if (it.moveToFirst()) {
+                val text = it.getString(it.getColumnIndexOrThrow("list"))
+                json.decodeFromString(ListSerializer(Voice.serializer()), text)
+            } else {
+                emptyList()
+            }
+        }
     }
 
     override suspend fun saveVoices(list: List<Voice>) = withContext(Dispatchers.IO) {
@@ -33,22 +35,18 @@ class AndroidSqlVoiceRepository(private val context: Context) : VoiceRepository 
         val text = json.encodeToString(Voice.serializer(), voice)
         val db = helper.writableDatabase
         db.execSQL("INSERT OR REPLACE INTO voices (id, data) VALUES (1, ?)", arrayOf(text))
-        println("Saved selected voice to SQLite: ${voice.name}")
     }
 
     override suspend fun getSelected(): Voice? = withContext(Dispatchers.IO) {
         val db = helper.readableDatabase
         val cursor = db.query("voices", arrayOf("data"), "id = ?", arrayOf("1"), null, null, null)
-        val v = if (cursor.moveToFirst()) {
-            val text = cursor.getString(cursor.getColumnIndexOrThrow("data"))
-            try {
+        cursor.use {
+            if (it.moveToFirst()) {
+                val text = it.getString(it.getColumnIndexOrThrow("data"))
                 json.decodeFromString(Voice.serializer(), text)
-            } catch (t: Throwable) {
-                println("Failed to decode selected voice: $t")
+            } else {
                 null
             }
-        } else null
-        cursor.close()
-        return@withContext v
+        }
     }
 }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/platform/AndroidFilePicker.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/platform/AndroidFilePicker.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Android implementation of FilePicker using ActivityResultLauncher.
@@ -92,7 +93,6 @@ class AndroidFilePicker(private val context: Context) : FilePicker {
             }
             tempFile.absolutePath
         } catch (e: Exception) {
-            e.printStackTrace()
             uri.toString() // Fallback to URI string if copy fails
         }
     }
@@ -100,7 +100,7 @@ class AndroidFilePicker(private val context: Context) : FilePicker {
     override suspend fun pickFile(title: String, extensions: List<String>): String? = suspendCancellableCoroutine { cont ->
         val safeLauncher = launcher
         if (safeLauncher == null) {
-            cont.resume(null)
+            cont.resumeWithException(IllegalStateException("File picker is unavailable"))
             return@suspendCancellableCoroutine
         }
         
@@ -112,7 +112,7 @@ class AndroidFilePicker(private val context: Context) : FilePicker {
             safeLauncher(extensions)
         } catch (e: Exception) {
             activeContinuation = null
-            cont.resume(null)
+            cont.resumeWithException(IllegalStateException("File picker could not be opened", e))
         }
     }
 
@@ -127,7 +127,6 @@ class AndroidFilePicker(private val context: Context) : FilePicker {
                 }
             }
         } catch (e: Exception) {
-            e.printStackTrace()
             null
         }
     }
@@ -146,8 +145,7 @@ class AndroidFilePicker(private val context: Context) : FilePicker {
         } catch (e: ArchiveReadException) {
             throw e
         } catch (e: Exception) {
-            e.printStackTrace()
-            null
+            throw ArchiveReadException(ArchiveReadError.IO_ERROR, "Archive could not be opened", e)
         }
     }
 

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/DictionaryLoader.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/DictionaryLoader.kt
@@ -4,7 +4,10 @@ import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
+
+class DictionaryLoadException : Exception("Dictionary could not be loaded")
 
 /**
  * Loads language dictionaries from the AOSP dictionaries repository on Codeberg.
@@ -62,12 +65,14 @@ class DictionaryLoader(private val fileStorage: io.github.jdreioe.wingmate.domai
             
             try {
                 val response = httpClient.get(url)
+                if (response.status.value !in 200..299) throw DictionaryLoadException()
                 val responseText = response.bodyAsText()
                 
                 // Parse on Default dispatcher (CPU bound)
                 val words = withContext(Dispatchers.Default) {
                     parseDictionary(responseText)
                 }
+                if (words.isEmpty()) throw DictionaryLoadException()
                 
                 println("DEBUG: Loaded ${words.size} words for language $languageCode ($baseName)")
                 
@@ -83,10 +88,10 @@ class DictionaryLoader(private val fileStorage: io.github.jdreioe.wingmate.domai
                     }
                 }
                 words
-            } catch (e: Exception) {
-                println("DEBUG: Failed to fetch dictionary for $languageCode ($url): ${e.message}")
-                e.printStackTrace()
-                emptyList()
+            } catch (failure: CancellationException) {
+                throw failure
+            } catch (_: Exception) {
+                throw DictionaryLoadException()
             }
         }
     }

--- a/core/presentation/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/SettingsStateManager.kt
+++ b/core/presentation/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/SettingsStateManager.kt
@@ -90,6 +90,11 @@ class SettingsStateManager(
      * Get current settings value synchronously
      */
     fun getCurrentSettings(): Settings = _settings.value
+
+    /** Applies settings that another trusted startup/restore read already loaded. */
+    fun applyLoadedSettings(settings: Settings) {
+        _settings.value = settings
+    }
     
     /**
      * Reload settings from repository (useful for external changes)

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/CompleteBackupManager.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/CompleteBackupManager.kt
@@ -24,6 +24,7 @@ import io.github.jdreioe.wingmate.platform.ArchiveEntry
 import io.github.jdreioe.wingmate.platform.readEntryBytes
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.serialization.Serializable
@@ -145,7 +146,13 @@ class CompleteBackupManager(
 
     suspend fun restoreBackup(path: String): BackupRestoreResult = restoreMutex.withLock {
         val picker = filePicker ?: return@withLock BackupRestoreResult.Failure("File import is unavailable")
-        val archive = runCatching { picker.openArchive(path) }.getOrNull()
+        val archive = try {
+            picker.openArchive(path)
+        } catch (failure: CancellationException) {
+            throw failure
+        } catch (_: Exception) {
+            null
+        }
             ?: return@withLock BackupRestoreResult.Failure("Could not open backup archive")
         val restoredMedia = mutableListOf<String>()
         try {
@@ -201,9 +208,12 @@ class CompleteBackupManager(
             }
             mutableRestoreRevision.value += 1
             BackupRestoreResult.Success(payload)
-        } catch (error: Throwable) {
+        } catch (failure: CancellationException) {
             restoredMedia.forEach { runCatching { mediaAccess.deleteRestored(it) } }
-            BackupRestoreResult.Failure(error.message ?: "Backup restore failed")
+            throw failure
+        } catch (_: Exception) {
+            restoredMedia.forEach { runCatching { mediaAccess.deleteRestored(it) } }
+            BackupRestoreResult.Failure("Backup could not be restored safely")
         } finally {
             archive.close()
         }


### PR DESCRIPTION
## Summary

- Add explicit loading, failure, and retry states for Android startup, settings, and board-set workflows.
- Replace raw exception details with localized user-facing error messages.
- Preserve screen state during recoverable failures and keep persistence operations lifecycle-safe.
- Add startup load-state coverage and improve cancellation handling across asynchronous operations.

## Testing

- Added `StartupLoadStateTest` coverage for successful loads, failures, and cancellation.
- Not run: broader Android build and test suite.