### PR TITLE
Centralize Ktor and serialization dependency versions

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -210,8 +210,8 @@ dependencies {
     implementation(libs.koin.compose)
 
     // Ktor engine for ARM API calls
-    implementation("io.ktor:ktor-client-okhttp:2.3.12")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.kotlinx.serialization.json)
 
     // Dual-screen / WindowManager (API 34+ rear display & window area APIs)
     implementation(libs.androidx.window)

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -25,10 +25,10 @@ kotlin {
                 implementation(libs.koin.core)
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-                implementation("io.ktor:ktor-client-core:2.3.12")
-                implementation("io.ktor:ktor-client-content-negotiation:2.3.12")
-                implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.12")
+                implementation(libs.kotlinx.serialization.json)
+                implementation(libs.ktor.client.core)
+                implementation(libs.ktor.client.contentNegotiation)
+                implementation(libs.ktor.serialization.json)
                 implementation("io.github.oshai:kotlin-logging:7.0.0")
                 implementation("io.github.pdvrieze.xmlutil:core:0.91.3")
                 implementation(libs.okio)
@@ -39,7 +39,7 @@ kotlin {
 
         val androidMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-okhttp:2.3.12")
+                implementation(libs.ktor.client.okhttp)
                 implementation("androidx.core:core-ktx:1.13.1")
                 implementation("app.cash.sqldelight:android-driver:2.0.2")
                 implementation("org.apache.commons:commons-compress:1.27.1")
@@ -49,7 +49,7 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))
-                implementation("io.ktor:ktor-client-mock:2.3.12")
+                implementation(libs.ktor.client.mock)
             }
         }
 
@@ -57,14 +57,14 @@ kotlin {
 
         val iosMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-darwin:2.3.12")
+                implementation(libs.ktor.client.darwin)
                 implementation("app.cash.sqldelight:native-driver:2.0.2")
             }
         }
 
         val jvmMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-okhttp:2.3.12")
+                implementation(libs.ktor.client.okhttp)
                 implementation("app.cash.sqldelight:sqlite-driver:2.0.2")
                 implementation("org.apache.commons:commons-compress:1.27.1")
             }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -21,7 +21,7 @@ kotlin {
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+                implementation(libs.kotlinx.serialization.json)
             }
         }
         val commonTest by getting {

--- a/feature/communication/data/build.gradle.kts
+++ b/feature/communication/data/build.gradle.kts
@@ -25,17 +25,17 @@ kotlin {
                 implementation(project(":feature:communication:domain"))
                 implementation(libs.koin.core)
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-                implementation("io.ktor:ktor-client-core:2.3.12")
-                implementation("io.ktor:ktor-client-content-negotiation:2.3.12")
-                implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.12")
+                implementation(libs.kotlinx.serialization.json)
+                implementation(libs.ktor.client.core)
+                implementation(libs.ktor.client.contentNegotiation)
+                implementation(libs.ktor.serialization.json)
                 implementation("io.github.oshai:kotlin-logging:7.0.0")
             }
         }
 
         val androidMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-okhttp:2.3.12")
+                implementation(libs.ktor.client.okhttp)
             }
         }
 
@@ -43,13 +43,13 @@ kotlin {
 
         val iosMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-darwin:2.3.12")
+                implementation(libs.ktor.client.darwin)
             }
         }
 
         val jvmMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-okhttp:2.3.12")
+                implementation(libs.ktor.client.okhttp)
             }
         }
     }

--- a/feature/communication/domain/build.gradle.kts
+++ b/feature/communication/domain/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
             dependencies {
                 implementation(project(":core:domain"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+                implementation(libs.kotlinx.serialization.json)
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,8 +63,14 @@ sqldelight-native = { module = "app.cash.sqldelight:native-driver", version.ref 
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 ktor-client-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
+ktor-server-contentNegotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-cors = { module = "io.ktor:ktor-server-cors", version.ref = "ktor" }
 
 # Kotlinx
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }

--- a/linuxApp/build.gradle.kts
+++ b/linuxApp/build.gradle.kts
@@ -10,23 +10,23 @@ kotlin {
 dependencies {
     implementation(project(":shared"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    implementation(libs.kotlinx.serialization.json)
     implementation("com.github.hypfvieh:dbus-java-core:5.2.0")
     implementation("com.github.hypfvieh:dbus-java-transport-native-unixsocket:5.2.0")
     implementation("com.arkivanov.mvikotlin:mvikotlin:3.3.0")
     implementation("com.arkivanov.mvikotlin:mvikotlin-main:3.3.0")
     
     // Ktor server for the native UI bridge
-    implementation("io.ktor:ktor-server-core:2.3.12")
-    implementation("io.ktor:ktor-server-netty:2.3.12")
-    implementation("io.ktor:ktor-server-content-negotiation:2.3.12")
-    implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.12")
-    implementation("io.ktor:ktor-server-cors:2.3.12")
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.netty)
+    implementation(libs.ktor.server.contentNegotiation)
+    implementation(libs.ktor.serialization.json)
+    implementation(libs.ktor.server.cors)
     
     // Ktor Client for Azure TTS
-    implementation("io.ktor:ktor-client-core:2.3.12")
-    implementation("io.ktor:ktor-client-okhttp:2.3.12")
-    implementation("io.ktor:ktor-client-content-negotiation:2.3.12")
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.client.contentNegotiation)
     
     // USB4Java for Partner Window (FTDI FT232H / EVE display)
     implementation("org.usb4java:usb4java:1.3.0")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -48,12 +48,12 @@ kotlin {
                 api(project(":feature:communication:data"))
                 api(project(":feature:communication:presentation"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+                implementation(libs.kotlinx.serialization.json)
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.0")
                 api(libs.koin.core)
-                implementation("io.ktor:ktor-client-core:2.3.12")
-                implementation("io.ktor:ktor-client-content-negotiation:2.3.12")
-                implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.12")
+                implementation(libs.ktor.client.core)
+                implementation(libs.ktor.client.contentNegotiation)
+                implementation(libs.ktor.serialization.json)
                 // Add logging for Kotlin Multiplatform
                 implementation("io.github.oshai:kotlin-logging:7.0.0")
                 implementation(libs.okio)
@@ -77,7 +77,7 @@ kotlin {
         val androidMain by getting {
             dependencies {
                 implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.4")
-                implementation("io.ktor:ktor-client-okhttp:2.3.12")
+                implementation(libs.ktor.client.okhttp)
                 implementation(
                     "com.github.aptabase:aptabase-kotlin:${libs.versions.aptabase.get()}"
                 ) {
@@ -99,7 +99,7 @@ kotlin {
         applyDefaultHierarchyTemplate()
         val iosMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-darwin:2.3.12")
+                implementation(libs.ktor.client.darwin)
                 // Ensure Koin is resolved for iOS binaries too
                 api(libs.koin.core)
                 // Compose Multiplatform for iOS UI
@@ -112,7 +112,7 @@ kotlin {
         }
         val jvmMain by getting {
             dependencies {
-                implementation("io.ktor:ktor-client-okhttp:2.3.12")
+                implementation(libs.ktor.client.okhttp)
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.9.0")
                 // Compose Multiplatform for desktop JVM UI
                 implementation(compose.runtime)


### PR DESCRIPTION
## Summary

- Add shared version-catalog aliases for Ktor client/server modules and Kotlin serialization.
- Replace hard-coded dependency coordinates across Android, Linux, shared, core, and communication modules.

## Testing

- Not run

Closes #165