### PR TITLE
#162: Make operational logging privacy-safe across platforms

### DIFF
--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/MainActivity.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/MainActivity.kt
@@ -21,10 +21,11 @@ import androidx.window.area.WindowAreaInfo
 import androidx.window.area.WindowAreaCapability
 import androidx.window.area.WindowAreaSessionCallback
 import kotlinx.coroutines.launch
-import android.util.Log
 import android.view.KeyEvent
 import java.util.concurrent.Executor
 import io.github.jdreioe.wingmate.display.ExternalDisplayPresentation
+import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Box
@@ -105,7 +106,11 @@ class MainActivity : ComponentActivity() {
             try {
                 windowAreaController = WindowAreaController.getOrCreate()
             } catch (e: Throwable) {
-                Log.w("MainActivity", "WindowAreaController not compatible on this device, skipping rear display support", e)
+                OperationalLogger.warn(
+                    operation = "rear_display.controller",
+                    outcome = "unsupported",
+                    exceptionClass = e.loggingClassName(),
+                )
             }
             
             if (::windowAreaController.isInitialized) {
@@ -119,11 +124,15 @@ class MainActivity : ComponentActivity() {
                                 .distinctUntilChanged()
                                 .collect {
                                     capabilityStatus = it
-                                    Log.d("MainActivity", "Rear display capability status: $it")
+                                    OperationalLogger.debug("rear_display.capability", "changed")
                                 }
                         }
                     } catch (e: Throwable) {
-                        Log.w("MainActivity", "WindowAreaController error during observation, skipping rear display", e)
+                        OperationalLogger.warn(
+                            operation = "rear_display.capability_observation",
+                            outcome = "failed",
+                            exceptionClass = e.loggingClassName(),
+                        )
                     }
                 }
             }
@@ -235,12 +244,17 @@ class MainActivity : ComponentActivity() {
         val dm = getSystemService(DISPLAY_SERVICE) as? DisplayManager ?: return
         val externalDisplays = dm.getDisplays(DisplayManager.DISPLAY_CATEGORY_PRESENTATION)
         
-        Log.d("MainActivity", "Display check: external=${externalDisplays.size}, foldable=$isFoldableUnfolded")
+        OperationalLogger.debug(
+            operation = "display.check",
+            outcome = "completed",
+            count = externalDisplays.size,
+            enabled = isFoldableUnfolded,
+        )
         
         // Auto-open only for external displays or foldable unfolded
         
         if (externalDisplays.isNotEmpty()) {
-            Log.d("MainActivity", "Auto-opening fullscreen display")
+            OperationalLogger.info("display.fullscreen", "auto_opened")
             io.github.jdreioe.wingmate.presentation.DisplayWindowBus.open()
         }
     }
@@ -280,17 +294,21 @@ class MainActivity : ComponentActivity() {
                 windowAreaSessionCallback = object : WindowAreaSessionCallback {
                     override fun onSessionStarted(session: WindowAreaSession) {
                         windowAreaSession = session
-                        Log.d("MainActivity", "Rear display session started - content mirrored to rear")
+                        OperationalLogger.info("rear_display.session", "started")
                     }
                     
                     override fun onSessionEnded(t: Throwable?) {
                         windowAreaSession = null
-                        Log.d("MainActivity", "Rear display session ended: ${t?.message}")
+                        OperationalLogger.info(
+                            operation = "rear_display.session",
+                            outcome = "ended",
+                            exceptionClass = t?.loggingClassName(),
+                        )
                     }
                 }
             )
         } else {
-            Log.d("MainActivity", "Rear display not available, status: $capabilityStatus")
+            OperationalLogger.debug("rear_display.session", "unavailable")
         }
     }
     

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/AzureSettingsDialog.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/AzureSettingsDialog.kt
@@ -6,9 +6,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.domain.ConfigRepository
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.TtsEngine
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.github.jdreioe.wingmate.application.FeatureUsageEvents
 import io.github.jdreioe.wingmate.application.FeatureUsageReporter
 import io.github.jdreioe.wingmate.application.reportEvent
@@ -32,9 +34,8 @@ fun AzureSettingsDialog(show: Boolean, onDismiss: () -> Unit, onSaved: (() -> Un
     val settingsStateManager = remember(koin) { koin.getOrNull<SettingsStateManager>() }
     val featureUsageReporter = remember(koin) { koin.getOrNull<FeatureUsageReporter>() }
 
-    // Log which ConfigRepository implementation we got (helps diagnose persistence)
     LaunchedEffect(configRepo) {
-        println("ConfigRepository implementation: ${configRepo?.javaClass?.name ?: "<none>"}")
+        OperationalLogger.debug("speech_config.repository", "resolved", enabled = configRepo != null)
     }
 
     if (configRepo == null) {
@@ -75,7 +76,7 @@ fun AzureSettingsDialog(show: Boolean, onDismiss: () -> Unit, onSaved: (() -> Un
     LaunchedEffect(Unit) {
         // load existing config
         val cfg = withContext(Dispatchers.Default) { configRepo.getSpeechConfigStatus() }
-        println("Loaded Azure config; credentialConfigured=${cfg.credentialConfigured}")
+        OperationalLogger.debug("speech_config.load", "succeeded", enabled = cfg.credentialConfigured)
         endpoint = cfg.endpoint
         credentialConfigured = cfg.credentialConfigured
         
@@ -370,12 +371,16 @@ fun AzureSettingsDialog(show: Boolean, onDismiss: () -> Unit, onSaved: (() -> Un
                             (!credentialConfigured || replacingCredentials) &&
                             endpoint.isNotBlank() && subscriptionKey.isNotBlank()
                         ) {
-                            println("Saving speech config: endpoint='$endpoint'")
+                            OperationalLogger.info("speech_config.save", "started")
                             try {
                                 configRepo.saveSpeechConfig(SpeechServiceConfig(endpoint = endpoint, subscriptionKey = subscriptionKey))
-                                println("Successfully saved speech config")
+                                OperationalLogger.info("speech_config.save", "succeeded")
                             } catch (t: Throwable) {
-                                println("Failed to save speech config: $t")
+                                OperationalLogger.warn(
+                                    operation = "speech_config.save",
+                                    outcome = "failed",
+                                    exceptionClass = t.loggingClassName(),
+                                )
                                 throw t
                             }
                         }

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/AzureSettingsFullScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/AzureSettingsFullScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.domain.ConfigRepository
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.TtsEngine
@@ -39,7 +40,7 @@ fun AzureSettingsFullScreen(
 
     LaunchedEffect(configRepo, settingsUseCase) {
         val cfg = withContext(Dispatchers.Default) { configRepo.getSpeechConfigStatus() }
-        println("Loaded Azure config; credentialConfigured=${cfg.credentialConfigured}")
+        OperationalLogger.debug("speech_config.load", "succeeded", enabled = cfg.credentialConfigured)
         endpoint = cfg.endpoint
         credentialConfigured = cfg.credentialConfigured
 

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/TestVoiceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/TestVoiceScreen.kt
@@ -11,7 +11,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.domain.SpeechService
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.Voice
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.github.jdreioe.wingmate.application.VoiceUseCase
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.Dispatchers
@@ -39,7 +41,7 @@ fun TestVoiceScreen(onNext: () -> Unit, onBack: () -> Unit) {
                 voiceUseCase.selected()
             }
         } catch (e: Exception) {
-            println("Failed to load selected voice (${e::class.simpleName})")
+            OperationalLogger.warn("voice_selection.load", "failed", exceptionClass = e.loggingClassName())
         } finally {
             loading = false
         }
@@ -116,7 +118,7 @@ fun TestVoiceScreen(onNext: () -> Unit, onBack: () -> Unit) {
                             try {
                                     speechService.stop()
                             } catch (e: Exception) {
-                                println("Failed to stop speech (${e::class.simpleName})")
+                                OperationalLogger.warn("speech.stop", "failed", exceptionClass = e.loggingClassName())
                             } finally {
                                 isPlaying = false
                             }
@@ -135,7 +137,7 @@ fun TestVoiceScreen(onNext: () -> Unit, onBack: () -> Unit) {
                                     )
                                 }
                             } catch (e: Exception) {
-                                println("Failed to speak (${e::class.simpleName})")
+                                OperationalLogger.warn("speech.test", "failed", exceptionClass = e.loggingClassName())
                             } finally {
                                 isPlaying = false
                             }
@@ -190,7 +192,7 @@ fun TestVoiceScreen(onNext: () -> Unit, onBack: () -> Unit) {
                             try {
                                     speechService.stop()
                             } catch (e: Exception) {
-                                println("Failed to stop speech (${e::class.simpleName})")
+                                OperationalLogger.warn("speech.stop", "failed", exceptionClass = e.loggingClassName())
                             }
                             onBack()
                         }
@@ -207,7 +209,7 @@ fun TestVoiceScreen(onNext: () -> Unit, onBack: () -> Unit) {
                             try {
                                     speechService.stop()
                             } catch (e: Exception) {
-                                println("Failed to stop speech (${e::class.simpleName})")
+                                OperationalLogger.warn("speech.stop", "failed", exceptionClass = e.loggingClassName())
                             }
                             onNext()
                         }

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/UiLanguageDialog.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/UiLanguageDialog.kt
@@ -13,6 +13,8 @@ import io.github.jdreioe.wingmate.application.reportEvent
 import io.github.jdreioe.wingmate.application.SettingsUseCase
 import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.domain.Settings
+import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import kotlinx.coroutines.launch
 import androidx.compose.ui.res.stringResource
 import org.koin.compose.koinInject
@@ -177,7 +179,7 @@ fun UiLanguageDialog(
                                 val current = runCatching { settingsUseCase.get() }.getOrNull() ?: Settings()
                                 val updated = current.copy(primaryLanguage = sel)
                                 settingsUseCase.update(updated)
-                                println("Saved primaryLanguage='$sel'")
+                                OperationalLogger.info("primary_language.save", "succeeded")
                                 featureUsageReporter.reportEvent(
                                     FeatureUsageEvents.LANGUAGE_UPDATED,
                                     "target" to "primary",
@@ -189,16 +191,16 @@ fun UiLanguageDialog(
                                     if (vuse != null) {
                                         val updatedVoice = vuse.copy(selectedLanguage = sel)
                                         runCatching { voiceUseCase.select(updatedVoice) }.onSuccess {
-                                            println("Updated selected voice '${vuse.name}' selectedLanguage='$sel'")
+                                            OperationalLogger.info("voice_language.save", "succeeded")
                                         }.onFailure { t ->
-                                            println("Failed to persist selected voice language: $t")
+                                            OperationalLogger.warn("voice_language.save", "failed", exceptionClass = t.loggingClassName())
                                         }
                                     }
                                 } catch (t: Throwable) {
-                                    println("Error while updating selected voice language: $t")
+                                    OperationalLogger.warn("voice_language.update", "failed", exceptionClass = t.loggingClassName())
                                 }
                             } catch (t: Throwable) {
-                                println("Failed saving primary language: $t")
+                                OperationalLogger.warn("primary_language.save", "failed", exceptionClass = t.loggingClassName())
                             }
                         }
                     }
@@ -270,13 +272,13 @@ fun UiLanguageDialog(
                             if (vuse != null) {
                                 val updatedVoice = vuse.copy(selectedLanguage = primary)
                                 runCatching { voiceUseCase.select(updatedVoice) }.onSuccess {
-                                    println("Updated selected voice '${vuse.name}' selectedLanguage='$primary'")
+                                    OperationalLogger.info("voice_language.save", "succeeded")
                                 }.onFailure { t ->
-                                    println("Failed to update selected voice language: $t")
+                                    OperationalLogger.warn("voice_language.save", "failed", exceptionClass = t.loggingClassName())
                                 }
                             }
                         } catch (t: Throwable) {
-                            println("Error while updating selected voice language: $t")
+                            OperationalLogger.warn("voice_language.update", "failed", exceptionClass = t.loggingClassName())
                         }
                     } catch (_: Throwable) {
                         // ignore

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/VoiceSelectionFullScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/VoiceSelectionFullScreen.kt
@@ -19,7 +19,9 @@ import androidx.compose.ui.unit.dp
 import io.github.jdreioe.wingmate.application.VoiceUseCase
 import io.github.jdreioe.wingmate.application.SettingsUseCase
 import io.github.jdreioe.wingmate.domain.Voice
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.TtsEngine
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.launch
@@ -66,14 +68,14 @@ fun VoiceSelectionFullScreen(onNext: () -> Unit, onCancel: () -> Unit, onBackToW
             val fromCloud = try {
                 withContext(Dispatchers.IO) { useCase.refreshFromAzure() }
             } catch (e: Exception) {
-                println("Failed to refresh from Azure: $e")
+                OperationalLogger.warn("voice_catalog.refresh", "failed", exceptionClass = e.loggingClassName())
                 emptyList()
             }
             
             val local = try {
                 withContext(Dispatchers.IO) { useCase.list() }
             } catch (e: Exception) {
-                println("Failed to load local voices: $e")
+                OperationalLogger.warn("voice_catalog.load", "failed", exceptionClass = e.loggingClassName())
                 emptyList()
             }
             
@@ -88,13 +90,13 @@ fun VoiceSelectionFullScreen(onNext: () -> Unit, onCancel: () -> Unit, onBackToW
             val alreadySelected = try {
                 withContext(Dispatchers.IO) { useCase.selected() }
             } catch (e: Exception) {
-                println("Failed to load selected voice: $e")
+                OperationalLogger.warn("voice_selection.load", "failed", exceptionClass = e.loggingClassName())
                 null
             }
             selected = alreadySelected
         } catch (t: Throwable) {
             error = "Failed to load voices: ${t.message}"
-            println("Voice loading error: $t")
+            OperationalLogger.warn("voice_catalog.load", "failed", exceptionClass = t.loggingClassName())
         } finally {
             loading = false
         }
@@ -389,10 +391,14 @@ fun VoiceSelectionFullScreen(onNext: () -> Unit, onCancel: () -> Unit, onBackToW
                                                 voice
                                             }
                                             withContext(Dispatchers.IO) { useCase.select(voiceToSelect) }
-                                            println("Selected voice: ${voice.name} with language: ${voiceToSelect.selectedLanguage}")
+                                            OperationalLogger.info("voice_selection.save", "succeeded")
                                             selected = voiceToSelect
                                         } catch (t: Throwable) {
-                                            println("Failed to select voice: ${voice.name}: $t")
+                                            OperationalLogger.warn(
+                                                operation = "voice_selection.save",
+                                                outcome = "failed",
+                                                exceptionClass = t.loggingClassName(),
+                                            )
                                         }
                                     }
                                 }

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -29,7 +29,6 @@ kotlin {
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.client.contentNegotiation)
                 implementation(libs.ktor.serialization.json)
-                implementation("io.github.oshai:kotlin-logging:7.0.0")
                 implementation("io.github.pdvrieze.xmlutil:core:0.91.3")
                 implementation(libs.okio)
                 implementation("app.cash.sqldelight:runtime:2.0.2")

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidImageCacher.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidImageCacher.kt
@@ -1,6 +1,8 @@
 package io.github.jdreioe.wingmate.infrastructure
 
 import android.content.Context
+import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.github.jdreioe.wingmate.infrastructure.ImageCacher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -41,7 +43,7 @@ class AndroidImageCacher(private val context: Context) : ImageCacher {
             cacheFile.writeBytes(bytes)
             "file://${cacheFile.absolutePath}"
         } catch (e: Exception) {
-            e.printStackTrace()
+            OperationalLogger.warn("image_cache.download", "failed", exceptionClass = e.loggingClassName())
             url 
         }
     }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSpeechService.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSpeechService.kt
@@ -19,10 +19,12 @@ import android.os.Handler
 import android.os.Looper
 import android.widget.Toast
 import io.github.jdreioe.wingmate.domain.SpeechService
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.SpeechSegment
 import io.github.jdreioe.wingmate.domain.SpeechTextProcessor
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.github.jdreioe.wingmate.infrastructure.AzureTtsClient
 import io.ktor.client.*
 import io.ktor.client.request.*
@@ -513,7 +515,11 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                 recordHistory(combinedText, vForSsml, outFile.absolutePath.takeIf { cacheAudio })
                 startPlayback(outFile, vForSsml, deleteAfterPlayback = !cacheAudio)
             } catch (t: Throwable) {
-                println("Azure TTS failed (${t::class.simpleName}), falling back to platform TTS")
+                OperationalLogger.warn(
+                    operation = "speech.azure_synthesis",
+                    outcome = "platform_fallback",
+                    exceptionClass = t.loggingClassName(),
+                )
                 // Fallback to platform TTS on error
                 recordHistory(combinedText, voice)
                 speakWithPlatformTts(combinedText, voice, pitch, rate)
@@ -824,7 +830,11 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                     )
                 )
             }.onFailure { t ->
-                println("DEBUG: Failed to record history (${t::class.simpleName})")
+                OperationalLogger.warn(
+                    operation = "speech_history.record",
+                    outcome = "failed",
+                    exceptionClass = t.loggingClassName(),
+                )
             }
         }
     }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlCategoryRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlCategoryRepository.kt
@@ -4,6 +4,7 @@ import android.content.ContentValues
 import android.content.Context
 import io.github.jdreioe.wingmate.domain.CategoryItem
 import io.github.jdreioe.wingmate.domain.CategoryRepository
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.UUID
@@ -23,7 +24,7 @@ class AndroidSqlCategoryRepository(private val context: Context) : CategoryRepos
             list += CategoryItem(id = id, name = name, selectedLanguage = selectedLanguage)
         }
         cursor.close()
-        println("Loaded {} categories from SQLite: ${list.size}")
+        OperationalLogger.debug("category.load", "succeeded", count = list.size)
         return@withContext list
     }
 

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlConfigRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlConfigRepository.kt
@@ -5,6 +5,7 @@ import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
 import io.github.jdreioe.wingmate.domain.ConfigRepository
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -36,19 +37,19 @@ class AndroidSqlConfigRepository(private val context: Context) : ConfigRepositor
         writeSecure(config)
         check(readSecure() == config) { "Secure Azure credential write could not be verified" }
         deleteLegacyPlaintext()
-        println("Saved Azure speech configuration securely; credentialConfigured=true")
+        OperationalLogger.info("speech_config.save", "succeeded", enabled = true)
     }
 
     override suspend fun clearSpeechConfig() = withContext(Dispatchers.IO) {
         check(prefs.edit().remove(ENCRYPTED_CONFIG).commit()) { "Could not clear secure Azure configuration" }
         deleteLegacyPlaintext()
-        println("Cleared Azure speech configuration; credentialConfigured=false")
+        OperationalLogger.info("speech_config.clear", "succeeded", enabled = false)
     }
 
     private fun migrateLegacy(): SpeechServiceConfig? {
         val legacy = readLegacySqlite() ?: readLegacyPreferences() ?: return null
         migrateLegacySpeechConfig(legacy, ::writeSecure, ::readSecure, ::deleteLegacyPlaintext)
-        println("Migrated Azure speech configuration to Android Keystore")
+        OperationalLogger.info("speech_config.migrate", "succeeded")
         return legacy
     }
 
@@ -67,7 +68,7 @@ class AndroidSqlConfigRepository(private val context: Context) : ConfigRepositor
     private fun decodeLegacy(value: String): SpeechServiceConfig? = runCatching {
         json.decodeFromString(SpeechServiceConfig.serializer(), value)
     }.onFailure {
-        println("Could not decode legacy Azure configuration; credential contents redacted")
+        OperationalLogger.warn("speech_config.legacy_decode", "failed")
     }.getOrNull()
 
     private fun deleteLegacyPlaintext() {
@@ -93,7 +94,7 @@ class AndroidSqlConfigRepository(private val context: Context) : ConfigRepositor
             val plaintext = cipher.doFinal(bytes.copyOfRange(IV_SIZE, bytes.size)).decodeToString()
             json.decodeFromString(SpeechServiceConfig.serializer(), plaintext)
         }.onFailure {
-            println("Could not read secure Azure configuration; credential contents redacted")
+            OperationalLogger.warn("speech_config.secure_read", "failed")
         }.getOrThrow()
     }
 

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlPhraseRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlPhraseRepository.kt
@@ -4,6 +4,7 @@ import android.content.ContentValues
 import android.content.Context
 import io.github.jdreioe.wingmate.domain.Phrase
 import io.github.jdreioe.wingmate.domain.PhraseRepository
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.UUID
@@ -44,7 +45,7 @@ class AndroidSqlPhraseRepository(private val context: Context) : PhraseRepositor
             )
         }
         cursor.close()
-        println("Loaded {} phrases from SQLite: ${list.size}")
+        OperationalLogger.debug("phrase.load", "succeeded", count = list.size)
         return@withContext list
     }
 

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidVoiceRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidVoiceRepository.kt
@@ -1,8 +1,10 @@
 package io.github.jdreioe.wingmate.infrastructure
 
 import android.content.Context
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.domain.VoiceRepository
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
@@ -21,7 +23,7 @@ class AndroidVoiceRepository(private val context: Context) : VoiceRepository {
                 json.decodeFromString(ListSerializer(Voice.serializer()), text)
             }
         } catch (t: Throwable) {
-            println("Failed to load voice catalog from SharedPreferences: $t")
+            OperationalLogger.warn("voice_catalog.load", "failed", exceptionClass = t.loggingClassName())
             emptyList()
         }
     }
@@ -30,37 +32,35 @@ class AndroidVoiceRepository(private val context: Context) : VoiceRepository {
         try {
             val text = json.encodeToString(ListSerializer(Voice.serializer()), list)
             prefs.edit().putString("voice_catalog", text).apply()
-            println("Saved voice catalog to SharedPreferences: ${list.size} voices")
+            OperationalLogger.debug("voice_catalog.save", "succeeded", count = list.size)
         } catch (t: Throwable) {
-            println("Failed to save voice catalog to SharedPreferences: $t")
+            OperationalLogger.warn("voice_catalog.save", "failed", exceptionClass = t.loggingClassName())
         }
     }
 
     override suspend fun saveSelected(voice: Voice) = withContext(Dispatchers.IO) {
-        // Removed SLF4J logger for cross-platform compatibility
         try {
             val text = json.encodeToString(Voice.serializer(), voice)
             prefs.edit().putString("selected_voice", text).apply()
-            println("Saved selected voice to SharedPreferences: {}: ${voice.name}")
+            OperationalLogger.debug("voice_selection.save", "succeeded")
         } catch (t: Throwable) {
-            println("Failed to save selected voice to SharedPreferences: ${t}")
+            OperationalLogger.warn("voice_selection.save", "failed", exceptionClass = t.loggingClassName())
             throw t
         }
     }
 
     override suspend fun getSelected(): Voice? = withContext(Dispatchers.IO) {
-        // Removed SLF4J logger for cross-platform compatibility
         val text = prefs.getString("selected_voice", null)
         if (text.isNullOrBlank()) {
-            println("No selected voice found in SharedPreferences")
+            OperationalLogger.debug("voice_selection.load", "not_found")
             return@withContext null
         }
         return@withContext try {
             val v = json.decodeFromString(Voice.serializer(), text)
-            println("Loaded selected voice from SharedPreferences: {}: ${v.name}")
+            OperationalLogger.debug("voice_selection.load", "succeeded")
             v
         } catch (t: Throwable) {
-            println("Failed to decode selected voice from SharedPreferences: ${t}")
+            OperationalLogger.warn("voice_selection.load", "failed", exceptionClass = t.loggingClassName())
             null
         }
     }

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AutoF0FlowUseCase.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AutoF0FlowUseCase.kt
@@ -5,9 +5,11 @@ import io.github.jdreioe.wingmate.domain.AzureF0Resource
 import io.github.jdreioe.wingmate.domain.AzureSignInResult
 import io.github.jdreioe.wingmate.domain.AzureSubscription
 import io.github.jdreioe.wingmate.domain.ConfigRepository
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.SettingsRepository
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.TtsEngine
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
@@ -28,7 +30,7 @@ class AutoF0FlowUseCase(
             } else {
                 "Sign-in was cancelled"
             }
-            println("AutoF0Flow: Sign-in failed: $msg")
+            OperationalLogger.warn("azure_f0.sign_in", "failed")
             return AutoF0FlowResult.SignInFailed(msg)
         }
 
@@ -165,7 +167,11 @@ class AutoF0FlowUseCase(
         return try {
             provisioner.getAccessToken()
         } catch (e: Exception) {
-            println("AutoF0Flow: Failed to get access token: ${e.message}")
+            OperationalLogger.warn(
+                operation = "azure_f0.access_token",
+                outcome = "failed",
+                exceptionClass = e.loggingClassName(),
+            )
             null
         }
     }

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureTtsClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureTtsClient.kt
@@ -4,16 +4,16 @@ import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.SpeechSegment
 import io.github.jdreioe.wingmate.domain.SpeechTextProcessor
+import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
-import io.github.oshai.kotlinlogging.KotlinLogging
 import nl.adaptivity.xmlutil.EventType
 import nl.adaptivity.xmlutil.xmlStreaming
 
-private val logger = KotlinLogging.logger {}
 /**
  * Enhanced shared Azure TTS client with improved audio quality and error handling.
  * Accepts SSML and returns audio bytes (mp3) from Azure.
@@ -48,9 +48,7 @@ object AzureTtsClient {
         }
         val url = "$baseUrl/cognitiveservices/v1"
 
-        // Enhanced logging with request details
-        logger.info { "Azure TTS request -> url=$url (endpoint=${config.endpoint}, format=${audioFormat.value})" }
-        logger.debug { "SSML length=${ssml.length} chars" }
+        OperationalLogger.info("azure_tts.synthesize", "started")
 
         try {
             val response: HttpResponse = client.post(url) {
@@ -65,12 +63,12 @@ object AzureTtsClient {
                 setBody(ssml)
             }
 
-            logger.info { "Azure TTS response status=${response.status}" }
+            OperationalLogger.info("azure_tts.synthesize", "response_received", statusCode = response.status.value)
             
             when {
                 response.status.isSuccess() -> {
                     val bytes = response.body<ByteArray>()
-                    logger.info { "Azure TTS returned ${bytes.size} bytes (${bytes.size / 1024}KB)" }
+                    OperationalLogger.info("azure_tts.synthesize", "succeeded", count = bytes.size)
                     
                     if (bytes.isEmpty()) {
                         throw RuntimeException("Azure TTS returned empty audio data")
@@ -79,23 +77,23 @@ object AzureTtsClient {
                     return bytes
                 }
                 response.status.value == 401 -> {
-                    logger.error { "Azure TTS authentication failed: ${response.status}" }
+                    OperationalLogger.warn("azure_tts.synthesize", "authentication_failed", statusCode = 401)
                     throw RuntimeException("Azure TTS authentication failed. Please check your subscription key.")
                 }
                 response.status.value == 429 -> {
-                    logger.error { "Azure TTS rate limit exceeded: ${response.status}" }
+                    OperationalLogger.warn("azure_tts.synthesize", "rate_limited", statusCode = 429)
                     throw RuntimeException("Azure TTS rate limit exceeded. Please try again later.")
                 }
                 response.status.value in 400..499 -> {
-                    logger.error { "Azure TTS client error: ${response.status}" }
+                    OperationalLogger.error("azure_tts.synthesize", "client_error", statusCode = response.status.value)
                     throw RuntimeException("Azure TTS request error: ${response.status.description}")
                 }
                 response.status.value in 500..599 -> {
-                    logger.error { "Azure TTS server error: ${response.status}" }
+                    OperationalLogger.error("azure_tts.synthesize", "server_error", statusCode = response.status.value)
                     throw RuntimeException("Azure TTS server error: ${response.status.description}")
                 }
                 else -> {
-                    logger.error { "Azure TTS failed: ${response.status}" }
+                    OperationalLogger.error("azure_tts.synthesize", "failed", statusCode = response.status.value)
                     throw RuntimeException("Azure TTS failed: ${response.status.description}")
                 }
             }
@@ -103,7 +101,11 @@ object AzureTtsClient {
             when (e) {
                 is RuntimeException -> throw e
                 else -> {
-                    logger.error(e) { "Azure TTS network error" }
+                    OperationalLogger.error(
+                        operation = "azure_tts.synthesize",
+                        outcome = "network_failed",
+                        exceptionClass = e.loggingClassName(),
+                    )
                     throw RuntimeException("Azure TTS network error: ${e.message}", e)
                 }
             }
@@ -270,7 +272,6 @@ object AzureTtsClient {
                 ?: "en-US"
         val pitch = voice.pitchForSSML ?: voice.pitch?.let(::convertPitchToSSML) ?: "medium"
         val rate = voice.rateForSSML ?: voice.rate?.let(::convertRateToSSML) ?: "medium"
-        logger.debug { "resolveVoiceParams: voiceName=${voice.name} baseLang=$baseLang pitch=$pitch rate=$rate" }
         return VoiceParams(voiceName, baseLang, pitch, rate)
     }
 
@@ -568,8 +569,7 @@ object AzureTtsClient {
     ): ByteArray {
         val url = "https://$region.tts.speech.microsoft.com/cognitiveservices/v1"
         
-        logger.info { "Azure TTS (token auth) -> url=$url, format=${audioFormat.value}" }
-        logger.debug { "SSML length=${ssml.length} chars" }
+        OperationalLogger.info("azure_tts.token_synthesize", "started")
         
         try {
             val response: HttpResponse = client.post(url) {
@@ -584,12 +584,12 @@ object AzureTtsClient {
                 setBody(ssml)
             }
             
-            logger.info { "Azure TTS (token auth) response status=${response.status}" }
+            OperationalLogger.info("azure_tts.token_synthesize", "response_received", statusCode = response.status.value)
             
             when {
                 response.status.isSuccess() -> {
                     val bytes = response.body<ByteArray>()
-                    logger.info { "Azure TTS returned ${bytes.size} bytes (${bytes.size / 1024}KB)" }
+                    OperationalLogger.info("azure_tts.token_synthesize", "succeeded", count = bytes.size)
                     
                     if (bytes.isEmpty()) {
                         throw RuntimeException("Azure TTS returned empty audio data")
@@ -597,15 +597,19 @@ object AzureTtsClient {
                     return bytes
                 }
                 response.status.value == 401 -> {
-                    logger.error { "Azure TTS token expired or invalid" }
+                    OperationalLogger.warn("azure_tts.token_synthesize", "authentication_failed", statusCode = 401)
                     throw TokenExpiredException("Azure TTS token expired or invalid")
                 }
                 response.status.value == 429 -> {
-                    logger.error { "Azure TTS rate limit exceeded" }
+                    OperationalLogger.warn("azure_tts.token_synthesize", "rate_limited", statusCode = 429)
                     throw RuntimeException("Azure TTS rate limit exceeded. Please try again later.")
                 }
                 else -> {
-                    logger.error { "Azure TTS failed: ${response.status}" }
+                    OperationalLogger.error(
+                        operation = "azure_tts.token_synthesize",
+                        outcome = "failed",
+                        statusCode = response.status.value,
+                    )
                     throw RuntimeException("Azure TTS failed: ${response.status}")
                 }
             }
@@ -614,7 +618,11 @@ object AzureTtsClient {
         } catch (e: RuntimeException) {
             throw e
         } catch (e: Exception) {
-            logger.error(e) { "Azure TTS network error" }
+            OperationalLogger.error(
+                operation = "azure_tts.token_synthesize",
+                outcome = "network_failed",
+                exceptionClass = e.loggingClassName(),
+            )
             throw RuntimeException("Azure TTS network error", e)
         }
     }
@@ -634,7 +642,7 @@ object AzureTtsClient {
         }
         val url = "$baseUrl/cognitiveservices/voices/list"
         
-        logger.info { "Fetching Azure voices from $url" }
+        OperationalLogger.info("azure_voice_catalog.fetch", "started")
         
         try {
             val response: HttpResponse = client.get(url) {
@@ -647,14 +655,22 @@ object AzureTtsClient {
             
             if (response.status.isSuccess()) {
                 val azureVoices = response.body<List<AzureVoiceDto>>()
-                logger.info { "Fetched ${azureVoices.size} voices from Azure" }
+                OperationalLogger.info("azure_voice_catalog.fetch", "succeeded", count = azureVoices.size)
                 return azureVoices.map { it.toDomain() }
             } else {
-                logger.error { "Failed to fetch voices: ${response.status}" }
+                OperationalLogger.error(
+                    operation = "azure_voice_catalog.fetch",
+                    outcome = "failed",
+                    statusCode = response.status.value,
+                )
                 throw RuntimeException("Failed to fetch voices: ${response.status}")
             }
         } catch (e: Exception) {
-            logger.error(e) { "Error fetching voices" }
+            OperationalLogger.error(
+                operation = "azure_voice_catalog.fetch",
+                outcome = "failed",
+                exceptionClass = e.loggingClassName(),
+            )
             throw e
         }
     }

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/DictionaryLoader.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/DictionaryLoader.kt
@@ -1,5 +1,6 @@
 package io.github.jdreioe.wingmate.infrastructure
 
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -37,7 +38,7 @@ class DictionaryLoader(private val fileStorage: io.github.jdreioe.wingmate.domai
         
         // Return from memory cache if available
         cache[cacheKey]?.let { 
-            println("DEBUG: Dictionary for $languageCode (file=$baseName) found in memory cache")
+            OperationalLogger.debug("dictionary.load", "memory_cache_hit")
             return it 
         }
         
@@ -48,11 +49,11 @@ class DictionaryLoader(private val fileStorage: io.github.jdreioe.wingmate.domai
                 val fileName = "$baseName.combined"
                 val cachedContent = fileStorage.load(fileName)
                 if (cachedContent != null && cachedContent.isNotBlank()) {
-                    println("DEBUG: Dictionary for $languageCode loaded from disk cache ($fileName)")
                     val words = withContext(Dispatchers.Default) {
                         parseDictionary(cachedContent)
                     }
                     if (words.isNotEmpty()) {
+                        OperationalLogger.debug("dictionary.load", "disk_cache_hit", count = words.size)
                         cache[cacheKey] = words
                         return@withContext words
                     }
@@ -61,8 +62,8 @@ class DictionaryLoader(private val fileStorage: io.github.jdreioe.wingmate.domai
             
             val url = "$BASE_URL/$baseName.combined"
             
-            println("DEBUG: Fetching dictionary from $url")
-            
+            OperationalLogger.debug("dictionary.load", "network_started")
+
             try {
                 val response = httpClient.get(url)
                 if (response.status.value !in 200..299) throw DictionaryLoadException()
@@ -74,7 +75,7 @@ class DictionaryLoader(private val fileStorage: io.github.jdreioe.wingmate.domai
                 }
                 if (words.isEmpty()) throw DictionaryLoadException()
                 
-                println("DEBUG: Loaded ${words.size} words for language $languageCode ($baseName)")
+                OperationalLogger.info("dictionary.load", "network_succeeded", count = words.size)
                 
                 // Cache the result
                 if (words.isNotEmpty()) {
@@ -84,7 +85,7 @@ class DictionaryLoader(private val fileStorage: io.github.jdreioe.wingmate.domai
                     if (fileStorage != null) {
                         val fileName = "$baseName.combined"
                         fileStorage.save(fileName, responseText)
-                        println("DEBUG: Saved dictionary for $languageCode to disk as $fileName")
+                        OperationalLogger.debug("dictionary.cache", "write_succeeded", count = words.size)
                     }
                 }
                 words

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/RealAacLogger.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/RealAacLogger.kt
@@ -1,7 +1,9 @@
 package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.AacLogger
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.SettingsRepository
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -72,7 +74,11 @@ class RealAacLogger(
                 sink.writeUtf8(json + "\n")
                 sink.close()
             }.onFailure { e ->
-                println("Failed to log OBL event: ${e.message}")
+                OperationalLogger.warn(
+                    operation = "usage_log.write",
+                    outcome = "failed",
+                    exceptionClass = e.loggingClassName(),
+                )
             }
         }
     }

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/SecureAzureSpeechService.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/SecureAzureSpeechService.kt
@@ -2,14 +2,11 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.*
 import io.ktor.client.*
-import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.time.Clock
 
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import kotlinx.serialization.json.*
-
-private val logger = KotlinLogging.logger {}
 
 /**
  * Secure Azure Speech Service using Token Exchange.
@@ -59,7 +56,11 @@ class SecureAzureSpeechService(
                 voiceName = effectiveVoice.name
             ))
         } catch (e: Exception) {
-            logger.error(e) { "Secure TTS failed, attempting fallback" }
+            OperationalLogger.warn(
+                operation = "speech.secure_synthesis",
+                outcome = "platform_fallback",
+                exceptionClass = e.loggingClassName(),
+            )
             
             // Fall back to system TTS if available
             systemTtsFallback?.speak(text, effectiveVoice, pitch, rate)
@@ -84,7 +85,11 @@ class SecureAzureSpeechService(
         try {
             speakSegmentsWithToken(segments, effectiveVoice)
         } catch (e: Exception) {
-            logger.error(e) { "Secure TTS segments failed, attempting fallback" }
+            OperationalLogger.warn(
+                operation = "speech.secure_segment_synthesis",
+                outcome = "platform_fallback",
+                exceptionClass = e.loggingClassName(),
+            )
             
             // Fall back to speaking combined text
             val combinedText = segments.joinToString(" ") { it.text }
@@ -114,7 +119,7 @@ class SecureAzureSpeechService(
                     
                 } catch (e: TokenExpiredException) {
                     // Token expired mid-request, invalidate and retry once
-                    logger.warn { "Token expired, refreshing and retrying" }
+                    OperationalLogger.warn("speech_token.refresh", "retrying")
                     tokenExchangeClient.invalidateToken()
                     
                     val newTokenResult = tokenExchangeClient.getToken()
@@ -184,7 +189,7 @@ class SecureAzureSpeechService(
     private suspend fun playAudio(audioBytes: ByteArray) {
         // Default implementation logs a warning
         // Platform implementations should override this
-        logger.warn { "playAudio not implemented - ${audioBytes.size} bytes received" }
+        OperationalLogger.warn("speech_audio.play", "not_implemented", count = audioBytes.size)
     }
     
     override suspend fun pause() {
@@ -243,7 +248,7 @@ class SecureAzureSpeechService(
             }
             lookup(langCode, requireLanguageTag = false) ?: if (langCode != "en") lookup("en", requireLanguageTag = true) else null
         } catch (e: Exception) {
-            logger.warn { "Failed to guess pronunciation" }
+            OperationalLogger.warn("pronunciation.lookup", "failed")
             null
         }
     }

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/SimpleNGramPredictionService.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/SimpleNGramPredictionService.kt
@@ -1,6 +1,6 @@
 package io.github.jdreioe.wingmate.infrastructure
 
-import io.github.oshai.kotlinlogging.KotlinLogging
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.PredictionResult
 import io.github.jdreioe.wingmate.domain.SaidText
 import io.github.jdreioe.wingmate.domain.TextPredictionService
@@ -17,7 +17,6 @@ import kotlinx.coroutines.withContext
  * the most frequently seen spelling for display.
  */
 class SimpleNGramPredictionService : TextPredictionService {
-    private val log = KotlinLogging.logger("SimpleNGramPredictionService")
     private val mutex = Mutex()
 
     private companion object {
@@ -117,10 +116,7 @@ class SimpleNGramPredictionService : TextPredictionService {
             .take(TOP_WORD_CACHE_LIMIT)
             .toList()
         trained = true
-        log.debug {
-            "Training complete. vocab=${wordFrequency.size}, prefixes=${wordsByPrefix.size}, " +
-                "bigrams=${bigramCounts.size}, trigrams=${trigramCounts.size}"
-        }
+        OperationalLogger.debug("prediction_model.train", "succeeded", count = wordFrequency.size)
     }
 
     private fun trainOnText(text: String, weight: Int) {

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/TokenExchangeClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/TokenExchangeClient.kt
@@ -6,10 +6,9 @@ import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
 import kotlinx.serialization.Serializable
-import io.github.oshai.kotlinlogging.KotlinLogging
+import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import kotlin.time.Clock
-
-private val logger = KotlinLogging.logger {}
 
 /**
  * Token Exchange Client for secure Azure TTS authentication.
@@ -42,13 +41,13 @@ class TokenExchangeClient(
             cachedRegion?.let { region ->
                 if (tokenExpiry > now + 60_000) {
                     val remainingSeconds = (tokenExpiry - now) / 1000
-                    logger.debug { "Using cached token, expires in ${remainingSeconds}s" }
+                    OperationalLogger.debug("speech_token.acquire", "cache_hit")
                     return TokenResult.Success(token, region, remainingSeconds)
                 }
             }
         }
         
-        logger.info { "Fetching new token from exchange service" }
+        OperationalLogger.info("speech_token.exchange", "started")
         
         return try {
             val response = httpClient.post(tokenExchangeUrl) {
@@ -65,24 +64,32 @@ class TokenExchangeClient(
                     cachedRegion = body.region
                     tokenExpiry = now + (body.expiresIn * 1000)
                     
-                    logger.info { "Token exchange successful, expires in ${body.expiresIn}s" }
+                    OperationalLogger.info("speech_token.exchange", "succeeded")
                     TokenResult.Success(body.token, body.region, body.expiresIn)
                 }
                 response.status.value == 401 -> {
-                    logger.error { "Token exchange unauthorized - check CLIENT_API_KEY" }
+                    OperationalLogger.warn("speech_token.exchange", "unauthorized", statusCode = 401)
                     TokenResult.Unauthorized
                 }
                 response.status.value == 429 -> {
-                    logger.error { "Token exchange rate limited" }
+                    OperationalLogger.warn("speech_token.exchange", "rate_limited", statusCode = 429)
                     TokenResult.RateLimited
                 }
                 else -> {
-                    logger.error { "Token exchange failed: ${response.status}" }
+                    OperationalLogger.error(
+                        operation = "speech_token.exchange",
+                        outcome = "failed",
+                        statusCode = response.status.value,
+                    )
                     TokenResult.Error("Token exchange failed: ${response.status}")
                 }
             }
         } catch (e: Exception) {
-            logger.error(e) { "Token exchange network error" }
+            OperationalLogger.error(
+                operation = "speech_token.exchange",
+                outcome = "network_failed",
+                exceptionClass = e.loggingClassName(),
+            )
             TokenResult.Error(e.message ?: "Network error during token exchange")
         }
     }
@@ -92,7 +99,7 @@ class TokenExchangeClient(
      * Call this if you receive a 401 from Azure TTS.
      */
     fun invalidateToken() {
-        logger.info { "Invalidating cached token" }
+        OperationalLogger.info("speech_token.cache", "invalidated")
         cachedToken = null
         cachedRegion = null
         tokenExpiry = 0

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosConfigRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosConfigRepository.kt
@@ -1,6 +1,7 @@
 package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.ConfigRepository
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
@@ -59,14 +60,14 @@ class IosConfigRepository : ConfigRepository {
         val legacy = runCatching {
             json.decodeFromString(SpeechServiceConfig.serializer(), legacyText)
         }.getOrElse {
-            println("Could not decode legacy Azure configuration; credential contents redacted")
+            OperationalLogger.warn("speech_config.legacy_decode", "failed")
             return@withContext null
         }
         migrateLegacySpeechConfig(legacy, ::writeKeychain, ::readKeychain) {
             defaults.removeObjectForKey(LEGACY_KEY)
             defaults.synchronize()
         }
-        println("Migrated Azure speech configuration to iOS Keychain")
+        OperationalLogger.info("speech_config.migrate", "succeeded")
         legacy
     }
 
@@ -76,14 +77,14 @@ class IosConfigRepository : ConfigRepository {
         check(readKeychain() == config) { "Secure Azure credential write could not be verified" }
         defaults.removeObjectForKey(LEGACY_KEY)
         defaults.synchronize()
-        println("Saved Azure speech configuration securely; credentialConfigured=true")
+        OperationalLogger.info("speech_config.save", "succeeded", enabled = true)
     }
 
     override suspend fun clearSpeechConfig() = withContext(Dispatchers.Default) {
         deleteKeychain()
         defaults.removeObjectForKey(LEGACY_KEY)
         defaults.synchronize()
-        println("Cleared Azure speech configuration; credentialConfigured=false")
+        OperationalLogger.info("speech_config.clear", "succeeded", enabled = false)
     }
 
     private fun readKeychain(): SpeechServiceConfig? = memScoped {

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPronunciationDictionaryRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPronunciationDictionaryRepository.kt
@@ -2,14 +2,13 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.PronunciationDictionaryRepository
 import io.github.jdreioe.wingmate.domain.PronunciationEntry
-import io.github.oshai.kotlinlogging.KotlinLogging
+import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import platform.Foundation.NSUserDefaults
-
-private val logger = KotlinLogging.logger {}
 
 class IosPronunciationDictionaryRepository : PronunciationDictionaryRepository {
     private val defaults by lazy { NSUserDefaults.standardUserDefaults() }
@@ -49,7 +48,11 @@ class IosPronunciationDictionaryRepository : PronunciationDictionaryRepository {
         return try {
             json.decodeFromString(ListSerializer(PronunciationEntry.serializer()), text)
         } catch (t: Throwable) {
-            logger.warn(t) { "Failed to decode PronunciationEntry list" }
+            OperationalLogger.warn(
+                operation = "pronunciation_dictionary.load",
+                outcome = "failed",
+                exceptionClass = t.loggingClassName(),
+            )
             emptyList()
         }
     }
@@ -60,7 +63,11 @@ class IosPronunciationDictionaryRepository : PronunciationDictionaryRepository {
             defaults.setObject(text, storageKey)
             // defaults.synchronize() is deprecated and often unnecessary, but can call if needed
         } catch (t: Throwable) {
-            logger.warn(t) { "Failed to save PronunciationEntry list" }
+            OperationalLogger.warn(
+                operation = "pronunciation_dictionary.save",
+                outcome = "failed",
+                exceptionClass = t.loggingClassName(),
+            )
         }
     }
 }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSaidTextRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSaidTextRepository.kt
@@ -2,15 +2,14 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.SaidText
 import io.github.jdreioe.wingmate.domain.SaidTextRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.datetime.Clock
 import platform.Foundation.NSUserDefaults
-
-private val saidLogger = KotlinLogging.logger {}
 
 class IosSaidTextRepository : SaidTextRepository {
     private val defaults by lazy { NSUserDefaults.standardUserDefaults() }
@@ -29,7 +28,7 @@ class IosSaidTextRepository : SaidTextRepository {
         )
         existing.add(enriched)
         saveAll(existing)
-        saidLogger.debug { "Saved SaidText item id=${enriched.id} voice=${enriched.voiceName} lang=${enriched.primaryLanguage}" }
+        OperationalLogger.debug("speech_history.save", "succeeded", count = existing.size)
         enriched
     }
 
@@ -48,7 +47,11 @@ class IosSaidTextRepository : SaidTextRepository {
         return try {
             json.decodeFromString(ListSerializer(SaidText.serializer()), text)
         } catch (t: Throwable) {
-            saidLogger.warn(t) { "Failed to decode SaidText list; returning empty" }
+            OperationalLogger.warn(
+                operation = "speech_history.load",
+                outcome = "failed",
+                exceptionClass = t.loggingClassName(),
+            )
             emptyList()
         }
     }
@@ -59,7 +62,11 @@ class IosSaidTextRepository : SaidTextRepository {
             defaults.setObject(text, storageKey)
             defaults.synchronize()
         } catch (t: Throwable) {
-            saidLogger.warn(t) { "Failed to save SaidText list" }
+            OperationalLogger.warn(
+                operation = "speech_history.save",
+                outcome = "failed",
+                exceptionClass = t.loggingClassName(),
+            )
         }
     }
 }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSpeechService.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSpeechService.kt
@@ -11,7 +11,8 @@ import io.github.jdreioe.wingmate.domain.SettingsRepository
 import io.github.jdreioe.wingmate.domain.TtsEngine
 import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.domain.VoiceRepository
-import io.github.oshai.kotlinlogging.KotlinLogging
+import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
@@ -32,8 +33,6 @@ import platform.Foundation.NSData
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
 import platform.Foundation.create
-
-private val logger = KotlinLogging.logger {}
 
 @OptIn(ExperimentalForeignApi::class)
 class IosSpeechService(
@@ -128,7 +127,7 @@ class IosSpeechService(
             }
             true
         }.onFailure {
-            logger.warn { "Failed to play recorded audio file" }
+            OperationalLogger.warn("speech_recording.play", "failed")
         }.getOrDefault(false)
     }
 
@@ -180,7 +179,7 @@ class IosSpeechService(
             }
             lookup(langCode, requireLanguageTag = false) ?: if (langCode != "en") lookup("en", requireLanguageTag = true) else null
         } catch (e: Exception) {
-            logger.warn { "Failed to guess pronunciation" }
+            OperationalLogger.warn("pronunciation.lookup", "failed")
             null
         }
     }
@@ -208,7 +207,7 @@ class IosSpeechService(
             audioPlayer.prepareToPlay()
             audioPlayer.play()
         }.onFailure { t ->
-            logger.warn { "Failed to play recorded audio" }
+            OperationalLogger.warn("speech_recording.play", "failed")
         }
     }
 
@@ -224,7 +223,11 @@ class IosSpeechService(
             audioPlayer.prepareToPlay()
             audioPlayer.play()
         }.onFailure { t ->
-            logger.warn(t) { "Failed to play synthesized Azure audio" }
+            OperationalLogger.warn(
+                operation = "speech_audio.play",
+                outcome = "failed",
+                exceptionClass = t.loggingClassName(),
+            )
         }
     }
 

--- a/core/data/src/jvmMain/kotlin/io/github/jdreioe/wingmate/infrastructure/ImageCacheService.kt
+++ b/core/data/src/jvmMain/kotlin/io/github/jdreioe/wingmate/infrastructure/ImageCacheService.kt
@@ -1,4 +1,6 @@
 package io.github.jdreioe.wingmate.infrastructure
+import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -39,7 +41,7 @@ object ImageCacheService {
             cacheFile.writeBytes(bytes)
             "file://${cacheFile.absolutePath}"
         } catch (e: Exception) {
-            e.printStackTrace()
+            OperationalLogger.warn("image_cache.download", "failed", exceptionClass = e.loggingClassName())
             url // Fallback to original URL on failure
         }
     }

--- a/core/data/src/jvmMain/kotlin/io/github/jdreioe/wingmate/infrastructure/JvmImageCacher.kt
+++ b/core/data/src/jvmMain/kotlin/io/github/jdreioe/wingmate/infrastructure/JvmImageCacher.kt
@@ -1,5 +1,7 @@
 package io.github.jdreioe.wingmate.infrastructure
 
+import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.github.jdreioe.wingmate.infrastructure.ImageCacher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -70,7 +72,7 @@ class JvmImageCacher : ImageCacher {
             cacheFile.writeBytes(bytes)
             "file://${cacheFile.absolutePath}"
         } catch (e: Exception) {
-            e.printStackTrace()
+            OperationalLogger.warn("image_cache.download", "failed", exceptionClass = e.loggingClassName())
             url // Fallback to original URL on failure
         }
     }

--- a/core/data/src/jvmTest/kotlin/io/github/jdreioe/wingmate/infrastructure/SpeechLogPrivacyTest.kt
+++ b/core/data/src/jvmTest/kotlin/io/github/jdreioe/wingmate/infrastructure/SpeechLogPrivacyTest.kt
@@ -5,125 +5,102 @@ import kotlin.test.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-/**
- * Regression guard for AAC speech privacy: no logging statement in the speech
- * infrastructure may emit speech text, SSML, phrase/history contents,
- * pronunciation words, or recording paths (issue #146).
- */
+/** Regression guard for the Android/shared production logging policy (issue #162). */
 class SpeechLogPrivacyTest {
 
     @Test
-    fun speechServicesDoNotLogSensitiveContent() {
-        val offenders = buildList {
-            monitoredFiles().forEach { (relative, file) ->
-                file.forEachLogLine { lineNo, line ->
-                    if (line.isSensitiveLogLine()) {
-                        add("$relative:$lineNo  ${line.trim()}")
-                    }
-                }
+    fun productionSourcesUseOnlyThePrivacySafeLogger() {
+        val offenders = productionFiles().flatMap { (relative, file) ->
+            file.readLines().mapIndexedNotNull { index, line ->
+                line.takeIf { it.isAdHocDiagnostic() || it.isDirectLoggerUse(relative) }
+                    ?.let { "$relative:${index + 1}  ${it.trim()}" }
             }
         }
+
         assertTrue(
             offenders.isEmpty(),
-            "Speech code may leak AAC text, SSML, history, pronunciation, or recording paths:\n" +
+            "Android/shared production diagnostics must use OperationalLogger:\n" +
                 offenders.joinToString("\n"),
         )
     }
 
     @Test
-    fun representativeSensitivePhrasesNeverAppearInLogLines() {
-        val phrases = listOf(
-            "I am scared",
-            "grandma\u2019s house",
-            "the pain is in my chest",
-            "123 Main Street",
-            "call 911",
-        )
-        monitoredFiles().forEach { (relative, file) ->
-            file.forEachLogLine { _, line ->
-                phrases.forEach { phrase ->
-                    assertFalse(
-                        line.contains(phrase),
-                        "$relative would log sensitive phrase '$phrase': ${line.trim()}",
-                    )
-                }
+    fun productionDiagnosticsDoNotReceiveSensitiveValuesOrRawThrowables() {
+        val offenders = productionFiles().flatMap { (relative, file) ->
+            val source = file.readText()
+            source.operationalLogCalls().mapNotNull { call ->
+                call.takeIf(String::isUnsafeOperationalLogCall)
+                    ?.let { "$relative  ${it.replace(Regex("""\s+"""), " ").trim()}" }
             }
         }
-    }
 
-    @Test
-    fun linuxBridgeSpeechLogLinesAreContentFree() {
-        val file = File(findRepoRoot(), "linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt")
-        assertTrue(file.exists(), "Missing KotlinBridge.kt")
-        file.forEachLogLine { lineNo, line ->
-            if (line.contains("[SPEECH]")) {
-                assertFalse(
-                    line.isSensitiveLogLine(),
-                    "KotlinBridge speech log leaks content at line $lineNo: ${line.trim()}",
-                )
-            }
-        }
-    }
-
-    @Test
-    fun knownDangerousLoggingPatternsAreDetected() {
-        val dangerous = listOf(
-            "println(\"Android Azure TTS SSML:\\n\$ssml\")",
-            "logger.debug { \"SSML length=\${ssml.length} chars, preview=\${ssml.take(200)}\" }",
-            "println(\"DEBUG: Recorded history for: \$text\")",
-            "println(\"DEBUG: Failed to record history: \${t.message}\")",
-            "logger.warn(e) { \"Failed to guess pronunciation for '\$text'\" }",
-            "logger.warn(t) { \"Failed to play recorded audio: \$path\" }",
-            "saidLogger.debug { \"Saved SaidText item path=\${enriched.audioFilePath}\" }",
-            "println(\"[SPEECH] Synthesizing with Azure TTS... Text: '\$text', Voice: \${voice?.name}\")",
-            "println(\"[SPEECH] Executing TTS command: \$args\")",
-            "println(\"[SPEECH] TTS Output: \$line\")",
-            "println(\"[SPEECH] /api/speak error: \${e.message}\")",
-            "println(\"[SPEECH] \$message\")",
-            "println(\"Failed to speak: \$e\")",
-            "logger.error { \"Azure TTS client error: \${response.status} - \${body.take(500)}\" }",
+        assertTrue(
+            offenders.isEmpty(),
+            "Operational diagnostics may only contain bounded, content-free metadata:\n" +
+                offenders.joinToString("\n"),
         )
-        dangerous.forEach { line ->
-            assertTrue(line.isSensitiveLogLine(), "Regression guard should flag: $line")
+    }
+
+    @Test
+    fun representativeUnsafeStatementsAreDetected() {
+        val unsafe = listOf(
+            "println(\"phrase=\$text\")",
+            "error.printStackTrace()",
+            "Log.w(\"Speech\", \"failed\", throwable)",
+            "logger.warn(error) { \"speech failed\" }",
+            "logger.info { \"endpoint=\$url\" }",
+            "OperationalLogger.warn(\"speech.play\", \"failed\", exceptionClass = error.message)",
+            "OperationalLogger.info(operation = text, outcome = \"spoken\")",
+            "OperationalLogger.info(\"speech.play\", \"started\", count = ssml.length)",
+        )
+
+        unsafe.forEach { statement ->
+            assertTrue(
+                statement.isAdHocDiagnostic() ||
+                    statement.isDirectLoggerUse("example.kt") ||
+                    statement.isUnsafeOperationalLogCall(),
+                "Regression guard should flag: $statement",
+            )
         }
     }
 
     @Test
-    fun contentFreeDiagnosticsAreNotFlagged() {
+    fun representativeContentFreeStatementsAreAllowed() {
         val safe = listOf(
-            "logger.info { \"Azure TTS response status=\${response.status}\" }",
-            "logger.info { \"Azure TTS returned \${bytes.size} bytes (\${bytes.size / 1024}KB)\" }",
-            "logger.debug { \"SSML length=\${ssml.length} chars\" }",
-            "logger.info { \"Azure TTS request -> url=\$url (format=\${audioFormat.value})\" }",
-            "logger.warn(e) { \"Azure TTS network error\" }",
-            "logger.warn { \"Failed to guess pronunciation\" }",
-            "logger.warn { \"Failed to play recorded audio\" }",
-            "logger.warn(t) { \"Failed to play synthesized Azure audio\" }",
-            "saidLogger.debug { \"Saved SaidText item id=\${enriched.id} voice=\${enriched.voiceName}\" }",
-            "println(\"[SPEECH] Audio playback finished.\")",
-            "println(\"[SPEECH] Executing TTS engine: \${File(ttsCommand).name}\")",
-            "println(\"[SPEECH] Speech failed (\${error::class.simpleName})\")",
-            "println(\"Failed to speak (\${e::class.simpleName})\")",
-            "println(\"[SPEECH] Received \${audioData.size} bytes audio. Playing...\")",
+            "OperationalLogger.info(\"speech.play\", \"started\")",
+            "OperationalLogger.info(\"voice_catalog.load\", \"succeeded\", count = voices.size)",
+            "OperationalLogger.warn(\"speech.play\", \"failed\", exceptionClass = error.loggingClassName())",
+            "OperationalLogger.info(\"azure_tts.synthesize\", \"response_received\", statusCode = response.status.value)",
         )
-        safe.forEach { line ->
-            assertFalse(line.isSensitiveLogLine(), "Should not flag: $line")
+
+        safe.forEach { statement ->
+            assertFalse(statement.isAdHocDiagnostic(), "Should allow: $statement")
+            assertFalse(statement.isDirectLoggerUse("example.kt"), "Should allow: $statement")
+            assertFalse(statement.isUnsafeOperationalLogCall(), "Should allow: $statement")
         }
     }
 
-    private fun monitoredFiles(): List<Pair<String, File>> {
+    private fun productionFiles(): List<Pair<String, File>> {
         val root = findRepoRoot()
-        return listOf(
-            "core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureTtsClient.kt",
-            "core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/SecureAzureSpeechService.kt",
-            "core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/TokenExchangeClient.kt",
-            "core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSpeechService.kt",
-            "core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSpeechService.kt",
-            "core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSaidTextRepository.kt",
-            "linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/LinuxSpeechService.kt",
-            "linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/AzureSpeechService.kt",
-            "androidApp/src/main/java/io/github/jdreioe/wingmate/ui/TestVoiceScreen.kt",
-        ).map { it to File(root, it) }
+        val sourceRoots = listOf(
+            "androidApp/src/main",
+            "shared/src",
+            "core",
+            "feature",
+        )
+        val productionSourceSet = Regex("/src/(?:common|android|ios|jvm)Main/")
+
+        return sourceRoots.flatMap { sourceRoot ->
+            File(root, sourceRoot).walkTopDown()
+                .filter(File::isFile)
+                .filter { it.extension == "kt" }
+                .filter { file ->
+                    val normalized = file.invariantSeparatorsPath
+                    normalized.contains("/androidApp/src/main/") || productionSourceSet.containsMatchIn(normalized)
+                }
+                .map { file -> file.relativeTo(root).invariantSeparatorsPath to file }
+                .toList()
+        }
     }
 
     private fun findRepoRoot(): File {
@@ -135,71 +112,75 @@ class SpeechLogPrivacyTest {
     }
 }
 
-private fun File.forEachLogLine(block: (Int, String) -> Unit) {
-    readLines().forEachIndexed { index, line ->
-        if (line.contains("println(") ||
-            line.contains("logger.") ||
-            line.contains("saidLogger.") ||
-            line.contains("System.err.print")
-        ) {
-            block(index + 1, line)
-        }
-    }
-}
-
-private val sensitiveVariableNames = setOf(
-    "ssml",
-    "text",
-    "phrase",
-    "history",
-    "args",
-    "body",
-    "errorbody",
-    "path",
-    "line",
-    "output",
-    "message",
-    "audiofilepath",
-    "recordingpath",
-    "audiopath",
-    "e",
-    "t",
-    "error",
-    "exception",
-    "throwable",
+private val directLoggerCall = Regex("""\b(?:logger|saidLogger|log)\.(?:trace|debug|info|warn|error)\s*[({]""")
+private val rawThrowableArgument = Regex(
+    """\.(?:trace|debug|info|warn|error)\s*\(\s*(?:e|t|error|exception|throwable)\b""",
+)
+private val unsafeOperationalValue = Regex(
+    """\b(?:operation|outcome|exceptionClass|count|statusCode|enabled)\s*=\s*(?:text|ssml|phrase|history|recording|token|credential|endpoint|url|settings|config|message|e\.message|t\.message|error\.message|exception\.message|throwable\.message)\b""",
+    RegexOption.IGNORE_CASE,
+)
+private val sensitiveInterpolation = Regex(
+    """\$\{?(?:text|ssml|phrase|history|recording|token|credential|endpoint|url|settings|config|message|e|t|error|exception|throwable)(?:[.}]|\b)""",
+    RegexOption.IGNORE_CASE,
+)
+private val sensitiveMetadataExpression = Regex(
+    """\b(?:count|statusCode|enabled)\s*=\s*(?:ssml|text|phrase|history|recording|token|credential|endpoint|url|settings|config)\.""",
+    RegexOption.IGNORE_CASE,
+)
+private val positionalOperationalTags = Regex(
+    """OperationalLogger\.(?:debug|info|warn|error)\s*\(\s*"[a-z0-9_.-]+"\s*,\s*"[a-z0-9_.-]+"""",
+)
+private val namedOperationalTags = Regex(
+    """\boperation\s*=\s*"[a-z0-9_.-]+"[\s\S]*\boutcome\s*=\s*"[a-z0-9_.-]+"""",
 )
 
-private val bareInterpolation = Regex("""\$([A-Za-z_][A-Za-z0-9_]*)""")
-private val bracketedInterpolation = Regex("""\$\{([A-Za-z0-9_.?]+)\}""")
+private fun String.isAdHocDiagnostic(): Boolean =
+    contains("println(") ||
+        contains("printStackTrace(") ||
+        contains("System.err.print") ||
+        Regex("""\bLog\.[vdiewtf]\s*\(""").containsMatchIn(this)
 
-private fun String.isSensitiveLogLine(): Boolean {
-    if (!contains("println(") &&
-        !contains("logger.") &&
-        !contains("saidLogger.") &&
-        !contains("System.err.print")
-    ) {
-        return false
-    }
-    val literalMarkers = listOf(
-        "preview=",
-        "body.take(",
-        "take(500)",
-        "history for:",
-        "for: \$",
-        "for '\$",
-        "TTS Output:",
-        "Text: '",
-    )
-    if (literalMarkers.any { contains(it) }) return true
+private fun String.isDirectLoggerUse(relativePath: String): Boolean =
+    relativePath != OPERATIONAL_LOGGER_PATH &&
+        (contains("KotlinLogging") || directLoggerCall.containsMatchIn(this) || rawThrowableArgument.containsMatchIn(this))
 
-    if (bareInterpolation.findAll(this).any {
-            it.groupValues[1].lowercase() in sensitiveVariableNames
+private fun String.isUnsafeOperationalLogCall(): Boolean {
+    if (!contains("OperationalLogger.")) return false
+    return (!positionalOperationalTags.containsMatchIn(this) && !namedOperationalTags.containsMatchIn(this)) ||
+        sensitiveInterpolation.containsMatchIn(this) ||
+        unsafeOperationalValue.containsMatchIn(this) ||
+        sensitiveMetadataExpression.containsMatchIn(this) ||
+        contains(".message") ||
+        contains(".toString()")
+}
+
+private fun String.operationalLogCalls(): List<String> = buildList {
+    var searchFrom = 0
+    while (true) {
+        val start = indexOf("OperationalLogger.", searchFrom)
+        if (start < 0) break
+        val open = indexOf('(', start)
+        if (open < 0) break
+        var depth = 0
+        var end = open
+        while (end < length) {
+            when (this@operationalLogCalls[end]) {
+                '(' -> depth++
+                ')' -> {
+                    depth--
+                    if (depth == 0) {
+                        end++
+                        break
+                    }
+                }
+            }
+            end++
         }
-    ) {
-        return true
-    }
-
-    return bracketedInterpolation.findAll(this).any { match ->
-        match.groupValues[1].substringAfterLast('.').trimEnd('?').lowercase() in sensitiveVariableNames
+        add(substring(start, end.coerceAtMost(length)))
+        searchFrom = end
     }
 }
+
+private const val OPERATIONAL_LOGGER_PATH =
+    "core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/OperationalLogger.kt"

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(libs.kotlinx.serialization.json)
+                implementation("io.github.oshai:kotlin-logging:7.0.0")
             }
         }
         val commonTest by getting {

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/OperationalLogger.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/OperationalLogger.kt
@@ -1,0 +1,69 @@
+package io.github.jdreioe.wingmate.domain
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+/**
+ * Content-free production diagnostics.
+ *
+ * Values are deliberately limited to bounded operational metadata. User content,
+ * configuration values, endpoints, and throwable objects do not belong here.
+ */
+object OperationalLogger {
+    private val logger = KotlinLogging.logger("WingmateOperations")
+
+    fun debug(
+        operation: String,
+        outcome: String,
+        count: Int? = null,
+        statusCode: Int? = null,
+        enabled: Boolean? = null,
+        exceptionClass: String? = null,
+    ) = logger.debug { message(operation, outcome, count, statusCode, enabled, exceptionClass) }
+
+    fun info(
+        operation: String,
+        outcome: String,
+        count: Int? = null,
+        statusCode: Int? = null,
+        enabled: Boolean? = null,
+        exceptionClass: String? = null,
+    ) = logger.info { message(operation, outcome, count, statusCode, enabled, exceptionClass) }
+
+    fun warn(
+        operation: String,
+        outcome: String,
+        count: Int? = null,
+        statusCode: Int? = null,
+        enabled: Boolean? = null,
+        exceptionClass: String? = null,
+    ) = logger.warn { message(operation, outcome, count, statusCode, enabled, exceptionClass) }
+
+    fun error(
+        operation: String,
+        outcome: String,
+        count: Int? = null,
+        statusCode: Int? = null,
+        enabled: Boolean? = null,
+        exceptionClass: String? = null,
+    ) = logger.error { message(operation, outcome, count, statusCode, enabled, exceptionClass) }
+
+    private fun message(
+        operation: String,
+        outcome: String,
+        count: Int?,
+        statusCode: Int?,
+        enabled: Boolean?,
+        exceptionClass: String?,
+    ): String = buildString {
+        append("operation=")
+        append(operation)
+        append(" outcome=")
+        append(outcome)
+        count?.let { append(" count=").append(it) }
+        statusCode?.let { append(" statusCode=").append(it) }
+        enabled?.let { append(" enabled=").append(it) }
+        exceptionClass?.let { append(" exception=").append(it) }
+    }
+}
+
+fun Throwable.loggingClassName(): String = this::class.simpleName ?: "UnknownThrowable"

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/UserDataManager.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/UserDataManager.kt
@@ -33,7 +33,11 @@ class UserDataManager(private val saidTextRepository: SaidTextRepository) {
                 saidTextRepository.addAll(history)
             }
         } catch (e: Exception) {
-            println("Error importing data: ${e.message}")
+            OperationalLogger.warn(
+                operation = "user_data.import",
+                outcome = "failed",
+                exceptionClass = e.loggingClassName(),
+            )
             throw e
         }
     }

--- a/feature/communication/data/build.gradle.kts
+++ b/feature/communication/data/build.gradle.kts
@@ -29,7 +29,6 @@ kotlin {
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.client.contentNegotiation)
                 implementation(libs.ktor.serialization.json)
-                implementation("io.github.oshai:kotlin-logging:7.0.0")
             }
         }
 

--- a/feature/communication/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/azure.kt
+++ b/feature/communication/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/azure.kt
@@ -2,6 +2,8 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.domain.ConfigRepository
+import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.ktor.client.*
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.*
@@ -11,9 +13,6 @@ import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import io.github.oshai.kotlinlogging.KotlinLogging
-
-private val logger = KotlinLogging.logger {}
 
 class AzureVoiceCatalog(private val configRepo: ConfigRepository) {
     private val client = HttpClient {
@@ -32,13 +31,13 @@ class AzureVoiceCatalog(private val configRepo: ConfigRepository) {
     suspend fun list(): List<Voice> {
         return try {
             val cfg = configRepo.getSpeechConfig() ?: run {
-                logger.debug { "AzureVoiceCatalog: no config; returning empty list" }
+                OperationalLogger.debug("azure_voice_catalog.load", "config_missing")
                 return emptyList()
             }
             val endpoint = cfg.endpoint.trim()
             val key = cfg.subscriptionKey.trim()
             if (endpoint.isEmpty() || key.isEmpty()) {
-                logger.warn { "AzureVoiceCatalog: empty endpoint or key; returning empty list" }
+                OperationalLogger.warn("azure_voice_catalog.load", "config_incomplete")
                 return emptyList()
             }
             val host = endpoint.removePrefix("https://").removePrefix("http://").removeSuffix("/")
@@ -60,7 +59,11 @@ class AzureVoiceCatalog(private val configRepo: ConfigRepository) {
                 )
             }
         } catch (t: Throwable) {
-            logger.warn(t) { "AzureVoiceCatalog: failed to fetch voice list; returning empty" }
+            OperationalLogger.warn(
+                operation = "azure_voice_catalog.load",
+                outcome = "failed",
+                exceptionClass = t.loggingClassName(),
+            )
             emptyList()
         }
     }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -54,8 +54,6 @@ kotlin {
                 implementation(libs.ktor.client.core)
                 implementation(libs.ktor.client.contentNegotiation)
                 implementation(libs.ktor.serialization.json)
-                // Add logging for Kotlin Multiplatform
-                implementation("io.github.oshai:kotlin-logging:7.0.0")
                 implementation(libs.okio)
 
                 // MVIKotlin for BLoC pattern

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
@@ -16,6 +16,7 @@ import io.github.jdreioe.wingmate.application.bloc.PhraseListStore
 import io.github.jdreioe.wingmate.di.appModule
 import io.github.jdreioe.wingmate.initKoin
 import io.github.jdreioe.wingmate.domain.ConfigRepository
+import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.SpeechService
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfigStatus
@@ -32,6 +33,7 @@ import io.github.jdreioe.wingmate.domain.SaidTextRepository
 import io.github.jdreioe.wingmate.domain.TextEditResult
 import io.github.jdreioe.wingmate.domain.TextEditingPolicy
 import io.github.jdreioe.wingmate.domain.TextSpan
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
 import io.github.jdreioe.wingmate.domain.obf.ObfButton
@@ -67,7 +69,6 @@ import io.github.jdreioe.wingmate.infrastructure.OpenSymbolsClient
 import io.github.jdreioe.wingmate.infrastructure.SymbolSearchClient
 import io.github.jdreioe.wingmate.infrastructure.QuickCorePresetService
 import io.github.jdreioe.wingmate.infrastructure.BoardImportResult
-import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlin.time.Clock
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -126,7 +127,7 @@ class KoinBridge : KoinComponent {
         try {
             get<SpeechService>().speak(text)
         } catch (t: Throwable) {
-            logger.warn(t) { "speak() failed; swallowing to avoid Swift bridge crash" }
+            OperationalLogger.warn("swift_bridge.speak", "failed", exceptionClass = t.loggingClassName())
         }
     }
 
@@ -134,7 +135,7 @@ class KoinBridge : KoinComponent {
         try {
             get<SpeechService>().speakWithCachePolicy(text = text, cacheAudio = cacheAudio)
         } catch (t: Throwable) {
-            logger.warn(t) { "speakBoardSentence() failed; swallowing to avoid Swift bridge crash" }
+            OperationalLogger.warn("swift_bridge.speak_board_sentence", "failed", exceptionClass = t.loggingClassName())
         }
     }
 
@@ -142,7 +143,7 @@ class KoinBridge : KoinComponent {
         try {
             get<SpeechService>().pause()
         } catch (t: Throwable) {
-            logger.warn(t) { "pause() failed; swallowing to avoid Swift bridge crash" }
+            OperationalLogger.warn("swift_bridge.pause", "failed", exceptionClass = t.loggingClassName())
         }
     }
 
@@ -150,13 +151,13 @@ class KoinBridge : KoinComponent {
         try {
             get<SpeechService>().stop()
         } catch (t: Throwable) {
-            logger.warn(t) { "stop() failed; swallowing to avoid Swift bridge crash" }
+            OperationalLogger.warn("swift_bridge.stop", "failed", exceptionClass = t.loggingClassName())
         }
     }
 
     suspend fun selectVoiceAndMaybeUpdatePrimary(voice: Voice) {
         val voiceUseCase: VoiceUseCase = get()
-    try { println("DEBUG: KoinBridge.selectVoiceAndMaybeUpdatePrimary() called for '\${voice.name}' selectedLang='\${voice.selectedLanguage}'") } catch (_: Throwable) {}
+        OperationalLogger.debug("voice_selection.update", "started")
         voiceUseCase.select(voice)
 
         // Optionally align Settings.primaryLanguage with selected voice
@@ -369,7 +370,7 @@ class KoinBridge : KoinComponent {
         try {
             phraseListStore().accept(PhraseListStore.Intent.UpdatePhraseRecording(id = phraseId, recordingPath = recordingPath))
         } catch (t: Throwable) {
-            logger.warn(t) { "updatePhraseRecording() failed; swallowing to avoid Swift bridge crash" }
+            OperationalLogger.warn("swift_bridge.phrase_recording_update", "failed", exceptionClass = t.loggingClassName())
         }
     }
 
@@ -794,7 +795,7 @@ class KoinBridge : KoinComponent {
                 service.train(list)
             }
         } catch (t: Throwable) {
-            logger.warn(t) { "trainPredictionModel() failed" }
+            OperationalLogger.warn("prediction_model.train", "failed", exceptionClass = t.loggingClassName())
         }
     }
 
@@ -893,8 +894,6 @@ data class IosBoardSetExportResult(
     val fileName: String? = null,
     val message: String = "",
 )
-
-private val logger = KotlinLogging.logger {}
 
 private fun String.toBoardActivationBehavior(): BoardActivationBehavior =
     when (this) {


### PR DESCRIPTION
## Summary

- Replace ad hoc and sensitive log output with structured operational logging.
- Redact user content, credentials, endpoints, voice names, and exception messages from logs.
- Centralize privacy-safe logging helpers and update Android, iOS, shared, and infrastructure code.
- Add and update logging privacy coverage tests.

## Testing

- Not run.