### PR TITLE
Gate Android releases on shared CI verification

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -18,8 +18,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  verify:
+    name: Android verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Compile, lint, and test Android
+        run: bash ci_scripts/verify_android.sh
+
   deploy:
     name: Deploy ${{ github.ref_name }}
+    needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -31,6 +46,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Set Android version
         id: version

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,20 @@ permissions:
   contents: read
 
 jobs:
+  android-verification:
+    name: Android verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@v4
+      - name: Compile, lint, and test Android
+        run: bash ci_scripts/verify_android.sh
+
   client-secret-boundary:
     runs-on: ubuntu-latest
     steps:

--- a/ci_scripts/verify_android.sh
+++ b/ci_scripts/verify_android.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Keep this task list shared by pull-request and Play release verification so
+# publishing cannot drift to a weaker gate.
+exec ./gradlew \
+  :androidApp:assembleDebug \
+  :androidApp:lintDebug \
+  :androidApp:testDebugUnitTest \
+  jvmTest \
+  --console=plain

--- a/docs/ANDROID_CI.md
+++ b/docs/ANDROID_CI.md
@@ -1,0 +1,13 @@
+# Android CI verification
+
+Pull requests and Google Play open-beta releases run
+`ci_scripts/verify_android.sh`. The gate assembles the debug Android app, runs
+Android lint and local unit tests, and runs every KMP `jvmTest` suite. Gradle's
+plain console output names a failing task directly.
+
+Both workflows use Java 21 and `gradle/actions/setup-gradle` to reuse wrapper,
+dependency, and local build caches. A clean GitHub-hosted runner still works on
+a cache miss; caching only shortens later runs. Expect roughly 3–5 minutes on a
+cold runner, with warm-cache runs generally faster. The Play workflow repeats
+this read-only, secret-free gate in a separate job before installing Infisical
+or running `publishReleaseBundle` with injected release credentials.


### PR DESCRIPTION
## Summary

- Add shared Android compile, lint, and test verification for Play releases and security CI.
- Block Play deployment until Android verification succeeds.
- Document the verification tasks, caching, runtime, and release security boundary.

## Testing

- Not run locally; CI workflows now run `ci_scripts/verify_android.sh`.