### PR TITLE
#170 Add board workspace presentation state management

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -90,6 +90,7 @@ android {
         targetSdk = libs.versions.android.targetSdk.get().toInt()
         versionCode = vCode
         versionName = vName
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         buildConfigField(
             "String",
             "OPENSYMBOLS_PROXY_URL",
@@ -185,12 +186,15 @@ dependencies {
     val composeBom = platform("androidx.compose:compose-bom:2025.09.01")
     implementation(composeBom)
     androidTestImplementation(composeBom)
+    androidTestImplementation(libs.androidx.testExt.junit)
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 
     // Common AndroidX helpers
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.lifecycle.runtimeKtx)
     implementation("androidx.lifecycle:lifecycle-runtime-compose:${libs.versions.androidx.lifecycle.get()}")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:${libs.versions.androidx.lifecycle.get()}")
 
     implementation(libs.androidx.activity.compose)
     implementation("androidx.compose.ui:ui")
@@ -198,6 +202,7 @@ dependencies {
     implementation("androidx.compose.material3:material3")
     implementation("androidx.compose.material:material-icons-extended")
     debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
 
     // Image loading
     implementation("io.coil-kt.coil3:coil-compose:3.5.0")
@@ -220,6 +225,7 @@ dependencies {
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlinx.serialization.json)
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${libs.versions.kotlinx.coroutines.get()}")
 }
 
 kotlin {

--- a/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardSetManagerScreenTest.kt
+++ b/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardSetManagerScreenTest.kt
@@ -1,0 +1,46 @@
+package io.github.jdreioe.wingmate.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class BoardSetManagerScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun suppliedBoardSetIsDisplayedAndForwardsOpenAction() {
+        var receivedAction: BoardSetManagerAction? = null
+        composeRule.setContent {
+            AppTheme {
+                BoardSetManagerScreen(
+                    state = BoardSetManagerState(
+                        boardSets = listOf(
+                            ObfBoardSet(
+                                id = "core-words",
+                                name = "Core words",
+                                rootBoardId = "home",
+                                boardIds = listOf("home"),
+                                createdAt = 1L,
+                                updatedAt = 2L,
+                            )
+                        ),
+                        isLoading = false,
+                    ),
+                    statusMessage = null,
+                    importAvailable = true,
+                    onAction = { receivedAction = it },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("Core words").assertIsDisplayed().performClick()
+
+        assertEquals(BoardSetManagerAction.OpenClicked("core-words"), receivedAction)
+    }
+}

--- a/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardWorkspaceContentTest.kt
+++ b/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardWorkspaceContentTest.kt
@@ -1,0 +1,59 @@
+package io.github.jdreioe.wingmate.ui
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+class BoardWorkspaceContentTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun suppliedReadyContentAndStatusAreDisplayed() {
+        composeRule.setContent {
+            AppTheme {
+                BoardWorkspaceContent(
+                    state = BoardWorkspaceState(
+                        contentStatus = BoardWorkspaceContentStatus.Ready,
+                        statusMessage = "Board saved",
+                    ),
+                    hasActiveBoard = true,
+                    onBackToLibrary = {},
+                ) {
+                    Text("Communication board")
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("Board saved").assertIsDisplayed()
+        composeRule.onNodeWithText("Communication board").assertIsDisplayed()
+    }
+
+    @Test
+    fun recoverableFailureWithoutBoardCanReturnToLibrary() {
+        var returnedToLibrary = false
+        composeRule.setContent {
+            AppTheme {
+                BoardWorkspaceContent(
+                    state = BoardWorkspaceState(
+                        contentStatus = BoardWorkspaceContentStatus.RecoverableFailure(
+                            "Could not load board"
+                        ),
+                    ),
+                    hasActiveBoard = false,
+                    onBackToLibrary = { returnedToLibrary = true },
+                ) {}
+            }
+        }
+
+        composeRule.onNodeWithText("Could not load board").assertIsDisplayed()
+        composeRule.onNodeWithText("Back to library").performClick()
+
+        assertTrue(returnedToLibrary)
+    }
+}

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/App.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/App.kt
@@ -9,7 +9,7 @@ import io.github.jdreioe.wingmate.application.FeatureUsageReporter
 import io.github.jdreioe.wingmate.application.reportEvent
 import io.github.jdreioe.wingmate.ui.WelcomeScreen
 import io.github.jdreioe.wingmate.ui.PhraseScreen
-import io.github.jdreioe.wingmate.ui.BoardSetManagerScreen
+import io.github.jdreioe.wingmate.ui.BoardSetManagerRoot
 import io.github.jdreioe.wingmate.ui.AppTheme
 import io.github.jdreioe.wingmate.ui.PlatformBackHandler
 import io.github.jdreioe.wingmate.ui.InteractionInputRoot
@@ -169,7 +169,7 @@ fun App() {
                                 )
                             }
                             Screen.BoardSets -> {
-                                BoardSetManagerScreen(
+                                BoardSetManagerRoot(
                                     onBackToWelcome = ::showWelcomeFlow,
                                     onBack = {
                                         createBoardSetOnLaunch = false

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetDialogs.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetDialogs.kt
@@ -103,17 +103,18 @@ internal enum class BoardSetTemplate(val quickCoreSlug: String? = null) {
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun CreateBoardSetDialog(
+    draft: CreateBoardSetDraft,
     onDismiss: () -> Unit,
-    onCreate: (name: String, rows: Int, columns: Int, template: BoardSetTemplate, keyboardPreset: KeyboardPreset) -> Unit,
+    onNameChange: (String) -> Unit,
+    onRowsChange: (String) -> Unit,
+    onColumnsChange: (String) -> Unit,
+    onTemplateSelected: (BoardSetTemplate, suggestedName: String?) -> Unit,
+    onKeyboardPresetSelected: (KeyboardPreset) -> Unit,
+    onCreate: () -> Unit,
     quickCoreProgress: Float? = null,
     quickCoreStage: String? = null,
     isQuickCoreImporting: Boolean = false,
 ) {
-    var name by remember { mutableStateOf("") }
-    var rowsText by remember { mutableStateOf("4") }
-    var columnsText by remember { mutableStateOf("8") }
-    var template by remember { mutableStateOf(BoardSetTemplate.Blank) }
-    var keyboardPreset by remember { mutableStateOf(KeyboardPreset.Qwerty) }
     val calculatorName = stringResource(R.string.calculator_default_name)
     val keyboardName = stringResource(R.string.keyboard_default_name)
 
@@ -123,63 +124,57 @@ internal fun CreateBoardSetDialog(
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(
-                    value = name,
-                    onValueChange = { name = it },
+                    value = draft.name,
+                    onValueChange = onNameChange,
                     label = { Text(stringResource(R.string.board_dialog_set_name)) },
                     singleLine = true
                 )
                 Text(stringResource(R.string.board_dialog_template), style = MaterialTheme.typography.labelLarge)
                 FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     FilterChip(
-                        selected = template == BoardSetTemplate.Blank,
-                        onClick = { template = BoardSetTemplate.Blank },
+                        selected = draft.template == BoardSetTemplate.Blank,
+                        onClick = { onTemplateSelected(BoardSetTemplate.Blank, null) },
                         label = { Text(stringResource(R.string.board_dialog_template_blank)) }
                     )
                     FilterChip(
-                        selected = template == BoardSetTemplate.Calculator,
-                        onClick = {
-                            template = BoardSetTemplate.Calculator
-                            if (name.isBlank()) name = calculatorName
-                        },
+                        selected = draft.template == BoardSetTemplate.Calculator,
+                        onClick = { onTemplateSelected(BoardSetTemplate.Calculator, calculatorName) },
                         label = { Text(stringResource(R.string.board_dialog_template_calculator)) }
                     )
                     FilterChip(
-                        selected = template == BoardSetTemplate.Keyboard,
-                        onClick = {
-                            template = BoardSetTemplate.Keyboard
-                            if (name.isBlank()) name = keyboardName
-                        },
+                        selected = draft.template == BoardSetTemplate.Keyboard,
+                        onClick = { onTemplateSelected(BoardSetTemplate.Keyboard, keyboardName) },
                         label = { Text(stringResource(R.string.board_dialog_template_keyboard)) }
                     )
                 }
-                if (template == BoardSetTemplate.Keyboard) Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (draft.template == BoardSetTemplate.Keyboard) Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     Text(
                         stringResource(R.string.board_dialog_keyboard_preset),
                         modifier = Modifier.align(Alignment.CenterVertically),
                         style = MaterialTheme.typography.labelLarge
                     )
                     FilterChip(
-                        selected = keyboardPreset == KeyboardPreset.Qwerty,
-                        onClick = { keyboardPreset = KeyboardPreset.Qwerty },
+                        selected = draft.keyboardPreset == KeyboardPreset.Qwerty,
+                        onClick = { onKeyboardPresetSelected(KeyboardPreset.Qwerty) },
                         label = { Text(stringResource(R.string.board_dialog_keyboard_preset_qwerty)) }
                     )
                     FilterChip(
-                        selected = keyboardPreset == KeyboardPreset.Alphabetical,
-                        onClick = { keyboardPreset = KeyboardPreset.Alphabetical },
+                        selected = draft.keyboardPreset == KeyboardPreset.Alphabetical,
+                        onClick = { onKeyboardPresetSelected(KeyboardPreset.Alphabetical) },
                         label = { Text(stringResource(R.string.board_dialog_keyboard_preset_alphabetical)) }
                     )
                 }
-                if (template == BoardSetTemplate.Blank) Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (draft.template == BoardSetTemplate.Blank) Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedTextField(
-                        value = rowsText,
-                        onValueChange = { rowsText = it.filter(Char::isDigit) },
+                        value = draft.rowsText,
+                        onValueChange = onRowsChange,
                         label = { Text(stringResource(R.string.board_dialog_rows)) },
                         modifier = Modifier.weight(1f),
                         singleLine = true
                     )
                     OutlinedTextField(
-                        value = columnsText,
-                        onValueChange = { columnsText = it.filter(Char::isDigit) },
+                        value = draft.columnsText,
+                        onValueChange = onColumnsChange,
                         label = { Text(stringResource(R.string.board_dialog_columns)) },
                         modifier = Modifier.weight(1f),
                         singleLine = true
@@ -202,8 +197,8 @@ internal fun CreateBoardSetDialog(
         },
         confirmButton = {
             TextButton(
-                onClick = { onCreate(name, rowsText.toIntOrNull() ?: 4, columnsText.toIntOrNull() ?: 8, template, keyboardPreset) },
-                enabled = name.isNotBlank() && !isQuickCoreImporting
+                onClick = onCreate,
+                enabled = draft.name.isNotBlank() && !isQuickCoreImporting
             ) { Text(stringResource(R.string.board_dialog_create)) }
         },
         dismissButton = {

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetManagerViewModel.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetManagerViewModel.kt
@@ -1,0 +1,548 @@
+package io.github.jdreioe.wingmate.ui
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hojmoseit.wingmate.R
+import io.github.jdreioe.wingmate.application.BoardSetSpeechCacheUseCase
+import io.github.jdreioe.wingmate.application.BoardSetUseCase
+import io.github.jdreioe.wingmate.application.EditingAccessController
+import io.github.jdreioe.wingmate.application.KeyboardPreset
+import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
+import io.github.jdreioe.wingmate.infrastructure.BoardImportResult
+import io.github.jdreioe.wingmate.infrastructure.BoardImportService
+import io.github.jdreioe.wingmate.infrastructure.QuickCoreDownloadProgress
+import io.github.jdreioe.wingmate.infrastructure.QuickCorePresetService
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+
+internal enum class BoardWorkspaceMode { Run, Edit }
+
+internal sealed interface BoardSetManagerRoute {
+    data object Library : BoardSetManagerRoute
+
+    data class Workspace(
+        val boardSetId: String,
+        val mode: BoardWorkspaceMode,
+    ) : BoardSetManagerRoute
+}
+
+internal sealed interface BoardSetManagerMessage {
+    data class Resource(@param:StringRes val id: Int) : BoardSetManagerMessage
+    data class Dynamic(val value: String) : BoardSetManagerMessage
+}
+
+internal data class BoardSetManagerProgress(
+    val fraction: Float?,
+    val stage: String,
+)
+
+internal data class CreateBoardSetDraft(
+    val name: String = "",
+    val rowsText: String = "4",
+    val columnsText: String = "8",
+    val template: BoardSetTemplate = BoardSetTemplate.Blank,
+    val keyboardPreset: KeyboardPreset = KeyboardPreset.Qwerty,
+)
+
+@Stable
+internal data class BoardSetManagerState(
+    val route: BoardSetManagerRoute = BoardSetManagerRoute.Library,
+    val boardSets: List<ObfBoardSet> = emptyList(),
+    val isLoading: Boolean = true,
+    val isCreating: Boolean = false,
+    val showCreateDialog: Boolean = false,
+    val createDraft: CreateBoardSetDraft = CreateBoardSetDraft(),
+    val showSettings: Boolean = false,
+    val deleteTargetId: String? = null,
+    val pendingProtectedDeleteId: String? = null,
+    val showDeleteAccessDialog: Boolean = false,
+    val statusMessage: BoardSetManagerMessage? = null,
+    val quickCoreProgress: BoardSetManagerProgress? = null,
+    val isQuickCoreImporting: Boolean = false,
+)
+
+internal sealed interface BoardSetManagerAction {
+    data class Initialize(
+        val createOnLaunch: Boolean,
+        val initialBoardSetId: String?,
+    ) : BoardSetManagerAction
+
+    data object BackClicked : BoardSetManagerAction
+    data object SettingsClicked : BoardSetManagerAction
+    data object SettingsDismissed : BoardSetManagerAction
+    data object CreateClicked : BoardSetManagerAction
+    data object CreateDismissed : BoardSetManagerAction
+    data class CreateNameChanged(val name: String) : BoardSetManagerAction
+    data class CreateRowsChanged(val rowsText: String) : BoardSetManagerAction
+    data class CreateColumnsChanged(val columnsText: String) : BoardSetManagerAction
+    data class CreateTemplateSelected(
+        val template: BoardSetTemplate,
+        val suggestedName: String? = null,
+    ) : BoardSetManagerAction
+    data class CreateKeyboardPresetSelected(val preset: KeyboardPreset) : BoardSetManagerAction
+    data object ImportClicked : BoardSetManagerAction
+    data class OpenClicked(val boardSetId: String) : BoardSetManagerAction
+    data class EditClicked(val boardSetId: String) : BoardSetManagerAction
+    data class DuplicateClicked(val boardSetId: String) : BoardSetManagerAction
+    data class ToggleLockClicked(val boardSetId: String) : BoardSetManagerAction
+    data class DeleteClicked(val boardSetId: String) : BoardSetManagerAction
+    data object DeleteDismissed : BoardSetManagerAction
+    data object DeleteConfirmed : BoardSetManagerAction
+    data object DeleteAccessDismissed : BoardSetManagerAction
+    data object DeleteAccessGranted : BoardSetManagerAction
+    data object WorkspaceExited : BoardSetManagerAction
+
+    data class CreateSubmitted(
+        val name: String,
+        val rows: Int,
+        val columns: Int,
+        val template: BoardSetTemplate,
+        val keyboardPreset: KeyboardPreset,
+        val defaultBoardName: String,
+    ) : BoardSetManagerAction
+}
+
+internal sealed interface BoardSetManagerEvent {
+    data object NavigateBack : BoardSetManagerEvent
+}
+
+/**
+ * The persistence boundary used by the manager presentation model. Keeping it narrow makes
+ * state transitions deterministic without replacing the shared board-set use cases.
+ */
+internal interface BoardSetManagerOperations {
+    val quickCoreProgress: Flow<QuickCoreDownloadProgress>
+
+    suspend fun listBoardSets(): List<ObfBoardSet>
+    suspend fun getBoardSet(id: String): ObfBoardSet?
+    suspend fun duplicateBoardSet(id: String)
+    suspend fun toggleLocked(id: String)
+    suspend fun deleteBoardSet(id: String)
+    suspend fun cacheAll()
+    suspend fun cacheBoardSet(id: String)
+    suspend fun requiresDeleteUnlock(): Boolean
+    suspend fun importBoardSet(): BoardImportResult
+    suspend fun importQuickCore(slug: String): BoardImportResult
+    suspend fun renameBoardSet(id: String, name: String): ObfBoardSet?
+    suspend fun createBoardSet(name: String, rows: Int, columns: Int, rootBoardName: String): ObfBoardSet
+    suspend fun createCalculatorBoardSet(name: String): ObfBoardSet
+    suspend fun createKeyboardBoardSet(name: String, preset: KeyboardPreset): ObfBoardSet
+}
+
+internal class DefaultBoardSetManagerOperations(
+    private val useCase: BoardSetUseCase,
+    private val speechCache: BoardSetSpeechCacheUseCase,
+    private val importService: BoardImportService?,
+    private val quickCoreService: QuickCorePresetService?,
+    private val editingAccessController: EditingAccessController?,
+) : BoardSetManagerOperations {
+    override val quickCoreProgress: Flow<QuickCoreDownloadProgress> =
+        quickCoreService?.progress ?: emptyFlow()
+
+    override suspend fun listBoardSets() = useCase.listBoardSets()
+    override suspend fun getBoardSet(id: String) = useCase.getBoardSet(id)
+    override suspend fun duplicateBoardSet(id: String) {
+        useCase.duplicateBoardSet(id)
+    }
+
+    override suspend fun toggleLocked(id: String) {
+        useCase.toggleLocked(id)
+    }
+
+    override suspend fun deleteBoardSet(id: String) = useCase.deleteBoardSet(id)
+    override suspend fun cacheAll() = speechCache.cacheAll()
+    override suspend fun cacheBoardSet(id: String) = speechCache.cacheBoardSet(id)
+    override suspend fun requiresDeleteUnlock() = editingAccessController?.requiresUnlock() == true
+    override suspend fun importBoardSet(): BoardImportResult =
+        importService?.importBoardSetResult()
+            ?: BoardImportResult.Failure(
+                code = io.github.jdreioe.wingmate.infrastructure.BoardImportErrorCode.FILE_UNREADABLE,
+                context = "Board import is unavailable",
+            )
+
+    override suspend fun importQuickCore(slug: String): BoardImportResult =
+        quickCoreService?.importPreset(slug)
+            ?: BoardImportResult.Failure(
+                code = io.github.jdreioe.wingmate.infrastructure.BoardImportErrorCode.FILE_UNREADABLE,
+                context = "Quick Core import is unavailable",
+            )
+
+    override suspend fun renameBoardSet(id: String, name: String) = useCase.renameBoardSet(id, name)
+    override suspend fun createBoardSet(
+        name: String,
+        rows: Int,
+        columns: Int,
+        rootBoardName: String,
+    ) = useCase.createBoardSet(name, rows, columns, rootBoardName)
+
+    override suspend fun createCalculatorBoardSet(name: String) = useCase.createCalculatorBoardSet(name)
+    override suspend fun createKeyboardBoardSet(name: String, preset: KeyboardPreset) =
+        useCase.createKeyboardBoardSet(name, preset)
+}
+
+internal class BoardSetManagerViewModel(
+    private val savedStateHandle: SavedStateHandle,
+    private val operations: BoardSetManagerOperations,
+) : ViewModel() {
+    private val restoredRoute = savedStateHandle.get<String>(ROUTE_BOARD_SET_ID)?.let { boardSetId ->
+        BoardSetManagerRoute.Workspace(
+            boardSetId = boardSetId,
+            mode = savedStateHandle.get<String>(ROUTE_MODE)
+                ?.let { runCatching { BoardWorkspaceMode.valueOf(it) }.getOrNull() }
+                ?: BoardWorkspaceMode.Run,
+        )
+    } ?: BoardSetManagerRoute.Library
+
+    private val _state = MutableStateFlow(
+        BoardSetManagerState(
+            route = restoredRoute,
+            showCreateDialog = savedStateHandle[SHOW_CREATE_DIALOG] ?: false,
+            createDraft = CreateBoardSetDraft(
+                name = savedStateHandle[CREATE_NAME] ?: "",
+                rowsText = savedStateHandle[CREATE_ROWS] ?: "4",
+                columnsText = savedStateHandle[CREATE_COLUMNS] ?: "8",
+                template = savedStateHandle.get<String>(CREATE_TEMPLATE)
+                    ?.let { runCatching { BoardSetTemplate.valueOf(it) }.getOrNull() }
+                    ?: BoardSetTemplate.Blank,
+                keyboardPreset = savedStateHandle.get<String>(CREATE_KEYBOARD_PRESET)
+                    ?.let { runCatching { KeyboardPreset.valueOf(it) }.getOrNull() }
+                    ?: KeyboardPreset.Qwerty,
+            ),
+            showSettings = savedStateHandle[SHOW_SETTINGS] ?: false,
+            deleteTargetId = savedStateHandle[DELETE_TARGET_ID],
+            pendingProtectedDeleteId = savedStateHandle[PENDING_DELETE_ID],
+            showDeleteAccessDialog = savedStateHandle[SHOW_DELETE_ACCESS_DIALOG] ?: false,
+        )
+    )
+    val state: StateFlow<BoardSetManagerState> = _state.asStateFlow()
+
+    private val _events = Channel<BoardSetManagerEvent>()
+    val events: Flow<BoardSetManagerEvent> = _events.receiveAsFlow()
+    private var initialized = false
+
+    init {
+        viewModelScope.launch {
+            operations.quickCoreProgress.collectLatest { progress ->
+                _state.update {
+                    it.copy(
+                        quickCoreProgress = BoardSetManagerProgress(
+                            fraction = progress.fraction?.toFloat(),
+                            stage = progress.stage,
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    fun onAction(action: BoardSetManagerAction) {
+        when (action) {
+            is BoardSetManagerAction.Initialize -> initialize(action)
+            BoardSetManagerAction.BackClicked -> {
+                setRoute(BoardSetManagerRoute.Library)
+                sendEvent(BoardSetManagerEvent.NavigateBack)
+            }
+            BoardSetManagerAction.SettingsClicked -> setShowSettings(true)
+            BoardSetManagerAction.SettingsDismissed -> setShowSettings(false)
+            BoardSetManagerAction.CreateClicked -> setShowCreateDialog(true)
+            BoardSetManagerAction.CreateDismissed -> dismissCreateDialog()
+            is BoardSetManagerAction.CreateNameChanged -> updateCreateDraft(
+                _state.value.createDraft.copy(name = action.name)
+            )
+            is BoardSetManagerAction.CreateRowsChanged -> updateCreateDraft(
+                _state.value.createDraft.copy(rowsText = action.rowsText.filter(Char::isDigit))
+            )
+            is BoardSetManagerAction.CreateColumnsChanged -> updateCreateDraft(
+                _state.value.createDraft.copy(columnsText = action.columnsText.filter(Char::isDigit))
+            )
+            is BoardSetManagerAction.CreateTemplateSelected -> {
+                val draft = _state.value.createDraft
+                updateCreateDraft(
+                    draft.copy(
+                        template = action.template,
+                        name = if (draft.name.isBlank()) action.suggestedName ?: draft.name else draft.name,
+                    )
+                )
+            }
+            is BoardSetManagerAction.CreateKeyboardPresetSelected -> updateCreateDraft(
+                _state.value.createDraft.copy(keyboardPreset = action.preset)
+            )
+            BoardSetManagerAction.ImportClicked -> importBoardSet()
+            is BoardSetManagerAction.OpenClicked -> openWorkspace(action.boardSetId, BoardWorkspaceMode.Run)
+            is BoardSetManagerAction.EditClicked -> openWorkspace(action.boardSetId, BoardWorkspaceMode.Edit)
+            is BoardSetManagerAction.DuplicateClicked -> duplicate(action.boardSetId)
+            is BoardSetManagerAction.ToggleLockClicked -> toggleLock(action.boardSetId)
+            is BoardSetManagerAction.DeleteClicked -> setDeleteTarget(action.boardSetId)
+            BoardSetManagerAction.DeleteDismissed -> setDeleteTarget(null)
+            BoardSetManagerAction.DeleteConfirmed -> confirmDelete()
+            BoardSetManagerAction.DeleteAccessDismissed -> clearProtectedDelete()
+            BoardSetManagerAction.DeleteAccessGranted -> deletePendingProtectedBoardSet()
+            BoardSetManagerAction.WorkspaceExited -> {
+                setRoute(BoardSetManagerRoute.Library)
+                refreshBoardSets()
+            }
+            is BoardSetManagerAction.CreateSubmitted -> createBoardSet(action)
+        }
+    }
+
+    private fun initialize(action: BoardSetManagerAction.Initialize) {
+        if (initialized) return
+        initialized = true
+        if (action.createOnLaunch && restoredRoute == BoardSetManagerRoute.Library) {
+            setShowCreateDialog(true)
+        }
+        refreshBoardSets()
+        viewModelScope.launch { runCatching { operations.cacheAll() } }
+        if (restoredRoute == BoardSetManagerRoute.Library && action.initialBoardSetId != null) {
+            viewModelScope.launch {
+                operations.getBoardSet(action.initialBoardSetId)?.let {
+                    openWorkspace(it.id, BoardWorkspaceMode.Run)
+                }
+            }
+        }
+    }
+
+    private fun refreshBoardSets() {
+        viewModelScope.launch {
+            _state.update { it.copy(isLoading = true) }
+            runCatching { operations.listBoardSets() }
+                .onSuccess { boardSets -> _state.update { it.copy(boardSets = boardSets) } }
+                .onFailure { error -> setStatus(error.toMessage(R.string.board_sets_load_error)) }
+            _state.update { it.copy(isLoading = false) }
+        }
+    }
+
+    private fun importBoardSet() {
+        viewModelScope.launch {
+            when (val result = operations.importBoardSet()) {
+                is BoardImportResult.Success -> {
+                    operations.cacheBoardSet(result.boardSet.id)
+                    setStatus(BoardSetManagerMessage.Resource(R.string.board_sets_imported))
+                    refreshBoardSets()
+                    openWorkspace(result.boardSet.id, BoardWorkspaceMode.Run)
+                }
+                BoardImportResult.Cancelled -> Unit
+                is BoardImportResult.Failure -> setStatus(
+                    result.context.takeIf(String::isNotBlank)?.let(BoardSetManagerMessage::Dynamic)
+                        ?: BoardSetManagerMessage.Resource(R.string.board_sets_import_error)
+                )
+            }
+        }
+    }
+
+    private fun duplicate(id: String) {
+        viewModelScope.launch {
+            runCatching { operations.duplicateBoardSet(id) }
+                .onSuccess {
+                    setStatus(BoardSetManagerMessage.Resource(R.string.board_sets_duplicated))
+                    refreshBoardSets()
+                }
+                .onFailure { setStatus(it.toMessage(R.string.board_sets_duplicate_error)) }
+        }
+    }
+
+    private fun toggleLock(id: String) {
+        viewModelScope.launch {
+            runCatching { operations.toggleLocked(id) }
+                .onSuccess { refreshBoardSets() }
+                .onFailure { setStatus(it.toMessage(R.string.board_sets_lock_error)) }
+        }
+    }
+
+    private fun confirmDelete() {
+        val targetId = _state.value.deleteTargetId ?: return
+        setDeleteTarget(null)
+        viewModelScope.launch {
+            if (operations.requiresDeleteUnlock()) {
+                savedStateHandle[PENDING_DELETE_ID] = targetId
+                savedStateHandle[SHOW_DELETE_ACCESS_DIALOG] = true
+                _state.update {
+                    it.copy(
+                        pendingProtectedDeleteId = targetId,
+                        showDeleteAccessDialog = true,
+                    )
+                }
+            } else {
+                deleteBoardSet(targetId)
+            }
+        }
+    }
+
+    private fun deletePendingProtectedBoardSet() {
+        val targetId = _state.value.pendingProtectedDeleteId ?: return
+        clearProtectedDelete()
+        deleteBoardSet(targetId)
+    }
+
+    private fun deleteBoardSet(id: String) {
+        viewModelScope.launch {
+            runCatching { operations.deleteBoardSet(id) }
+                .onSuccess {
+                    setStatus(BoardSetManagerMessage.Resource(R.string.board_sets_deleted))
+                    refreshBoardSets()
+                }
+                .onFailure { setStatus(it.toMessage(R.string.board_sets_delete_error)) }
+        }
+    }
+
+    private fun createBoardSet(action: BoardSetManagerAction.CreateSubmitted) {
+        dismissCreateDialog()
+        _state.update {
+            it.copy(
+                isCreating = true,
+                isQuickCoreImporting = action.template.quickCoreSlug != null,
+            )
+        }
+        viewModelScope.launch {
+            val result = runCatching {
+                val quickCoreSlug = action.template.quickCoreSlug
+                if (quickCoreSlug != null) {
+                    when (val imported = operations.importQuickCore(quickCoreSlug)) {
+                        is BoardImportResult.Success -> operations.renameBoardSet(
+                            imported.boardSet.id,
+                            action.name.trim(),
+                        ) ?: imported.boardSet
+                        BoardImportResult.Cancelled -> null
+                        is BoardImportResult.Failure -> throw BoardSetCreationException(imported.context)
+                    }
+                } else {
+                    when (action.template) {
+                        BoardSetTemplate.Blank -> operations.createBoardSet(
+                            action.name.trim(),
+                            action.rows,
+                            action.columns,
+                            action.defaultBoardName,
+                        )
+                        BoardSetTemplate.Calculator -> operations.createCalculatorBoardSet(action.name.trim())
+                        BoardSetTemplate.Keyboard -> operations.createKeyboardBoardSet(
+                            action.name.trim(),
+                            action.keyboardPreset,
+                        )
+                        else -> error("Quick Core presets are imported separately")
+                    }
+                }
+            }
+            result.onSuccess { created ->
+                if (created != null) {
+                    showCreatedBoardSet(created)
+                    if (action.template == BoardSetTemplate.Blank) {
+                        openWorkspace(created.id, BoardWorkspaceMode.Edit)
+                    } else if (action.template.quickCoreSlug != null) {
+                        openWorkspace(created.id, BoardWorkspaceMode.Run)
+                    }
+                }
+            }.onFailure { error ->
+                setStatus(error.toMessage(R.string.board_sets_create_error))
+            }
+            _state.update { it.copy(isCreating = false, isQuickCoreImporting = false) }
+        }
+    }
+
+    private fun showCreatedBoardSet(created: ObfBoardSet) {
+        _state.update { state ->
+            state.copy(
+                boardSets = (listOf(created) + state.boardSets)
+                    .distinctBy { it.id }
+                    .sortedByDescending { it.updatedAt },
+            )
+        }
+    }
+
+    private fun openWorkspace(boardSetId: String, mode: BoardWorkspaceMode) {
+        setRoute(BoardSetManagerRoute.Workspace(boardSetId, mode))
+    }
+
+    private fun setRoute(route: BoardSetManagerRoute) {
+        when (route) {
+            BoardSetManagerRoute.Library -> {
+                savedStateHandle[ROUTE_BOARD_SET_ID] = null
+                savedStateHandle[ROUTE_MODE] = null
+            }
+            is BoardSetManagerRoute.Workspace -> {
+                savedStateHandle[ROUTE_BOARD_SET_ID] = route.boardSetId
+                savedStateHandle[ROUTE_MODE] = route.mode.name
+            }
+        }
+        _state.update { it.copy(route = route) }
+    }
+
+    private fun setShowCreateDialog(show: Boolean) {
+        savedStateHandle[SHOW_CREATE_DIALOG] = show
+        _state.update { it.copy(showCreateDialog = show) }
+    }
+
+    private fun dismissCreateDialog() {
+        setShowCreateDialog(false)
+        updateCreateDraft(CreateBoardSetDraft())
+    }
+
+    private fun updateCreateDraft(draft: CreateBoardSetDraft) {
+        savedStateHandle[CREATE_NAME] = draft.name
+        savedStateHandle[CREATE_ROWS] = draft.rowsText
+        savedStateHandle[CREATE_COLUMNS] = draft.columnsText
+        savedStateHandle[CREATE_TEMPLATE] = draft.template.name
+        savedStateHandle[CREATE_KEYBOARD_PRESET] = draft.keyboardPreset.name
+        _state.update { it.copy(createDraft = draft) }
+    }
+
+    private fun setShowSettings(show: Boolean) {
+        savedStateHandle[SHOW_SETTINGS] = show
+        _state.update { it.copy(showSettings = show) }
+    }
+
+    private fun setDeleteTarget(id: String?) {
+        savedStateHandle[DELETE_TARGET_ID] = id
+        _state.update { it.copy(deleteTargetId = id) }
+    }
+
+    private fun clearProtectedDelete() {
+        savedStateHandle[PENDING_DELETE_ID] = null
+        savedStateHandle[SHOW_DELETE_ACCESS_DIALOG] = false
+        _state.update {
+            it.copy(
+                pendingProtectedDeleteId = null,
+                showDeleteAccessDialog = false,
+            )
+        }
+    }
+
+    private fun setStatus(message: BoardSetManagerMessage) {
+        _state.update { it.copy(statusMessage = message) }
+    }
+
+    private fun sendEvent(event: BoardSetManagerEvent) {
+        viewModelScope.launch { _events.send(event) }
+    }
+
+    private fun Throwable.toMessage(@StringRes fallback: Int): BoardSetManagerMessage =
+        message?.takeIf(String::isNotBlank)?.let(BoardSetManagerMessage::Dynamic)
+            ?: BoardSetManagerMessage.Resource(fallback)
+
+    private class BoardSetCreationException(message: String) : Exception(message)
+
+    private companion object {
+        const val ROUTE_BOARD_SET_ID = "board_set_manager.route.board_set_id"
+        const val ROUTE_MODE = "board_set_manager.route.mode"
+        const val SHOW_CREATE_DIALOG = "board_set_manager.dialog.create"
+        const val CREATE_NAME = "board_set_manager.create.name"
+        const val CREATE_ROWS = "board_set_manager.create.rows"
+        const val CREATE_COLUMNS = "board_set_manager.create.columns"
+        const val CREATE_TEMPLATE = "board_set_manager.create.template"
+        const val CREATE_KEYBOARD_PRESET = "board_set_manager.create.keyboard_preset"
+        const val SHOW_SETTINGS = "board_set_manager.dialog.settings"
+        const val DELETE_TARGET_ID = "board_set_manager.dialog.delete_target_id"
+        const val PENDING_DELETE_ID = "board_set_manager.dialog.pending_delete_id"
+        const val SHOW_DELETE_ACCESS_DIALOG = "board_set_manager.dialog.delete_access"
+    }
+}

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -120,6 +121,7 @@ import io.github.jdreioe.wingmate.domain.obf.BoardReturnBehavior
 import io.github.jdreioe.wingmate.domain.obf.pageSettingsOverrides
 import io.github.jdreioe.wingmate.domain.obf.resolveBoardSettings
 import io.github.jdreioe.wingmate.domain.obf.withPageSettingsOverrides
+import io.github.jdreioe.wingmate.domain.obf.withHomeFieldsBottomLeft
 import io.github.jdreioe.wingmate.domain.obf.parseObfButtonActions
 import io.github.jdreioe.wingmate.domain.obf.resolveObfLocalizedString
 import io.github.jdreioe.wingmate.domain.obf.GridFieldSpan
@@ -137,7 +139,6 @@ import io.github.jdreioe.wingmate.domain.obf.renameDraftBoard
 import io.github.jdreioe.wingmate.domain.obf.resizeDraftBoard
 import io.github.jdreioe.wingmate.domain.obf.moveDraftField
 import io.github.jdreioe.wingmate.domain.obf.resizeDraftField
-import io.github.jdreioe.wingmate.domain.obf.withHomeFieldsBottomLeft
 import io.github.jdreioe.wingmate.domain.obf.updateDraftCell
 import io.github.jdreioe.wingmate.domain.obf.clearDraftCell
 import io.github.jdreioe.wingmate.domain.obf.joinSentenceText
@@ -162,25 +163,6 @@ import kotlin.random.Random
 import kotlin.time.Clock
 
 import com.hojmoseit.wingmate.R
-
-internal data class BoardSetEditSession(
-    val original: BoardSetGraph,
-    val draft: BoardSetGraph,
-    val undoStack: List<BoardSetGraph> = emptyList()
-) {
-    val isDirty: Boolean get() = draft != original
-
-    fun apply(updated: BoardSetGraph): BoardSetEditSession {
-        val normalized = updated.withHomeFieldsBottomLeft()
-        if (normalized == draft) return this
-        return copy(draft = normalized, undoStack = undoStack + draft)
-    }
-
-    fun undo(): BoardSetEditSession {
-        val previous = undoStack.lastOrNull() ?: return this
-        return copy(draft = previous, undoStack = undoStack.dropLast(1))
-    }
-}
 
 private data class WorkspaceCellTarget(
     val row: Int,
@@ -256,7 +238,7 @@ fun BoardSetManagerRoot(
             importAvailable = boardImportService != null,
             onAction = viewModel::onAction,
         )
-        is BoardSetManagerRoute.Workspace -> BoardSetWorkspaceScreen(
+        is BoardSetManagerRoute.Workspace -> BoardSetWorkspaceRoot(
             boardSetId = route.boardSetId,
             initialMode = route.mode,
             onSwitchToKeyboard = { viewModel.onAction(BoardSetManagerAction.BackClicked) },
@@ -570,7 +552,7 @@ private fun BoardSetLibraryCard(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun BoardSetWorkspaceScreen(
+private fun BoardSetWorkspaceRoot(
     boardSetId: String,
     initialMode: BoardWorkspaceMode,
     onSwitchToKeyboard: () -> Unit,
@@ -590,33 +572,39 @@ private fun BoardSetWorkspaceScreen(
     val shareService = remember(koin) { koin.getOrNull<io.github.jdreioe.wingmate.platform.ShareService>() }
     val editingAccessController = remember(koin) { koin.getOrNull<EditingAccessController>() }
     val scope = rememberCoroutineScope()
-    var savedGraph by remember(boardSetId) { mutableStateOf<BoardSetGraph?>(null) }
-    var editSession by remember(boardSetId) { mutableStateOf<BoardSetEditSession?>(null) }
-    var mode by remember(boardSetId) { mutableStateOf(initialMode) }
-    var selectedBoardId by remember(boardSetId) { mutableStateOf<String?>(null) }
-    var boardStack by remember(boardSetId) { mutableStateOf<List<String>>(emptyList()) }
-    var selectedButtons by remember(boardSetId) {
-        mutableStateOf<List<Pair<ObfButton, ImageBitmap?>>>(emptyList())
+    val workspaceFactory = remember(boardSetId) {
+        viewModelFactory {
+            initializer { BoardWorkspaceViewModel(createSavedStateHandle()) }
+        }
     }
+    val workspaceViewModel: BoardWorkspaceViewModel = viewModel(
+        key = "board-workspace-$boardSetId",
+        factory = workspaceFactory,
+    )
+    val workspace by workspaceViewModel.state.collectAsStateWithLifecycle()
+    val savedGraph = workspace.savedGraph
+    val editSession = workspace.editSession
+    val mode = workspace.mode
+    val statusMessage = workspace.statusMessage
+    val showFinishDialog = workspace.showFinishDialog
+    val isExporting = workspace.isExporting
+    val isFullscreen = workspace.isFullscreen
+    val selectedButtonModels = workspace.selectedButtons
+    val selectedButtons: List<Pair<ObfButton, ImageBitmap?>> = selectedButtonModels.map { it to null }
     // #120: time-bounded selection highlight.
     val selectionHighlight = remember(boardSetId) { SelectionHighlight() }
     var highlightedButtonId by remember(boardSetId) { mutableStateOf<String?>(null) }
     var highlightGeneration by remember(boardSetId) { mutableLongStateOf(0L) }
-    var isLoading by remember(boardSetId) { mutableStateOf(true) }
-    var statusMessage by remember(boardSetId) { mutableStateOf<String?>(null) }
     var nativeKeyboardDraft by remember(boardSetId) { mutableStateOf<String?>(null) }
     var showAddBoardDialog by remember { mutableStateOf(false) }
     var editingCell by remember { mutableStateOf<WorkspaceCellTarget?>(null) }
     var selectedField by remember(boardSetId) { mutableStateOf<Pair<Int, Int>?>(null) }
-    var showFinishDialog by remember { mutableStateOf(false) }
     var showResizeBoardDialog by remember { mutableStateOf(false) }
     var showDeleteBoardDialog by remember { mutableStateOf(false) }
     var settingsTarget by remember(boardSetId) { mutableStateOf<BoardSettingsTarget?>(null) }
-    var isExporting by remember(boardSetId) { mutableStateOf(false) }
-    var isFullscreen by remember(boardSetId) { mutableStateOf(false) }
     val hiddenButtonsSession = remember(boardSetId) { HiddenButtonsSession() }
     val showHiddenButtons = hiddenButtonsSession.revealed
-    var showEditingAccessDialog by remember(boardSetId) { mutableStateOf(false) }
+    val showEditingAccessDialog = workspace.showEditingAccessDialog
     var appBarMenuExpanded by remember(boardSetId) { mutableStateOf(false) }
     val unlockToEditMessage = stringResource(R.string.board_workspace_unlock_to_edit)
     val saveErrorMessage = stringResource(R.string.board_workspace_save_error)
@@ -677,22 +665,42 @@ private fun BoardSetWorkspaceScreen(
     }
 
     LaunchedEffect(boardSetId) {
-        isLoading = true
-        val loaded = withContext(Dispatchers.Default) { useCase.loadBoardSetGraph(boardSetId) }
-        val normalized = loaded?.withHomeFieldsBottomLeft()
-        savedGraph = normalized
-        selectedBoardId = normalized?.boardSet?.rootBoardId
-        if (normalized != null && initialMode == BoardWorkspaceMode.Edit && !normalized.boardSet.isLocked) {
-            if (editingAccessController?.requiresUnlock() == true) {
-                mode = BoardWorkspaceMode.Run
-                showEditingAccessDialog = true
-            } else {
-                editSession = BoardSetEditSession(normalized, normalized)
+        if (workspaceViewModel.state.value.savedGraph != null) return@LaunchedEffect
+        runCatching {
+            withContext(Dispatchers.Default) { useCase.loadBoardSetGraph(boardSetId) }
+                ?.withHomeFieldsBottomLeft()
+        }.onSuccess { graph ->
+            val requiresUnlock = graph != null &&
+                initialMode == BoardWorkspaceMode.Edit &&
+                !graph.boardSet.isLocked &&
+                editingAccessController?.requiresUnlock() == true
+            workspaceViewModel.onAction(
+                BoardWorkspaceAction.Initialize(
+                    graph = graph,
+                    startInEditMode = initialMode == BoardWorkspaceMode.Edit && !requiresUnlock,
+                )
+            )
+            if (requiresUnlock) {
+                workspaceViewModel.onAction(BoardWorkspaceAction.EditingAccessRequired)
             }
-        } else if (normalized?.boardSet?.isLocked == true) {
-            mode = BoardWorkspaceMode.Run
+        }.onFailure { error ->
+            workspaceViewModel.onAction(
+                BoardWorkspaceAction.LoadFailed(
+                    error.message ?: "Unable to load board set"
+                )
+            )
         }
-        isLoading = false
+    }
+
+    LaunchedEffect(workspaceViewModel, onExitToLibrary) {
+        workspaceViewModel.events.collect { event ->
+            when (event) {
+                BoardWorkspaceEvent.NavigateToLibrary -> {
+                    hiddenButtonsSession.reset()
+                    onExitToLibrary()
+                }
+            }
+        }
     }
 
     // #120: expire the selection highlight after the configured duration. Re-activating a
@@ -720,7 +728,7 @@ private fun BoardSetWorkspaceScreen(
     }
 
     val activeGraph = editSession?.draft ?: savedGraph
-    val activeBoard = activeGraph?.boardsById?.get(selectedBoardId)
+    val activeBoard = activeGraph?.boardsById?.get(workspace.selectedBoardId)
     val resolvedBoardSettings = remember(
         activeGraph?.boardSet?.screenSettings,
         activeBoard?.extensions,
@@ -788,20 +796,17 @@ private fun BoardSetWorkspaceScreen(
     fun enterEditing() {
         val graph = savedGraph ?: return
         if (graph.boardSet.isLocked) {
-            statusMessage = unlockToEditMessage
+            workspaceViewModel.onAction(BoardWorkspaceAction.StatusChanged(unlockToEditMessage))
             return
         }
-        selectedButtons = emptyList()
-        boardStack = emptyList()
         selectedField = null
-        editSession = BoardSetEditSession(graph, graph)
-        mode = BoardWorkspaceMode.Edit
+        workspaceViewModel.onAction(BoardWorkspaceAction.StartEditing)
     }
 
     fun startEditing() {
         scope.launch {
             if (editingAccessController?.requiresUnlock() == true) {
-                showEditingAccessDialog = true
+                workspaceViewModel.onAction(BoardWorkspaceAction.EditingAccessRequired)
             } else {
                 enterEditing()
             }
@@ -809,35 +814,22 @@ private fun BoardSetWorkspaceScreen(
     }
 
     fun requestFinishEditing() {
-        val session = editSession ?: return
-        if (session.isDirty) showFinishDialog = true
-        else {
-            selectedField = null
-            editSession = null
-            mode = BoardWorkspaceMode.Run
-        }
+        selectedField = null
+        workspaceViewModel.onAction(BoardWorkspaceAction.FinishEditingClicked)
     }
 
     fun navigateBack() {
-        if (mode == BoardWorkspaceMode.Edit) {
-            requestFinishEditing()
-        } else if (boardStack.isNotEmpty()) {
-            selectedBoardId = boardStack.last()
-            boardStack = boardStack.dropLast(1)
-        } else {
-            hiddenButtonsSession.reset()
-            onExitToLibrary()
-        }
+        workspaceViewModel.onAction(BoardWorkspaceAction.BackClicked)
     }
 
     fun exportBoardSet() {
         scope.launch {
-            isExporting = true
-            statusMessage = null
+            workspaceViewModel.onAction(BoardWorkspaceAction.ExportStarted)
+            var resultMessage = "Export cancelled"
             try {
                 val graph = activeGraph
                 if (graph == null) {
-                    statusMessage = "Export failed: no board set loaded"
+                    resultMessage = "Export failed: no board set loaded"
                 } else {
                     when (val export = useCase.exportBoardSetAsObzResult(graph.boardSet.id)) {
                         is ObzExportResult.Success -> {
@@ -845,13 +837,13 @@ private fun BoardSetWorkspaceScreen(
                             val fileName = "${graph.boardSet.name}.obz"
                             if (shareService != null) {
                                 val shared = shareService.shareFile(fileName, obzBytes)
-                                statusMessage = if (shared) {
+                                resultMessage = if (shared) {
                                     "Exported ${graph.boardSet.name}.obz"
                                 } else {
                                     "Export cancelled"
                                 }
                             } else {
-                                statusMessage = "Export saved (${obzBytes.size} bytes)"
+                                resultMessage = "Export saved (${obzBytes.size} bytes)"
                             }
                         }
                         is ObzExportResult.Failure -> {
@@ -859,14 +851,14 @@ private fun BoardSetWorkspaceScreen(
                                 .takeIf { it.isNotEmpty() }
                                 ?.joinToString(prefix = ": ")
                                 .orEmpty()
-                            statusMessage = "Export failed: ${export.context}$resources"
+                            resultMessage = "Export failed: ${export.context}$resources"
                     }
                     }
                 }
             } catch (e: Exception) {
-                statusMessage = "Export failed: ${e.message ?: "unknown error"}"
+                resultMessage = "Export failed: ${e.message ?: "unknown error"}"
             } finally {
-                isExporting = false
+                workspaceViewModel.onAction(BoardWorkspaceAction.ExportFinished(resultMessage))
             }
         }
     }
@@ -885,17 +877,21 @@ private fun BoardSetWorkspaceScreen(
             },
             confirmButton = {
                 TextButton(onClick = {
-                    selectedButtons = currentDraft.takeIf { it.isNotEmpty() }
-                        ?.let { text ->
-                            listOf(
-                                ObfButton(
-                                    id = workspaceId("native-keyboard"),
-                                    label = text,
-                                    vocalization = text,
-                                ) to null
-                            )
-                        }
-                        .orEmpty()
+                    workspaceViewModel.onAction(
+                        BoardWorkspaceAction.ReplaceSentence(
+                            currentDraft.takeIf { it.isNotEmpty() }
+                                ?.let { text ->
+                                    listOf(
+                                        ObfButton(
+                                            id = workspaceId("native-keyboard"),
+                                            label = text,
+                                            vocalization = text,
+                                        )
+                                    )
+                                }
+                                .orEmpty()
+                        )
+                    )
                     nativeKeyboardDraft = null
                 }) {
                     Text(stringResource(R.string.board_native_keyboard_return))
@@ -953,7 +949,7 @@ private fun BoardSetWorkspaceScreen(
                         }
                     )
                 }
-                editSession = session.apply(updated)
+                workspaceViewModel.onAction(BoardWorkspaceAction.ApplyEdit(updated))
             },
             onBack = { settingsTarget = null }
         )
@@ -1025,7 +1021,7 @@ private fun BoardSetWorkspaceScreen(
                                         enabled = editSession?.undoStack?.isNotEmpty() == true,
                                         onClick = {
                                             appBarMenuExpanded = false
-                                            editSession = editSession?.undo()
+                                            workspaceViewModel.onAction(BoardWorkspaceAction.UndoEdit)
                                         }
                                     )
                                     DropdownMenuItem(
@@ -1070,7 +1066,11 @@ private fun BoardSetWorkspaceScreen(
                                             val session = editSession
                                             val board = activeBoard
                                             if (session != null && board != null) {
-                                                editSession = session.apply(setDraftRoot(session.draft, board.id))
+                                                workspaceViewModel.onAction(
+                                                    BoardWorkspaceAction.ApplyEdit(
+                                                        setDraftRoot(session.draft, board.id)
+                                                    )
+                                                )
                                             }
                                         }
                                     )
@@ -1113,7 +1113,9 @@ private fun BoardSetWorkspaceScreen(
                                         leadingIcon = { Icon(Icons.Default.Fullscreen, contentDescription = null) },
                                         onClick = {
                                             appBarMenuExpanded = false
-                                            isFullscreen = true
+                                            workspaceViewModel.onAction(
+                                                BoardWorkspaceAction.FullscreenChanged(true)
+                                            )
                                         }
                                     )
                                     DropdownMenuItem(
@@ -1133,14 +1135,17 @@ private fun BoardSetWorkspaceScreen(
                                             exportBoardSet()
                                         }
                                     )
-                                    if (selectedBoardId != activeGraph?.boardSet?.rootBoardId) {
+                                    if (workspace.selectedBoardId != activeGraph?.boardSet?.rootBoardId) {
                                         DropdownMenuItem(
                                             text = { Text(stringResource(R.string.board_workspace_home)) },
                                             leadingIcon = { Icon(Icons.Default.Home, contentDescription = null) },
                                             onClick = {
                                                 appBarMenuExpanded = false
-                                                selectedBoardId = activeGraph?.boardSet?.rootBoardId
-                                                boardStack = emptyList()
+                                                activeGraph?.boardSet?.rootBoardId?.let { rootBoardId ->
+                                                    workspaceViewModel.onAction(
+                                                        BoardWorkspaceAction.GoHome(rootBoardId)
+                                                    )
+                                                }
                                             }
                                         )
                                     }
@@ -1159,7 +1164,7 @@ private fun BoardSetWorkspaceScreen(
                         }
                     } else if (mode == BoardWorkspaceMode.Edit) {
                         IconButton(
-                            onClick = { editSession = editSession?.undo() },
+                            onClick = { workspaceViewModel.onAction(BoardWorkspaceAction.UndoEdit) },
                             enabled = editSession?.undoStack?.isNotEmpty() == true
                         ) {
                             Icon(Icons.AutoMirrored.Filled.Undo, contentDescription = stringResource(R.string.board_workspace_undo))
@@ -1184,7 +1189,11 @@ private fun BoardSetWorkspaceScreen(
                                 val session = editSession
                                 val board = activeBoard
                                 if (session != null && board != null) {
-                                    editSession = session.apply(setDraftRoot(session.draft, board.id))
+                                    workspaceViewModel.onAction(
+                                        BoardWorkspaceAction.ApplyEdit(
+                                            setDraftRoot(session.draft, board.id)
+                                        )
+                                    )
                                 }
                             },
                             enabled = activeBoard != null && activeBoard.id != activeGraph.boardSet.rootBoardId
@@ -1232,7 +1241,9 @@ private fun BoardSetWorkspaceScreen(
                                 )
                             )
                         }
-                        IconButton(onClick = { isFullscreen = true }) {
+                        IconButton(onClick = {
+                            workspaceViewModel.onAction(BoardWorkspaceAction.FullscreenChanged(true))
+                        }) {
                             Icon(
                                 Icons.Default.Fullscreen,
                                 contentDescription = stringResource(R.string.board_workspace_enter_fullscreen)
@@ -1253,10 +1264,13 @@ private fun BoardSetWorkspaceScreen(
                                 contentDescription = stringResource(R.string.phrase_screen_import_export_data)
                             )
                         }
-                        if (selectedBoardId != activeGraph?.boardSet?.rootBoardId) {
+                        if (workspace.selectedBoardId != activeGraph?.boardSet?.rootBoardId) {
                             IconButton(onClick = {
-                                selectedBoardId = activeGraph?.boardSet?.rootBoardId
-                                boardStack = emptyList()
+                                activeGraph?.boardSet?.rootBoardId?.let { rootBoardId ->
+                                    workspaceViewModel.onAction(
+                                        BoardWorkspaceAction.GoHome(rootBoardId)
+                                    )
+                                }
                             }) {
                                 Icon(Icons.Default.Home, contentDescription = stringResource(R.string.board_workspace_home))
                             }
@@ -1282,33 +1296,21 @@ private fun BoardSetWorkspaceScreen(
         },
     ) { innerPadding ->
         Box(Modifier.fillMaxSize().padding(innerPadding)) {
-            when {
-                isLoading -> CircularProgressIndicator(Modifier.align(Alignment.Center))
-                activeGraph == null || activeBoard == null -> Column(
-                    modifier = Modifier.align(Alignment.Center),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    Text(stringResource(R.string.board_workspace_load_error))
-                    TextButton(onClick = onExitToLibrary) {
-                        Text(stringResource(R.string.board_workspace_back_to_library))
-                    }
-                }
-                else -> Column(Modifier.fillMaxSize()) {
-                    if (!isFullscreen) statusMessage?.let {
-                        Text(
-                            it,
-                            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 6.dp),
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                    }
+            BoardWorkspaceContent(
+                state = workspace,
+                hasActiveBoard = activeGraph != null && activeBoard != null,
+                onBackToLibrary = onExitToLibrary,
+            ) {
+                if (activeGraph != null && activeBoard != null) {
                     if (!isFullscreen && mode == BoardWorkspaceMode.Edit) {
                         BoardStrip(
                             boards = activeGraph.boards,
-                            selectedBoardId = selectedBoardId,
+                            selectedBoardId = workspace.selectedBoardId,
                             onSelect = {
-                                selectedBoardId = it
-                                boardStack = emptyList()
-                                selectedButtons = emptyList()
+                                workspaceViewModel.onAction(
+                                    BoardWorkspaceAction.SelectBoard(it)
+                                )
+                                workspaceViewModel.onAction(BoardWorkspaceAction.ClearSentence)
                                 selectedField = null
                             }
                         )
@@ -1394,14 +1396,21 @@ private fun BoardSetWorkspaceScreen(
                                             }
                                         }
                                         is ObfButtonActionEffect.Unsupported -> {
-                                            statusMessage = unsupportedActionTemplate.replace("%ACTION%", effect.action)
+                                            workspaceViewModel.onAction(
+                                                BoardWorkspaceAction.StatusChanged(
+                                                    unsupportedActionTemplate.replace("%ACTION%", effect.action)
+                                                )
+                                            )
                                         }
                                     }
                                 }
-                                selectedButtons = nextSelection
+                                workspaceViewModel.onAction(
+                                    BoardWorkspaceAction.ReplaceSentence(nextSelection.map { it.first })
+                                )
                                 if (navigateHome) {
-                                    boardStack = emptyList()
-                                    selectedBoardId = activeGraph.boardSet.rootBoardId
+                                    workspaceViewModel.onAction(
+                                        BoardWorkspaceAction.GoHome(activeGraph.boardSet.rootBoardId)
+                                    )
                                 }
                                 if (speakAfterActions) {
                                     speakSelectedButtons(
@@ -1417,8 +1426,9 @@ private fun BoardSetWorkspaceScreen(
                             } else {
                                 val linkedBoard = activeGraph.resolveLinkedBoard(button.loadBoard)
                                 if (linkedBoard != null) {
-                                    selectedBoardId?.let { boardStack = boardStack + it }
-                                    selectedBoardId = linkedBoard.id
+                                    workspaceViewModel.onAction(
+                                        BoardWorkspaceAction.OpenBoard(linkedBoard.id)
+                                    )
                                 } else {
                                     val resolved = resolveObfLocalizedString(
                                         activeBoard.strings,
@@ -1430,7 +1440,11 @@ private fun BoardSetWorkspaceScreen(
                                         spokenText.isNotEmpty() &&
                                         shouldAddBoardSelection(resolvedBoardSettings.activationBehavior)
                                     ) {
-                                        selectedButtons = selectedButtons + (button to null)
+                                        workspaceViewModel.onAction(
+                                            BoardWorkspaceAction.ReplaceSentence(
+                                                selectedButtonModels + button
+                                            )
+                                        )
                                     }
                                     val sound = button.soundId?.let { id ->
                                         activeBoard.sounds.firstOrNull { it.id == id }
@@ -1470,12 +1484,16 @@ private fun BoardSetWorkspaceScreen(
                                     if (spokenText.isNotEmpty() || sound != null) {
                                         val returned = applyBoardReturnBehavior(
                                             behavior = resolvedBoardSettings.returnBehavior,
-                                            currentBoardId = selectedBoardId,
-                                            boardStack = boardStack,
+                                            currentBoardId = workspace.selectedBoardId,
+                                            boardStack = workspace.boardStack,
                                             rootBoardId = activeGraph.boardSet.rootBoardId
                                         )
-                                        selectedBoardId = returned.first
-                                        boardStack = returned.second
+                                        workspaceViewModel.onAction(
+                                            BoardWorkspaceAction.RestorePosition(
+                                                selectedBoardId = returned.first,
+                                                boardStack = returned.second,
+                                            )
+                                        )
                                     }
                                 }
                             }
@@ -1506,7 +1524,7 @@ private fun BoardSetWorkspaceScreen(
                                 val boardId = activeBoard.id
                                 if (session != null) {
                                     selectedField = null
-                                    editSession = session.apply(
+                                    workspaceViewModel.onAction(BoardWorkspaceAction.ApplyEdit(
                                         moveDraftField(
                                             session.draft,
                                             boardId,
@@ -1515,7 +1533,7 @@ private fun BoardSetWorkspaceScreen(
                                             toRow,
                                             toColumn
                                         )
-                                    )
+                                    ))
                                 }
                             }
                         } else null,
@@ -1538,7 +1556,7 @@ private fun BoardSetWorkspaceScreen(
                                     columnSpan = columnSpan
                                 )
                                 if (resized != session.draft) {
-                                    editSession = session.apply(resized)
+                                    workspaceViewModel.onAction(BoardWorkspaceAction.ApplyEdit(resized))
                                 }
                             }
                         } else null,
@@ -1546,13 +1564,13 @@ private fun BoardSetWorkspaceScreen(
                             { fraction ->
                                 val session = editSession ?: return@ObfBoardView
                                 val boardId = activeBoard.id
-                                editSession = session.apply(
+                                workspaceViewModel.onAction(BoardWorkspaceAction.ApplyEdit(
                                     session.draft.copy(
                                         boards = session.draft.boards.map { board ->
                                             if (board.id == boardId) board.withGridHeightFraction(fraction) else board
                                         }
                                     )
-                                )
+                                ))
                             }
                         } else null,
                         homeBoardId = activeGraph.boardSet.rootBoardId,
@@ -1568,9 +1586,11 @@ private fun BoardSetWorkspaceScreen(
                             )
                         },
                         onDeleteLast = {
-                            if (selectedButtons.isNotEmpty()) selectedButtons = selectedButtons.dropLast(1)
+                            workspaceViewModel.onAction(BoardWorkspaceAction.RemoveLastSentenceButton)
                         },
-                        onClearSentence = { selectedButtons = emptyList() },
+                        onClearSentence = {
+                            workspaceViewModel.onAction(BoardWorkspaceAction.ClearSentence)
+                        },
                         modifier = Modifier.weight(1f).fillMaxWidth()
                     )
                 }
@@ -1582,7 +1602,9 @@ private fun BoardSetWorkspaceScreen(
                     color = MaterialTheme.colorScheme.surface.copy(alpha = 0.9f),
                     tonalElevation = 4.dp
                 ) {
-                    IconButton(onClick = { isFullscreen = false }) {
+                    IconButton(onClick = {
+                        workspaceViewModel.onAction(BoardWorkspaceAction.FullscreenChanged(false))
+                    }) {
                         Icon(
                             Icons.Default.FullscreenExit,
                             contentDescription = stringResource(R.string.board_workspace_exit_fullscreen)
@@ -1600,8 +1622,10 @@ private fun BoardSetWorkspaceScreen(
             onCreate = { name, rows, columns, keyboardLayout ->
                 val session = editSession ?: return@CreateBoardDialog
                 val updated = addDraftBoard(session.draft, name, rows, columns, keyboardLayout)
-                editSession = session.apply(updated)
-                selectedBoardId = updated.boards.last().id
+                workspaceViewModel.onAction(BoardWorkspaceAction.ApplyEdit(updated))
+                workspaceViewModel.onAction(
+                    BoardWorkspaceAction.SelectBoard(updated.boards.last().id)
+                )
                 showAddBoardDialog = false
             }
         )
@@ -1611,9 +1635,10 @@ private fun BoardSetWorkspaceScreen(
         EditingAccessDialog(
             controller = editingAccessController,
             mode = EditingAccessDialogMode.Unlock,
-            onDismiss = { showEditingAccessDialog = false },
+            onDismiss = {
+                workspaceViewModel.onAction(BoardWorkspaceAction.EditingAccessDismissed)
+            },
             onSuccess = {
-                showEditingAccessDialog = false
                 enterEditing()
             }
         )
@@ -1652,7 +1677,7 @@ private fun BoardSetWorkspaceScreen(
             onSave = { label, vocalization, imageUrl, recordingPath, backgroundColor, language, mathMode, hidden, linkedBoardId,
                        action, actions, shape, wordType ->
                 val session = editSession ?: return@EditBoardCellDialog
-                editSession = session.apply(
+                workspaceViewModel.onAction(BoardWorkspaceAction.ApplyEdit(
                     updateDraftCell(
                         graph = session.draft,
                         boardId = activeBoard.id,
@@ -1672,14 +1697,14 @@ private fun BoardSetWorkspaceScreen(
                         shape = shape,
                         wordType = wordType
                     )
-                )
+                ))
                 editingCell = null
             },
             onClearCell = {
                 val session = editSession ?: return@EditBoardCellDialog
-                editSession = session.apply(
+                workspaceViewModel.onAction(BoardWorkspaceAction.ApplyEdit(
                     clearDraftCell(session.draft, activeBoard.id, target.row, target.column)
-                )
+                ))
                 editingCell = null
             }
         )
@@ -1687,16 +1712,16 @@ private fun BoardSetWorkspaceScreen(
 
     if (showFinishDialog) {
         AlertDialog(
-            onDismissRequest = { showFinishDialog = false },
+            onDismissRequest = {
+                workspaceViewModel.onAction(BoardWorkspaceAction.KeepEditing)
+            },
             title = { Text(stringResource(R.string.board_workspace_finish_title)) },
             text = { Text(stringResource(R.string.board_workspace_finish_body)) },
             confirmButton = {
                 Button(onClick = {
                     val session = editSession ?: return@Button
-                    showFinishDialog = false
                     selectedField = null
-                    editSession = null
-                    mode = BoardWorkspaceMode.Run
+                    workspaceViewModel.onAction(BoardWorkspaceAction.SaveStarted)
                     val graph = session.draft
                     // Persist on an application-scoped scope so leaving this screen can't
                     // cancel the write halfway; branch back to the main thread for state updates.
@@ -1705,13 +1730,13 @@ private fun BoardSetWorkspaceScreen(
                         withContext(Dispatchers.Default) {
                             useCase.saveBoardSetGraph(graph)
                         }.onSuccess { saved ->
-                            savedGraph = saved
+                            workspaceViewModel.onAction(BoardWorkspaceAction.SaveSucceeded(saved))
                         }.onFailure { error ->
                             // Persistence failed: drop back into editing with the draft intact
                             // so the user does not lose their work.
-                            mode = BoardWorkspaceMode.Edit
-                            editSession = session
-                            statusMessage = error.message ?: saveErrorMessage
+                            workspaceViewModel.onAction(
+                                BoardWorkspaceAction.SaveFailed(error.message ?: saveErrorMessage)
+                            )
                         }
                     }
                 }) { Text(stringResource(R.string.board_workspace_save_changes)) }
@@ -1719,13 +1744,12 @@ private fun BoardSetWorkspaceScreen(
             dismissButton = {
                 Row {
                     TextButton(onClick = {
-                        showFinishDialog = false
                         selectedField = null
-                        editSession = null
-                        mode = BoardWorkspaceMode.Run
-                        selectedBoardId = savedGraph?.boardSet?.rootBoardId
+                        workspaceViewModel.onAction(BoardWorkspaceAction.DiscardEdits)
                     }) { Text(stringResource(R.string.board_workspace_discard)) }
-                    TextButton(onClick = { showFinishDialog = false }) {
+                    TextButton(onClick = {
+                        workspaceViewModel.onAction(BoardWorkspaceAction.KeepEditing)
+                    }) {
                         Text(stringResource(R.string.board_workspace_keep_editing))
                     }
                 }
@@ -1746,7 +1770,7 @@ private fun BoardSetWorkspaceScreen(
                 if (resized == session.draft) {
                     false
                 } else {
-                    editSession = session.apply(resized)
+                    workspaceViewModel.onAction(BoardWorkspaceAction.ApplyEdit(resized))
                     showResizeBoardDialog = false
                     true
                 }
@@ -1771,8 +1795,10 @@ private fun BoardSetWorkspaceScreen(
                     val session = editSession
                     if (session != null) {
                         val updated = deleteDraftBoard(session.draft, activeBoard.id)
-                        editSession = session.apply(updated)
-                        selectedBoardId = updated.boardSet.rootBoardId
+                        workspaceViewModel.onAction(BoardWorkspaceAction.ApplyEdit(updated))
+                        workspaceViewModel.onAction(
+                            BoardWorkspaceAction.GoHome(updated.boardSet.rootBoardId)
+                        )
                     }
                     showDeleteBoardDialog = false
                 }) { Text(stringResource(R.string.common_delete), color = MaterialTheme.colorScheme.error) }
@@ -1783,6 +1809,70 @@ private fun BoardSetWorkspaceScreen(
                 }
             }
         )
+    }
+}
+
+/**
+ * Stateless workspace shell. It keeps loading and failure rendering independent from the
+ * orchestration-heavy root while allowing the real board surface to remain a cohesive section.
+ */
+@Composable
+internal fun BoardWorkspaceContent(
+    state: BoardWorkspaceState,
+    hasActiveBoard: Boolean,
+    onBackToLibrary: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Box(modifier.fillMaxSize()) {
+        when {
+            state.contentStatus == BoardWorkspaceContentStatus.Loading && !hasActiveBoard -> {
+                CircularProgressIndicator(Modifier.align(Alignment.Center))
+            }
+            !hasActiveBoard -> Column(
+                modifier = Modifier.align(Alignment.Center),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                val failure = state.contentStatus as? BoardWorkspaceContentStatus.RecoverableFailure
+                Text(failure?.message ?: stringResource(R.string.board_workspace_load_error))
+                TextButton(onClick = onBackToLibrary) {
+                    Text(stringResource(R.string.board_workspace_back_to_library))
+                }
+            }
+            else -> Column(Modifier.fillMaxSize()) {
+                if (!state.isFullscreen) state.statusMessage?.let { message ->
+                    Text(
+                        message,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 6.dp),
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+                content()
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 600, heightDp = 400)
+@Composable
+private fun BoardWorkspaceContentPreview() {
+    AppTheme {
+        BoardWorkspaceContent(
+            state = BoardWorkspaceState(
+                contentStatus = BoardWorkspaceContentStatus.Ready,
+                statusMessage = "Board saved",
+            ),
+            hasActiveBoard = true,
+            onBackToLibrary = {},
+        ) {
+            Text(
+                text = "Communication board",
+                modifier = Modifier.padding(24.dp),
+                style = MaterialTheme.typography.headlineMedium,
+            )
+        }
     }
 }
 

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -65,6 +65,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
@@ -73,6 +78,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.tooling.preview.Preview
 import io.github.jdreioe.wingmate.application.BoardSetUseCase
 import io.github.jdreioe.wingmate.application.ObzExportResult
 import io.github.jdreioe.wingmate.application.BoardSetSpeechCacheUseCase
@@ -156,15 +162,6 @@ import kotlin.random.Random
 import kotlin.time.Clock
 
 import com.hojmoseit.wingmate.R
-private enum class BoardWorkspaceMode { Run, Edit }
-
-private sealed interface BoardSetRoute {
-    data object Library : BoardSetRoute
-    data class Workspace(
-        val boardSetId: String,
-        val mode: BoardWorkspaceMode
-    ) : BoardSetRoute
-}
 
 internal data class BoardSetEditSession(
     val original: BoardSetGraph,
@@ -195,7 +192,7 @@ private data class WorkspaceCellTarget(
  * Board-set entry point with a familiar library -> Run/Edit workspace flow.
  */
 @Composable
-fun BoardSetManagerScreen(
+fun BoardSetManagerRoot(
     onBack: () -> Unit,
     onBackToWelcome: () -> Unit,
     createOnLaunch: Boolean = false,
@@ -206,249 +203,203 @@ fun BoardSetManagerScreen(
     val boardSetSpeechCache = koinInject<BoardSetSpeechCacheUseCase>()
     val boardImportService = remember(koin) { koin.getOrNull<BoardImportService>() }
     val quickCorePresetService = remember(koin) { koin.getOrNull<QuickCorePresetService>() }
-    val quickCoreProgress by quickCorePresetService?.progress?.collectAsState()
-        ?: remember { mutableStateOf(null) }
-    val speechService = koinInject<SpeechService>()
-    val voiceUseCase = koinInject<VoiceUseCase>()
-    val featureUsageReporter = koinInject<io.github.jdreioe.wingmate.application.FeatureUsageReporter>()
-    val updateService = remember(koin) { koin.getOrNull<io.github.jdreioe.wingmate.domain.UpdateService>() }
     val editingAccessController = remember(koin) { koin.getOrNull<EditingAccessController>() }
-    val scope = rememberCoroutineScope()
-    var route by remember { mutableStateOf<BoardSetRoute>(BoardSetRoute.Library) }
-    var boardSets by remember { mutableStateOf<List<ObfBoardSet>>(emptyList()) }
-    var isLoading by remember { mutableStateOf(true) }
-    var isCreating by remember { mutableStateOf(false) }
-    var showCreateDialog by remember { mutableStateOf(false) }
-    var isQuickCoreImporting by remember { mutableStateOf(false) }
-    var showSettings by remember { mutableStateOf(false) }
-    var showImportExport by remember { mutableStateOf(false) }
-    var deleteTarget by remember { mutableStateOf<ObfBoardSet?>(null) }
-    var pendingProtectedDelete by remember { mutableStateOf<ObfBoardSet?>(null) }
-    var showDeleteAccessDialog by remember { mutableStateOf(false) }
-    var statusMessage by remember { mutableStateOf<String?>(null) }
-    val loadError = stringResource(R.string.board_sets_load_error)
-    val duplicatedMessage = stringResource(R.string.board_sets_duplicated)
-    val duplicateError = stringResource(R.string.board_sets_duplicate_error)
-    val lockError = stringResource(R.string.board_sets_lock_error)
-    val createError = stringResource(R.string.board_sets_create_error)
-    val deletedMessage = stringResource(R.string.board_sets_deleted)
-    val deleteError = stringResource(R.string.board_sets_delete_error)
-    val importedMessage = stringResource(R.string.board_sets_imported)
-    val importError = stringResource(R.string.board_sets_import_error)
+    val operations = remember(
+        useCase,
+        boardSetSpeechCache,
+        boardImportService,
+        quickCorePresetService,
+        editingAccessController,
+    ) {
+        DefaultBoardSetManagerOperations(
+            useCase = useCase,
+            speechCache = boardSetSpeechCache,
+            importService = boardImportService,
+            quickCoreService = quickCorePresetService,
+            editingAccessController = editingAccessController,
+        )
+    }
+    val factory = remember(operations) {
+        viewModelFactory {
+            initializer {
+                BoardSetManagerViewModel(
+                    savedStateHandle = createSavedStateHandle(),
+                    operations = operations,
+                )
+            }
+        }
+    }
+    val viewModel: BoardSetManagerViewModel = viewModel(factory = factory)
+    val state by viewModel.state.collectAsStateWithLifecycle()
     val defaultBoardName = stringResource(R.string.board_dialog_default_board_name)
 
-    fun refreshBoardSets() {
-        scope.launch {
-            isLoading = true
-            runCatching { useCase.listBoardSets() }
-                .onSuccess { boardSets = it }
-                .onFailure { statusMessage = it.message ?: loadError }
-            isLoading = false
-        }
-    }
-
-    fun showCreatedBoardSet(created: ObfBoardSet) {
-        boardSets = (listOf(created) + boardSets)
-            .distinctBy { it.id }
-            .sortedByDescending { it.updatedAt }
-    }
-
-    fun deleteBoardSet(boardSet: ObfBoardSet) {
-        scope.launch {
-            runCatching { useCase.deleteBoardSet(boardSet.id) }
-                .onSuccess {
-                    statusMessage = deletedMessage
-                    refreshBoardSets()
-                }
-                .onFailure { statusMessage = it.message ?: deleteError }
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        refreshBoardSets()
-        boardSetSpeechCache.cacheAll()
-    }
-    LaunchedEffect(initialBoardSetId) {
-        val targetBoardSet = initialBoardSetId?.let { id ->
-            withContext(Dispatchers.Default) { useCase.getBoardSet(id) }
-        }
-        if (targetBoardSet != null) {
-            route = BoardSetRoute.Workspace(targetBoardSet.id, BoardWorkspaceMode.Run)
-        }
-    }
-    LaunchedEffect(createOnLaunch) {
-        if (createOnLaunch) showCreateDialog = true
-    }
-
-    when (val currentRoute = route) {
-        BoardSetRoute.Library -> BoardSetLibraryScreen(
-            boardSets = boardSets,
-            isLoading = isLoading,
-            isCreating = isCreating,
-            statusMessage = statusMessage,
-            onBack = onBack,
-            onOpenSettings = { showSettings = true },
-            onCreate = { showCreateDialog = true },
-            onImport = boardImportService?.let { importService -> {
-                scope.launch {
-                    when (val result = importService.importBoardSetResult()) {
-                        is BoardImportResult.Success -> {
-                                val imported = result.boardSet
-                                boardSetSpeechCache.cacheBoardSet(imported.id)
-                                statusMessage = importedMessage
-                                refreshBoardSets()
-                                route = BoardSetRoute.Workspace(imported.id, BoardWorkspaceMode.Run)
-                        }
-                        BoardImportResult.Cancelled -> Unit
-                        is BoardImportResult.Failure -> {
-                            statusMessage = result.context.ifBlank { importError }
-                        }
-                    }
-                }
-            } },
-            onOpen = { route = BoardSetRoute.Workspace(it.id, BoardWorkspaceMode.Run) },
-            onEdit = { route = BoardSetRoute.Workspace(it.id, BoardWorkspaceMode.Edit) },
-            onDuplicate = { boardSet ->
-                scope.launch {
-                    runCatching { useCase.duplicateBoardSet(boardSet.id) }
-                        .onSuccess {
-                            statusMessage = duplicatedMessage
-                            refreshBoardSets()
-                        }
-                        .onFailure { statusMessage = it.message ?: duplicateError }
-                }
-            },
-            onToggleLock = { boardSet ->
-                scope.launch {
-                    runCatching { useCase.toggleLocked(boardSet.id) }
-                        .onSuccess { refreshBoardSets() }
-                        .onFailure { statusMessage = it.message ?: lockError }
-                }
-            },
-            onDelete = { deleteTarget = it }
+    LaunchedEffect(viewModel, createOnLaunch, initialBoardSetId) {
+        viewModel.onAction(
+            BoardSetManagerAction.Initialize(
+                createOnLaunch = createOnLaunch,
+                initialBoardSetId = initialBoardSetId,
+            )
         )
-
-        is BoardSetRoute.Workspace -> BoardSetWorkspaceScreen(
-            boardSetId = currentRoute.boardSetId,
-            initialMode = currentRoute.mode,
-            onSwitchToKeyboard = onBack,
-            onExitToLibrary = {
-                route = BoardSetRoute.Library
-                refreshBoardSets()
+    }
+    LaunchedEffect(viewModel, onBack) {
+        viewModel.events.collect { event ->
+            when (event) {
+                BoardSetManagerEvent.NavigateBack -> onBack()
             }
+        }
+    }
+
+    when (val route = state.route) {
+        BoardSetManagerRoute.Library -> BoardSetManagerScreen(
+            state = state,
+            statusMessage = state.statusMessage?.resolve(),
+            importAvailable = boardImportService != null,
+            onAction = viewModel::onAction,
+        )
+        is BoardSetManagerRoute.Workspace -> BoardSetWorkspaceScreen(
+            boardSetId = route.boardSetId,
+            initialMode = route.mode,
+            onSwitchToKeyboard = { viewModel.onAction(BoardSetManagerAction.BackClicked) },
+            onExitToLibrary = { viewModel.onAction(BoardSetManagerAction.WorkspaceExited) },
         )
     }
 
-    if (showCreateDialog) {
+    if (state.showCreateDialog) {
         CreateBoardSetDialog(
-            onDismiss = { showCreateDialog = false },
-            onCreate = { name, rows, columns, template, keyboardPreset ->
-                showCreateDialog = false
-                isCreating = true
-                scope.launch {
-                    val quickCoreSlug = template.quickCoreSlug
-                    if (quickCoreSlug != null) {
-                        val service = quickCorePresetService
-                        if (service == null) {
-                            statusMessage = createError
-                            isCreating = false
-                            return@launch
-                        }
-                        isQuickCoreImporting = true
-                        when (val result = service.importPreset(quickCoreSlug)) {
-                            is BoardImportResult.Success -> {
-                                val created = useCase.renameBoardSet(result.boardSet.id, name.trim())
-                                    ?: result.boardSet
-                                showCreateDialog = false
-                                showCreatedBoardSet(created)
-                                route = BoardSetRoute.Workspace(created.id, BoardWorkspaceMode.Run)
-                            }
-                            is BoardImportResult.Failure -> statusMessage = result.context
-                            BoardImportResult.Cancelled -> Unit
-                        }
-                        isQuickCoreImporting = false
-                        isCreating = false
-                        return@launch
-                    }
-                    runCatching {
-                        when (template) {
-                            BoardSetTemplate.Blank -> useCase.createBoardSet(name.trim(), rows, columns, defaultBoardName)
-                            BoardSetTemplate.Calculator -> useCase.createCalculatorBoardSet(name.trim())
-                            BoardSetTemplate.Keyboard -> useCase.createKeyboardBoardSet(name.trim(), keyboardPreset)
-                            else -> error("Quick Core presets are imported separately")
-                        }
-                    }
-                        .onSuccess { created ->
-                            showCreatedBoardSet(created)
-                            when (template) {
-                                BoardSetTemplate.Blank -> {
-                                    route = BoardSetRoute.Workspace(created.id, BoardWorkspaceMode.Edit)
-                                }
-                                BoardSetTemplate.Calculator,
-                                BoardSetTemplate.Keyboard -> Unit
-                                else -> Unit
-                            }
-                        }
-                        .onFailure { statusMessage = it.message ?: createError }
-                    isCreating = false
-                }
+            draft = state.createDraft,
+            onDismiss = { viewModel.onAction(BoardSetManagerAction.CreateDismissed) },
+            onNameChange = { viewModel.onAction(BoardSetManagerAction.CreateNameChanged(it)) },
+            onRowsChange = { viewModel.onAction(BoardSetManagerAction.CreateRowsChanged(it)) },
+            onColumnsChange = { viewModel.onAction(BoardSetManagerAction.CreateColumnsChanged(it)) },
+            onTemplateSelected = { template, suggestedName ->
+                viewModel.onAction(BoardSetManagerAction.CreateTemplateSelected(template, suggestedName))
             },
-            quickCoreProgress = quickCoreProgress?.fraction?.toFloat(),
-            quickCoreStage = quickCoreProgress?.stage,
-            isQuickCoreImporting = isQuickCoreImporting,
+            onKeyboardPresetSelected = {
+                viewModel.onAction(BoardSetManagerAction.CreateKeyboardPresetSelected(it))
+            },
+            onCreate = {
+                val draft = state.createDraft
+                viewModel.onAction(
+                    BoardSetManagerAction.CreateSubmitted(
+                        name = draft.name,
+                        rows = draft.rowsText.toIntOrNull() ?: 4,
+                        columns = draft.columnsText.toIntOrNull() ?: 8,
+                        template = draft.template,
+                        keyboardPreset = draft.keyboardPreset,
+                        defaultBoardName = defaultBoardName,
+                    )
+                )
+            },
+            quickCoreProgress = state.quickCoreProgress?.fraction,
+            quickCoreStage = state.quickCoreProgress?.stage,
+            isQuickCoreImporting = state.isQuickCoreImporting,
         )
     }
 
-    deleteTarget?.let { boardSet ->
+    state.deleteTargetId?.let { targetId ->
+        val boardSet = state.boardSets.firstOrNull { it.id == targetId } ?: return@let
         AlertDialog(
-            onDismissRequest = { deleteTarget = null },
+            onDismissRequest = { viewModel.onAction(BoardSetManagerAction.DeleteDismissed) },
             title = { Text(stringResource(R.string.board_sets_delete_title)) },
             text = { Text(stringResource(R.string.board_sets_delete_body, boardSet.name)) },
             confirmButton = {
                 TextButton(
-                    onClick = {
-                        deleteTarget = null
-                        scope.launch {
-                            if (editingAccessController?.requiresUnlock() == true) {
-                                pendingProtectedDelete = boardSet
-                                showDeleteAccessDialog = true
-                            } else {
-                                deleteBoardSet(boardSet)
-                            }
-                        }
-                    }
+                    onClick = { viewModel.onAction(BoardSetManagerAction.DeleteConfirmed) }
                 ) { Text(stringResource(R.string.common_delete), color = MaterialTheme.colorScheme.error) }
             },
             dismissButton = {
-                TextButton(onClick = { deleteTarget = null }) { Text(stringResource(R.string.common_cancel)) }
+                TextButton(onClick = { viewModel.onAction(BoardSetManagerAction.DeleteDismissed) }) {
+                    Text(stringResource(R.string.common_cancel))
+                }
             }
         )
     }
 
-    if (showDeleteAccessDialog && editingAccessController != null) {
+    if (state.showDeleteAccessDialog && editingAccessController != null) {
         EditingAccessDialog(
             controller = editingAccessController,
             mode = EditingAccessDialogMode.Unlock,
-            onDismiss = {
-                showDeleteAccessDialog = false
-                pendingProtectedDelete = null
-            },
-            onSuccess = {
-                showDeleteAccessDialog = false
-                pendingProtectedDelete?.let(::deleteBoardSet)
-                pendingProtectedDelete = null
-            }
+            onDismiss = { viewModel.onAction(BoardSetManagerAction.DeleteAccessDismissed) },
+            onSuccess = { viewModel.onAction(BoardSetManagerAction.DeleteAccessGranted) },
         )
     }
 
-    if (showSettings) {
+    if (state.showSettings) {
         SettingsScreen(
-            onDismiss = { showSettings = false },
-            onBackToWelcome = onBackToWelcome
+            onDismiss = { viewModel.onAction(BoardSetManagerAction.SettingsDismissed) },
+            onBackToWelcome = {
+                viewModel.onAction(BoardSetManagerAction.SettingsDismissed)
+                onBackToWelcome()
+            },
         )
     }
-    if (showImportExport) {
-        SettingsExportDialog(onDismiss = { showImportExport = false })
+}
+
+@Composable
+private fun BoardSetManagerMessage.resolve(): String = when (this) {
+    is BoardSetManagerMessage.Dynamic -> value
+    is BoardSetManagerMessage.Resource -> stringResource(id)
+}
+
+@Composable
+internal fun BoardSetManagerScreen(
+    state: BoardSetManagerState,
+    statusMessage: String?,
+    importAvailable: Boolean,
+    onAction: (BoardSetManagerAction) -> Unit,
+) {
+    BoardSetLibraryScreen(
+        boardSets = state.boardSets,
+        isLoading = state.isLoading,
+        isCreating = state.isCreating,
+        statusMessage = statusMessage,
+        onBack = { onAction(BoardSetManagerAction.BackClicked) },
+        onOpenSettings = { onAction(BoardSetManagerAction.SettingsClicked) },
+        onCreate = { onAction(BoardSetManagerAction.CreateClicked) },
+        onImport = if (importAvailable) {
+            { onAction(BoardSetManagerAction.ImportClicked) }
+        } else {
+            null
+        },
+        onOpen = { onAction(BoardSetManagerAction.OpenClicked(it.id)) },
+        onEdit = { onAction(BoardSetManagerAction.EditClicked(it.id)) },
+        onDuplicate = { onAction(BoardSetManagerAction.DuplicateClicked(it.id)) },
+        onToggleLock = { onAction(BoardSetManagerAction.ToggleLockClicked(it.id)) },
+        onDelete = { onAction(BoardSetManagerAction.DeleteClicked(it.id)) },
+    )
+}
+
+@Preview(showBackground = true, widthDp = 1000, heightDp = 700)
+@Composable
+private fun BoardSetManagerScreenPreview() {
+    AppTheme {
+        BoardSetManagerScreen(
+            state = BoardSetManagerState(
+                boardSets = listOf(
+                    ObfBoardSet(
+                        id = "core-words",
+                        name = "Core words",
+                        rootBoardId = "home",
+                        boardIds = listOf("home", "people", "places"),
+                        createdAt = 1L,
+                        updatedAt = 2L,
+                    ),
+                    ObfBoardSet(
+                        id = "school",
+                        name = "School",
+                        rootBoardId = "classroom",
+                        boardIds = listOf("classroom", "subjects"),
+                        isLocked = true,
+                        createdAt = 1L,
+                        updatedAt = 2L,
+                    ),
+                ),
+                isLoading = false,
+            ),
+            statusMessage = null,
+            importAvailable = true,
+            onAction = {},
+        )
     }
 }
 

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardWorkspaceState.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardWorkspaceState.kt
@@ -1,0 +1,304 @@
+package io.github.jdreioe.wingmate.ui
+
+import androidx.compose.runtime.Stable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.github.jdreioe.wingmate.domain.obf.BoardSetGraph
+import io.github.jdreioe.wingmate.domain.obf.ObfButton
+import io.github.jdreioe.wingmate.domain.obf.withHomeFieldsBottomLeft
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * User-visible workspace state is independent from rendering, so navigation, communication,
+ * editing, and recovery transitions remain deterministic and survive configuration changes.
+ */
+@Stable
+internal data class BoardWorkspaceState(
+    val contentStatus: BoardWorkspaceContentStatus = BoardWorkspaceContentStatus.Loading,
+    val savedGraph: BoardSetGraph? = null,
+    val editSession: BoardSetEditSession? = null,
+    val mode: BoardWorkspaceMode = BoardWorkspaceMode.Run,
+    val selectedBoardId: String? = null,
+    val boardStack: List<String> = emptyList(),
+    val selectedButtons: List<ObfButton> = emptyList(),
+    val showFinishDialog: Boolean = false,
+    val showEditingAccessDialog: Boolean = false,
+    val isSaving: Boolean = false,
+    val isFullscreen: Boolean = false,
+    val isExporting: Boolean = false,
+    val statusMessage: String? = null,
+) {
+    val activeGraph: BoardSetGraph? get() = editSession?.draft ?: savedGraph
+    val canNavigateBack: Boolean get() = boardStack.isNotEmpty()
+
+    fun selectBoard(boardId: String): BoardWorkspaceState =
+        copy(selectedBoardId = boardId, boardStack = emptyList())
+
+    fun openBoard(boardId: String): BoardWorkspaceState =
+        copy(
+            selectedBoardId = boardId,
+            boardStack = selectedBoardId?.let { boardStack + it } ?: boardStack,
+        )
+
+    fun navigateBack(): BoardWorkspaceState =
+        boardStack.lastOrNull()?.let { previous ->
+            copy(selectedBoardId = previous, boardStack = boardStack.dropLast(1))
+        } ?: this
+
+    fun goHome(rootBoardId: String): BoardWorkspaceState =
+        copy(selectedBoardId = rootBoardId, boardStack = emptyList())
+
+    fun withPosition(
+        selectedBoardId: String?,
+        boardStack: List<String>,
+    ): BoardWorkspaceState = copy(
+        selectedBoardId = selectedBoardId,
+        boardStack = boardStack,
+    )
+}
+
+internal sealed interface BoardWorkspaceContentStatus {
+    data object Loading : BoardWorkspaceContentStatus
+    data object Empty : BoardWorkspaceContentStatus
+    data object Ready : BoardWorkspaceContentStatus
+    data class RecoverableFailure(val message: String) : BoardWorkspaceContentStatus
+}
+
+internal sealed interface BoardWorkspaceAction {
+    data class Initialize(val graph: BoardSetGraph?, val startInEditMode: Boolean) : BoardWorkspaceAction
+    data class LoadFailed(val message: String) : BoardWorkspaceAction
+    data class SelectBoard(val boardId: String) : BoardWorkspaceAction
+    data class OpenBoard(val boardId: String) : BoardWorkspaceAction
+    data object BackClicked : BoardWorkspaceAction
+    data class GoHome(val rootBoardId: String) : BoardWorkspaceAction
+    data class RestorePosition(
+        val selectedBoardId: String?,
+        val boardStack: List<String>,
+    ) : BoardWorkspaceAction
+    data class ReplaceSentence(val buttons: List<ObfButton>) : BoardWorkspaceAction
+    data object RemoveLastSentenceButton : BoardWorkspaceAction
+    data object ClearSentence : BoardWorkspaceAction
+    data object StartEditing : BoardWorkspaceAction
+    data object EditingAccessRequired : BoardWorkspaceAction
+    data object EditingAccessDismissed : BoardWorkspaceAction
+    data class ApplyEdit(val graph: BoardSetGraph) : BoardWorkspaceAction
+    data object UndoEdit : BoardWorkspaceAction
+    data object FinishEditingClicked : BoardWorkspaceAction
+    data object KeepEditing : BoardWorkspaceAction
+    data object DiscardEdits : BoardWorkspaceAction
+    data object SaveStarted : BoardWorkspaceAction
+    data class SaveSucceeded(val graph: BoardSetGraph) : BoardWorkspaceAction
+    data class SaveFailed(val message: String) : BoardWorkspaceAction
+    data class FullscreenChanged(val isFullscreen: Boolean) : BoardWorkspaceAction
+    data object ExportStarted : BoardWorkspaceAction
+    data class ExportFinished(val message: String) : BoardWorkspaceAction
+    data class StatusChanged(val message: String?) : BoardWorkspaceAction
+}
+
+internal sealed interface BoardWorkspaceEvent {
+    data object NavigateToLibrary : BoardWorkspaceEvent
+}
+
+/**
+ * Saves only the small transient values needed after process recreation. The graph remains in
+ * this ViewModel across configuration changes but is reloaded from the shared use case after
+ * process death, keeping persisted board content in one source of truth.
+ */
+internal class BoardWorkspaceViewModel(
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val _state = MutableStateFlow(
+        BoardWorkspaceState(
+            selectedBoardId = savedStateHandle[SELECTED_BOARD_ID],
+            boardStack = savedStateHandle.get<ArrayList<String>>(BOARD_STACK)?.toList().orEmpty(),
+            selectedButtons = savedStateHandle.get<String>(SENTENCE_BUTTONS)
+                ?.let { encoded -> runCatching { json.decodeFromString<List<ObfButton>>(encoded) }.getOrNull() }
+                .orEmpty(),
+        )
+    )
+    val state: StateFlow<BoardWorkspaceState> = _state.asStateFlow()
+    private val _events = Channel<BoardWorkspaceEvent>()
+    val events = _events.receiveAsFlow()
+
+    fun onAction(action: BoardWorkspaceAction) {
+        val updated = when (action) {
+            is BoardWorkspaceAction.Initialize -> {
+                val current = _state.value
+                if (current.savedGraph != null) {
+                    current
+                } else if (action.graph == null) {
+                    current.copy(contentStatus = BoardWorkspaceContentStatus.Empty)
+                } else {
+                    val graph = action.graph.withHomeFieldsBottomLeft()
+                    val availableBoardIds = graph.boardsById.keys
+                    val positioned = if (current.selectedBoardId !in availableBoardIds) {
+                        current.selectBoard(graph.boardSet.rootBoardId)
+                    } else {
+                        current.copy(boardStack = current.boardStack.filter { it in availableBoardIds })
+                    }
+                    positioned.copy(
+                        contentStatus = BoardWorkspaceContentStatus.Ready,
+                        savedGraph = graph,
+                        editSession = if (action.startInEditMode && !graph.boardSet.isLocked) {
+                            BoardSetEditSession(graph, graph)
+                        } else {
+                            null
+                        },
+                        mode = if (action.startInEditMode && !graph.boardSet.isLocked) {
+                            BoardWorkspaceMode.Edit
+                        } else {
+                            BoardWorkspaceMode.Run
+                        },
+                    )
+                }
+            }
+            is BoardWorkspaceAction.LoadFailed -> _state.value.copy(
+                contentStatus = BoardWorkspaceContentStatus.RecoverableFailure(action.message),
+                statusMessage = action.message,
+            )
+            is BoardWorkspaceAction.SelectBoard -> _state.value.selectBoard(action.boardId)
+            is BoardWorkspaceAction.OpenBoard -> _state.value.openBoard(action.boardId)
+            BoardWorkspaceAction.BackClicked -> handleBack()
+            is BoardWorkspaceAction.GoHome -> _state.value.goHome(action.rootBoardId)
+            is BoardWorkspaceAction.RestorePosition -> _state.value.withPosition(
+                selectedBoardId = action.selectedBoardId,
+                boardStack = action.boardStack,
+            )
+            is BoardWorkspaceAction.ReplaceSentence -> _state.value.copy(selectedButtons = action.buttons)
+            BoardWorkspaceAction.RemoveLastSentenceButton -> _state.value.copy(
+                selectedButtons = _state.value.selectedButtons.dropLast(1)
+            )
+            BoardWorkspaceAction.ClearSentence -> _state.value.copy(selectedButtons = emptyList())
+            BoardWorkspaceAction.StartEditing -> {
+                val graph = _state.value.savedGraph ?: return
+                _state.value.goHome(graph.boardSet.rootBoardId).copy(
+                    editSession = BoardSetEditSession(graph, graph),
+                    mode = BoardWorkspaceMode.Edit,
+                    selectedButtons = emptyList(),
+                    showEditingAccessDialog = false,
+                )
+            }
+            BoardWorkspaceAction.EditingAccessRequired -> _state.value.copy(
+                showEditingAccessDialog = true
+            )
+            BoardWorkspaceAction.EditingAccessDismissed -> _state.value.copy(
+                showEditingAccessDialog = false
+            )
+            is BoardWorkspaceAction.ApplyEdit -> {
+                val session = _state.value.editSession ?: return
+                _state.value.copy(editSession = session.apply(action.graph))
+            }
+            BoardWorkspaceAction.UndoEdit -> _state.value.copy(
+                editSession = _state.value.editSession?.undo()
+            )
+            BoardWorkspaceAction.FinishEditingClicked -> finishEditing()
+            BoardWorkspaceAction.KeepEditing -> _state.value.copy(showFinishDialog = false)
+            BoardWorkspaceAction.DiscardEdits -> {
+                val graph = _state.value.savedGraph ?: return
+                _state.value.goHome(graph.boardSet.rootBoardId).copy(
+                    editSession = null,
+                    mode = BoardWorkspaceMode.Run,
+                    showFinishDialog = false,
+                )
+            }
+            BoardWorkspaceAction.SaveStarted -> _state.value.copy(
+                showFinishDialog = false,
+                isSaving = true,
+            )
+            is BoardWorkspaceAction.SaveSucceeded -> _state.value.copy(
+                contentStatus = BoardWorkspaceContentStatus.Ready,
+                savedGraph = action.graph.withHomeFieldsBottomLeft(),
+                editSession = null,
+                mode = BoardWorkspaceMode.Run,
+                isSaving = false,
+                statusMessage = null,
+            )
+            is BoardWorkspaceAction.SaveFailed -> _state.value.copy(
+                contentStatus = BoardWorkspaceContentStatus.RecoverableFailure(action.message),
+                mode = BoardWorkspaceMode.Edit,
+                isSaving = false,
+                statusMessage = action.message,
+            )
+            is BoardWorkspaceAction.FullscreenChanged -> _state.value.copy(
+                isFullscreen = action.isFullscreen
+            )
+            BoardWorkspaceAction.ExportStarted -> _state.value.copy(
+                isExporting = true,
+                statusMessage = null,
+            )
+            is BoardWorkspaceAction.ExportFinished -> _state.value.copy(
+                isExporting = false,
+                statusMessage = action.message,
+            )
+            is BoardWorkspaceAction.StatusChanged -> _state.value.copy(
+                statusMessage = action.message
+            )
+        }
+        if (updated != _state.value) {
+            _state.update { updated }
+            savedStateHandle[SELECTED_BOARD_ID] = updated.selectedBoardId
+            savedStateHandle[BOARD_STACK] = ArrayList(updated.boardStack)
+            savedStateHandle[SENTENCE_BUTTONS] = updated.selectedButtons
+                .takeIf { it.isNotEmpty() }
+                ?.let(json::encodeToString)
+        }
+    }
+
+    private fun handleBack(): BoardWorkspaceState {
+        val current = _state.value
+        return when {
+            current.mode == BoardWorkspaceMode.Edit -> finishEditing()
+            current.canNavigateBack -> current.navigateBack()
+            else -> {
+                viewModelScope.launch { _events.send(BoardWorkspaceEvent.NavigateToLibrary) }
+                current
+            }
+        }
+    }
+
+    private fun finishEditing(): BoardWorkspaceState {
+        val current = _state.value
+        val session = current.editSession ?: return current
+        return if (session.isDirty) {
+            current.copy(showFinishDialog = true)
+        } else {
+            current.copy(editSession = null, mode = BoardWorkspaceMode.Run)
+        }
+    }
+
+    private companion object {
+        const val SELECTED_BOARD_ID = "board_workspace.selected_board_id"
+        const val BOARD_STACK = "board_workspace.board_stack"
+        const val SENTENCE_BUTTONS = "board_workspace.sentence_buttons"
+    }
+}
+
+/** Holds an editing draft and its undo history without any Compose or persistence dependency. */
+internal data class BoardSetEditSession(
+    val original: BoardSetGraph,
+    val draft: BoardSetGraph,
+    val undoStack: List<BoardSetGraph> = emptyList(),
+) {
+    val isDirty: Boolean get() = draft != original
+
+    fun apply(updated: BoardSetGraph): BoardSetEditSession {
+        val normalized = updated.withHomeFieldsBottomLeft()
+        if (normalized == draft) return this
+        return copy(draft = normalized, undoStack = undoStack + draft)
+    }
+
+    fun undo(): BoardSetEditSession {
+        val previous = undoStack.lastOrNull() ?: return this
+        return copy(draft = previous, undoStack = undoStack.dropLast(1))
+    }
+}

--- a/androidApp/src/test/java/io/github/jdreioe/wingmate/ui/BoardSetManagerViewModelTest.kt
+++ b/androidApp/src/test/java/io/github/jdreioe/wingmate/ui/BoardSetManagerViewModelTest.kt
@@ -1,0 +1,194 @@
+package io.github.jdreioe.wingmate.ui
+
+import androidx.lifecycle.SavedStateHandle
+import io.github.jdreioe.wingmate.application.KeyboardPreset
+import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
+import io.github.jdreioe.wingmate.infrastructure.BoardImportResult
+import io.github.jdreioe.wingmate.infrastructure.QuickCoreDownloadProgress
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BoardSetManagerViewModelTest {
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initialize loads board sets and workspace actions update the route`() = runTest {
+        val operations = FakeBoardSetManagerOperations().apply {
+            boardSets += boardSet("set-1", "Core words")
+        }
+        val viewModel = BoardSetManagerViewModel(SavedStateHandle(), operations)
+
+        viewModel.onAction(BoardSetManagerAction.Initialize(false, null))
+
+        assertFalse(viewModel.state.value.isLoading)
+        assertEquals(listOf("set-1"), viewModel.state.value.boardSets.map { it.id })
+        assertEquals(1, operations.cacheAllCalls)
+
+        viewModel.onAction(BoardSetManagerAction.EditClicked("set-1"))
+        assertEquals(
+            BoardSetManagerRoute.Workspace("set-1", BoardWorkspaceMode.Edit),
+            viewModel.state.value.route,
+        )
+
+        viewModel.onAction(BoardSetManagerAction.WorkspaceExited)
+        assertEquals(BoardSetManagerRoute.Library, viewModel.state.value.route)
+    }
+
+    @Test
+    fun `saved workspace route and dialogs are restored after recreation`() {
+        val savedState = SavedStateHandle()
+        val first = BoardSetManagerViewModel(savedState, FakeBoardSetManagerOperations())
+
+        first.onAction(BoardSetManagerAction.OpenClicked("set-7"))
+        first.onAction(BoardSetManagerAction.CreateClicked)
+        first.onAction(BoardSetManagerAction.CreateNameChanged("My board"))
+        first.onAction(BoardSetManagerAction.CreateRowsChanged("6"))
+        first.onAction(BoardSetManagerAction.SettingsClicked)
+
+        val restored = BoardSetManagerViewModel(savedState, FakeBoardSetManagerOperations())
+
+        assertEquals(
+            BoardSetManagerRoute.Workspace("set-7", BoardWorkspaceMode.Run),
+            restored.state.value.route,
+        )
+        assertTrue(restored.state.value.showCreateDialog)
+        assertEquals("My board", restored.state.value.createDraft.name)
+        assertEquals("6", restored.state.value.createDraft.rowsText)
+        assertTrue(restored.state.value.showSettings)
+    }
+
+    @Test
+    fun `protected deletion waits for access before deleting`() = runTest {
+        val operations = FakeBoardSetManagerOperations().apply {
+            boardSets += boardSet("set-1", "Core words")
+            deleteRequiresUnlock = true
+        }
+        val viewModel = BoardSetManagerViewModel(SavedStateHandle(), operations)
+        viewModel.onAction(BoardSetManagerAction.Initialize(false, null))
+
+        viewModel.onAction(BoardSetManagerAction.DeleteClicked("set-1"))
+        viewModel.onAction(BoardSetManagerAction.DeleteConfirmed)
+
+        assertTrue(viewModel.state.value.showDeleteAccessDialog)
+        assertEquals("set-1", viewModel.state.value.pendingProtectedDeleteId)
+        assertTrue(operations.deletedIds.isEmpty())
+
+        viewModel.onAction(BoardSetManagerAction.DeleteAccessGranted)
+
+        assertFalse(viewModel.state.value.showDeleteAccessDialog)
+        assertEquals(listOf("set-1"), operations.deletedIds)
+        assertTrue(viewModel.state.value.boardSets.isEmpty())
+    }
+
+    @Test
+    fun `creating a blank board set opens it in edit mode`() = runTest {
+        val operations = FakeBoardSetManagerOperations()
+        val viewModel = BoardSetManagerViewModel(SavedStateHandle(), operations)
+        viewModel.onAction(BoardSetManagerAction.Initialize(false, null))
+
+        viewModel.onAction(
+            BoardSetManagerAction.CreateSubmitted(
+                name = " My board ",
+                rows = 4,
+                columns = 8,
+                template = BoardSetTemplate.Blank,
+                keyboardPreset = KeyboardPreset.Qwerty,
+                defaultBoardName = "Home",
+            )
+        )
+
+        assertEquals("My board", operations.createdNames.single())
+        assertEquals(
+            BoardSetManagerRoute.Workspace("created-1", BoardWorkspaceMode.Edit),
+            viewModel.state.value.route,
+        )
+        assertFalse(viewModel.state.value.isCreating)
+    }
+
+    @Test
+    fun `back action resets the route and emits navigation once`() = runTest {
+        val viewModel = BoardSetManagerViewModel(SavedStateHandle(), FakeBoardSetManagerOperations())
+        viewModel.onAction(BoardSetManagerAction.OpenClicked("set-1"))
+        val event = async { viewModel.events.first() }
+
+        viewModel.onAction(BoardSetManagerAction.BackClicked)
+
+        assertEquals(BoardSetManagerRoute.Library, viewModel.state.value.route)
+        assertEquals(BoardSetManagerEvent.NavigateBack, event.await())
+    }
+
+    private fun boardSet(id: String, name: String) = ObfBoardSet(
+        id = id,
+        name = name,
+        rootBoardId = "$id-root",
+        boardIds = listOf("$id-root"),
+        createdAt = 1L,
+        updatedAt = 2L,
+    )
+
+    private inner class FakeBoardSetManagerOperations : BoardSetManagerOperations {
+        override val quickCoreProgress = MutableStateFlow(QuickCoreDownloadProgress())
+        val boardSets = mutableListOf<ObfBoardSet>()
+        val deletedIds = mutableListOf<String>()
+        val createdNames = mutableListOf<String>()
+        var deleteRequiresUnlock = false
+        var cacheAllCalls = 0
+
+        override suspend fun listBoardSets() = boardSets.toList()
+        override suspend fun getBoardSet(id: String) = boardSets.firstOrNull { it.id == id }
+        override suspend fun duplicateBoardSet(id: String) = Unit
+        override suspend fun toggleLocked(id: String) = Unit
+        override suspend fun deleteBoardSet(id: String) {
+            deletedIds += id
+            boardSets.removeAll { it.id == id }
+        }
+
+        override suspend fun cacheAll() {
+            cacheAllCalls++
+        }
+
+        override suspend fun cacheBoardSet(id: String) = Unit
+        override suspend fun requiresDeleteUnlock() = deleteRequiresUnlock
+        override suspend fun importBoardSet(): BoardImportResult = BoardImportResult.Cancelled
+        override suspend fun importQuickCore(slug: String): BoardImportResult = BoardImportResult.Cancelled
+        override suspend fun renameBoardSet(id: String, name: String) = null
+
+        override suspend fun createBoardSet(
+            name: String,
+            rows: Int,
+            columns: Int,
+            rootBoardName: String,
+        ): ObfBoardSet {
+            createdNames += name
+            return boardSet("created-1", name).also(boardSets::add)
+        }
+
+        override suspend fun createCalculatorBoardSet(name: String) = boardSet("calculator-1", name)
+        override suspend fun createKeyboardBoardSet(name: String, preset: KeyboardPreset) =
+            boardSet("keyboard-1", name)
+    }
+}

--- a/androidApp/src/test/java/io/github/jdreioe/wingmate/ui/BoardWorkspaceStateTest.kt
+++ b/androidApp/src/test/java/io/github/jdreioe/wingmate/ui/BoardWorkspaceStateTest.kt
@@ -1,0 +1,182 @@
+package io.github.jdreioe.wingmate.ui
+
+import androidx.lifecycle.SavedStateHandle
+import io.github.jdreioe.wingmate.domain.obf.BoardSetGraph
+import io.github.jdreioe.wingmate.domain.obf.ObfBoard
+import io.github.jdreioe.wingmate.domain.obf.ObfButton
+import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BoardWorkspaceStateTest {
+    @Test
+    fun `following a board link records the current board and back restores it`() {
+        val navigation = BoardWorkspaceState(selectedBoardId = "home")
+
+        val linked = navigation.openBoard("people")
+
+        assertEquals("people", linked.selectedBoardId)
+        assertEquals(listOf("home"), linked.boardStack)
+        assertTrue(linked.canNavigateBack)
+        assertEquals(navigation, linked.navigateBack())
+    }
+
+    @Test
+    fun `selecting a board or going home clears navigation history`() {
+        val navigation = BoardWorkspaceState(
+            selectedBoardId = "people",
+            boardStack = listOf("home"),
+        )
+
+        assertEquals(
+            BoardWorkspaceState(selectedBoardId = "places"),
+            navigation.selectBoard("places"),
+        )
+        assertEquals(
+            BoardWorkspaceState(selectedBoardId = "home"),
+            navigation.goHome("home"),
+        )
+    }
+
+    @Test
+    fun `workspace location is restored after recreation`() {
+        val savedState = SavedStateHandle()
+        val first = BoardWorkspaceViewModel(savedState)
+        first.onAction(
+            BoardWorkspaceAction.Initialize(
+                graph = graph(name = "Core words", boardIds = listOf("home", "people")),
+                startInEditMode = false,
+            )
+        )
+        first.onAction(BoardWorkspaceAction.OpenBoard("people"))
+
+        val restored = BoardWorkspaceViewModel(savedState)
+
+        assertEquals("people", restored.state.value.selectedBoardId)
+        assertEquals(listOf("home"), restored.state.value.boardStack)
+    }
+
+    @Test
+    fun `initialization falls back to the home board when restored board was removed`() {
+        val savedState = SavedStateHandle(
+            mapOf(
+                "board_workspace.selected_board_id" to "removed-board",
+                "board_workspace.board_stack" to arrayListOf("home", "removed-board"),
+            )
+        )
+        val viewModel = BoardWorkspaceViewModel(savedState)
+
+        viewModel.onAction(
+            BoardWorkspaceAction.Initialize(
+                graph = graph(name = "Core words", boardIds = listOf("home", "people")),
+                startInEditMode = false,
+            )
+        )
+
+        assertEquals("home", viewModel.state.value.selectedBoardId)
+        assertTrue(viewModel.state.value.boardStack.isEmpty())
+    }
+
+    @Test
+    fun `composed message survives recreation and can be edited afterwards`() {
+        val savedState = SavedStateHandle()
+        val first = BoardWorkspaceViewModel(savedState)
+        first.onAction(
+            BoardWorkspaceAction.ReplaceSentence(
+                listOf(
+                    ObfButton(id = "hello", label = "Hello", vocalization = "Hello"),
+                    ObfButton(id = "world", label = "world", vocalization = "world"),
+                )
+            )
+        )
+
+        val restored = BoardWorkspaceViewModel(savedState)
+        restored.onAction(BoardWorkspaceAction.RemoveLastSentenceButton)
+
+        assertEquals(listOf("Hello"), restored.state.value.selectedButtons.map { it.vocalization })
+    }
+
+    @Test
+    fun `edit session only records meaningful changes and undo restores the draft`() {
+        val original = graph(name = "Core words")
+        val session = BoardSetEditSession(original, original)
+
+        assertEquals(session, session.apply(original))
+
+        val changed = original.copy(boardSet = original.boardSet.copy(name = "My words"))
+        val edited = session.apply(changed)
+
+        assertTrue(edited.isDirty)
+        assertEquals(listOf(original), edited.undoStack)
+        assertEquals(original, edited.undo().draft)
+        assertFalse(edited.undo().isDirty)
+    }
+
+    @Test
+    fun `failed save keeps communication and edited draft visible`() {
+        val original = graph(name = "Core words")
+        val edited = original.copy(boardSet = original.boardSet.copy(name = "My words"))
+        val viewModel = BoardWorkspaceViewModel(SavedStateHandle())
+        val sentence = ObfButton(id = "hello", label = "Hello", vocalization = "Hello")
+        viewModel.onAction(BoardWorkspaceAction.Initialize(original, startInEditMode = true))
+        viewModel.onAction(BoardWorkspaceAction.ReplaceSentence(listOf(sentence)))
+        viewModel.onAction(BoardWorkspaceAction.ApplyEdit(edited))
+        viewModel.onAction(BoardWorkspaceAction.SaveStarted)
+
+        viewModel.onAction(BoardWorkspaceAction.SaveFailed("Could not save"))
+
+        assertEquals(BoardWorkspaceMode.Edit, viewModel.state.value.mode)
+        assertEquals(edited, viewModel.state.value.activeGraph)
+        assertEquals(listOf(sentence), viewModel.state.value.selectedButtons)
+        assertEquals(
+            BoardWorkspaceContentStatus.RecoverableFailure("Could not save"),
+            viewModel.state.value.contentStatus,
+        )
+    }
+
+    @Test
+    fun `dirty edit asks for confirmation and undo restores original graph`() {
+        val original = graph(name = "Core words")
+        val viewModel = BoardWorkspaceViewModel(SavedStateHandle())
+        viewModel.onAction(BoardWorkspaceAction.Initialize(original, startInEditMode = true))
+        viewModel.onAction(
+            BoardWorkspaceAction.ApplyEdit(
+                original.copy(boardSet = original.boardSet.copy(name = "My words"))
+            )
+        )
+
+        viewModel.onAction(BoardWorkspaceAction.FinishEditingClicked)
+        assertTrue(viewModel.state.value.showFinishDialog)
+
+        viewModel.onAction(BoardWorkspaceAction.KeepEditing)
+        viewModel.onAction(BoardWorkspaceAction.UndoEdit)
+        assertEquals(original, viewModel.state.value.activeGraph)
+        assertFalse(viewModel.state.value.editSession?.isDirty ?: true)
+    }
+
+    private fun graph(
+        name: String,
+        boardIds: List<String> = listOf("home"),
+    ): BoardSetGraph {
+        val boards = boardIds.map { boardId ->
+            ObfBoard(
+                format = "open-board-0.1",
+                id = boardId,
+                name = boardId.replaceFirstChar(Char::uppercase),
+            )
+        }
+        return BoardSetGraph(
+            boardSet = ObfBoardSet(
+                id = "core",
+                name = name,
+                rootBoardId = boards.first().id,
+                boardIds = boards.map(ObfBoard::id),
+                createdAt = 1L,
+                updatedAt = 1L,
+            ),
+            boards = boards,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Add ViewModel-driven state management for board-set library and workspace presentation.
- Persist workspace routes, dialog drafts, settings, and delete state across process recreation.
- Refactor board-set creation, import, deletion, locking, duplication, and workspace navigation actions.
- Add Compose UI and ViewModel coverage for board-set management and workspace content.

## Testing

- Not run.
- Added unit tests for `BoardSetManagerViewModel` and `BoardWorkspaceState`.
- Added Compose tests for board-set manager interaction and workspace content states.