### PR TITLE
#167 Gate Android CI with critical emulator UI tests

### DIFF
--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -31,6 +31,21 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
       - name: Compile, lint, and test Android
         run: bash ci_scripts/verify_android.sh
+      - name: Enable KVM for the Android emulator
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Run critical Android UI tests
+        uses: reactivecircus/android-emulator-runner@v2.38.0
+        with:
+          api-level: 35
+          arch: x86_64
+          profile: pixel_6
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew :androidApp:connectedDebugAndroidTest --console=plain
 
   deploy:
     name: Deploy ${{ github.ref_name }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,6 +22,21 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
       - name: Compile, lint, and test Android
         run: bash ci_scripts/verify_android.sh
+      - name: Enable KVM for the Android emulator
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Run critical Android UI tests
+        uses: reactivecircus/android-emulator-runner@v2.38.0
+        with:
+          api-level: 35
+          arch: x86_64
+          profile: pixel_6
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: ./gradlew :androidApp:connectedDebugAndroidTest --console=plain
 
   client-secret-boundary:
     runs-on: ubuntu-latest

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -187,6 +187,9 @@ dependencies {
     implementation(composeBom)
     androidTestImplementation(composeBom)
     androidTestImplementation(libs.androidx.testExt.junit)
+    // Compose UI Test still brings Espresso 3.5 transitively. That release
+    // reflects on InputManager.getInstance(), which no longer exists on API 36.
+    androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
 
     // Common AndroidX helpers

--- a/docs/ANDROID_CI.md
+++ b/docs/ANDROID_CI.md
@@ -2,8 +2,9 @@
 
 Pull requests and Google Play open-beta releases run
 `ci_scripts/verify_android.sh`. The gate assembles the debug Android app, runs
-Android lint and local unit tests, and runs every KMP `jvmTest` suite. Gradle's
-plain console output names a failing task directly.
+Android lint and local unit tests, and runs every KMP `jvmTest` suite. It then
+runs the small Compose instrumentation suite on a disposable Pixel 6 emulator
+using API 35. Gradle's plain console output names a failing task directly.
 
 Both workflows use Java 21 and `gradle/actions/setup-gradle` to reuse wrapper,
 dependency, and local build caches. A clean GitHub-hosted runner still works on
@@ -11,3 +12,23 @@ a cache miss; caching only shortens later runs. Expect roughly 3–5 minutes on 
 cold runner, with warm-cache runs generally faster. The Play workflow repeats
 this read-only, secret-free gate in a separate job before installing Infisical
 or running `publishReleaseBundle` with injected release credentials.
+
+## Manual accessibility verification
+
+Instrumentation protects keyboard/switch activation and Rest mode at the input
+and Compose semantics layers. Before a Play release that changes an access path,
+verify these behaviors on a real device with the user's actual access setup:
+
+- TalkBack announces actionable communication cells, controls, dialogs, and
+  their selected/disabled state in a useful order.
+- A paired keyboard or switch activates the focused target exactly once, and
+  Rest mode stops and resumes activation without trapping focus.
+- Touch-and-hold timing, large touch targets, and visible focus/activation
+  feedback remain usable with the configured accessibility timing.
+- Speaking, board navigation, and backup restore preserve the composed message
+  and current communication context after interruptions and configuration
+  changes.
+
+Use a dedicated test device for instrumentation. Never run
+`connectedDebugAndroidTest` on a user's Wingmate device: runner cleanup and
+debug signing can replace or remove the installed app and its private data.


### PR DESCRIPTION
## Summary

- Run critical Android Compose UI tests in security and Play deployment workflows.
- Configure API 35 Pixel 6 emulators with KVM support and disabled animations.
- Document CI coverage and manual accessibility verification requirements.
- Add Espresso compatibility for Android instrumentation tests.

## Testing

- Added CI checks for `./gradlew :androidApp:connectedDebugAndroidTest --console=plain`.
- Not run locally; emulator instrumentation runs in GitHub Actions.