### PR TITLE
Secure Azure Speech endpoint validation and credential requests

### DIFF
--- a/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardSetManagerScreenTest.kt
+++ b/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardSetManagerScreenTest.kt
@@ -42,10 +42,7 @@ class BoardSetManagerScreenTest {
 
         composeRule.onNodeWithText("Core words").assertIsDisplayed()
         composeRule
-            .onNodeWithTag(
-                testTag = "${BOARD_SET_CARD_TEST_TAG_PREFIX}core-words",
-                useUnmergedTree = true,
-            )
+            .onNodeWithTag("${BOARD_SET_OPEN_TEST_TAG_PREFIX}core-words")
             .performClick()
 
         assertEquals(BoardSetManagerAction.OpenClicked("core-words"), receivedAction)

--- a/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardSetManagerScreenTest.kt
+++ b/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardSetManagerScreenTest.kt
@@ -2,6 +2,7 @@ package io.github.jdreioe.wingmate.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
@@ -39,7 +40,10 @@ class BoardSetManagerScreenTest {
             }
         }
 
-        composeRule.onNodeWithText("Core words").assertIsDisplayed().performClick()
+        composeRule.onNodeWithText("Core words").assertIsDisplayed()
+        composeRule
+            .onNodeWithTag("${BOARD_SET_CARD_TEST_TAG_PREFIX}core-words")
+            .performClick()
 
         assertEquals(BoardSetManagerAction.OpenClicked("core-words"), receivedAction)
     }

--- a/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardSetManagerScreenTest.kt
+++ b/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardSetManagerScreenTest.kt
@@ -42,7 +42,10 @@ class BoardSetManagerScreenTest {
 
         composeRule.onNodeWithText("Core words").assertIsDisplayed()
         composeRule
-            .onNodeWithTag("${BOARD_SET_CARD_TEST_TAG_PREFIX}core-words")
+            .onNodeWithTag(
+                testTag = "${BOARD_SET_CARD_TEST_TAG_PREFIX}core-words",
+                useUnmergedTree = true,
+            )
             .performClick()
 
         assertEquals(BoardSetManagerAction.OpenClicked("core-words"), receivedAction)

--- a/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardWorkspaceContentTest.kt
+++ b/androidApp/src/androidTest/java/io/github/jdreioe/wingmate/ui/BoardWorkspaceContentTest.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.hojmoseit.wingmate.R
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -39,6 +41,9 @@ class BoardWorkspaceContentTest {
     fun recoverableFailureWithoutBoardCanReturnToLibrary() {
         var returnedToLibrary = false
         var retried = false
+        val backToLibraryLabel = InstrumentationRegistry.getInstrumentation()
+            .targetContext
+            .getString(R.string.board_workspace_back_to_library)
         composeRule.setContent {
             AppTheme {
                 BoardWorkspaceContent(
@@ -56,7 +61,7 @@ class BoardWorkspaceContentTest {
 
         composeRule.onNodeWithText("Could not load board").assertIsDisplayed()
         composeRule.onNodeWithText("Retry").performClick()
-        composeRule.onNodeWithText("Back to library").performClick()
+        composeRule.onNodeWithText(backToLibraryLabel).performClick()
 
         assertTrue(retried)
         assertTrue(returnedToLibrary)

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/AzureCredentialEditor.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/AzureCredentialEditor.kt
@@ -28,6 +28,7 @@ internal fun AzureCredentialEditor(
     subscriptionKey: String,
     onSubscriptionKeyChange: (String) -> Unit,
     onReplaceCredentials: () -> Unit,
+    endpointError: String? = null,
     modifier: Modifier = Modifier,
 ) {
     if (credentialConfigured && !replacingCredentials) {
@@ -60,6 +61,8 @@ internal fun AzureCredentialEditor(
             label = { Text(stringResource(R.string.ui_settings_region_endpoint)) },
             placeholder = { Text(stringResource(R.string.ui_settings_region_example)) },
             modifier = Modifier.fillMaxWidth().then(showKeyboard),
+            isError = endpointError != null,
+            supportingText = endpointError?.let { message -> { Text(message) } },
             singleLine = true
         )
         Spacer(Modifier.height(12.dp))

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -166,7 +167,7 @@ import kotlin.time.Clock
 
 import com.hojmoseit.wingmate.R
 
-internal const val BOARD_SET_CARD_TEST_TAG_PREFIX = "board-set-card-"
+internal const val BOARD_SET_OPEN_TEST_TAG_PREFIX = "board-set-open-"
 
 private data class WorkspaceCellTarget(
     val row: Int,
@@ -522,43 +523,48 @@ private fun BoardSetLibraryCard(
     onDelete: () -> Unit
 ) {
     Card(
-        onClick = onOpen,
-        modifier = Modifier
-            .fillMaxWidth()
-            .testTag("$BOARD_SET_CARD_TEST_TAG_PREFIX${boardSet.id}"),
+        modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
     ) {
-        ListItem(
-            headlineContent = { Text(boardSet.name, fontWeight = FontWeight.SemiBold) },
-            supportingContent = {
-                Text(pluralStringResource(R.plurals.board_sets_board_count, boardSet.boardIds.size, boardSet.boardIds.size))
-            },
-            leadingContent = {
-                Icon(
-                    if (boardSet.isLocked) Icons.Default.Lock else Icons.Default.Home,
-                    contentDescription = if (boardSet.isLocked) stringResource(R.string.board_sets_locked) else null
-                )
-            },
-            trailingContent = {
-                Row {
-                    IconButton(onClick = onEdit, enabled = !boardSet.isLocked) {
-                        Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.board_sets_edit))
-                    }
-                    IconButton(onClick = onDuplicate) {
-                        Icon(Icons.Default.ContentCopy, contentDescription = stringResource(R.string.board_sets_duplicate))
-                    }
-                    IconButton(onClick = onToggleLock) {
-                        Icon(
-                            if (boardSet.isLocked) Icons.Default.LockOpen else Icons.Default.Lock,
-                            contentDescription = stringResource(if (boardSet.isLocked) R.string.board_sets_unlock else R.string.board_sets_lock)
-                        )
-                    }
-                    IconButton(onClick = onDelete) {
-                        Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.common_delete), tint = MaterialTheme.colorScheme.error)
-                    }
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            val openLabel = stringResource(R.string.board_sets_open)
+            ListItem(
+                headlineContent = { Text(boardSet.name, fontWeight = FontWeight.SemiBold) },
+                supportingContent = {
+                    Text(pluralStringResource(R.plurals.board_sets_board_count, boardSet.boardIds.size, boardSet.boardIds.size))
+                },
+                leadingContent = {
+                    Icon(
+                        if (boardSet.isLocked) Icons.Default.Lock else Icons.Default.Home,
+                        contentDescription = if (boardSet.isLocked) stringResource(R.string.board_sets_locked) else null
+                    )
+                },
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable(onClickLabel = openLabel, onClick = onOpen)
+                    .testTag("$BOARD_SET_OPEN_TEST_TAG_PREFIX${boardSet.id}"),
+            )
+            Row {
+                IconButton(onClick = onEdit, enabled = !boardSet.isLocked) {
+                    Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.board_sets_edit))
+                }
+                IconButton(onClick = onDuplicate) {
+                    Icon(Icons.Default.ContentCopy, contentDescription = stringResource(R.string.board_sets_duplicate))
+                }
+                IconButton(onClick = onToggleLock) {
+                    Icon(
+                        if (boardSet.isLocked) Icons.Default.LockOpen else Icons.Default.Lock,
+                        contentDescription = stringResource(if (boardSet.isLocked) R.string.board_sets_unlock else R.string.board_sets_lock)
+                    )
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(Icons.Default.Delete, contentDescription = stringResource(R.string.common_delete), tint = MaterialTheme.colorScheme.error)
                 }
             }
-        )
+        }
     }
 }
 

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -74,6 +74,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -164,6 +165,8 @@ import kotlin.random.Random
 import kotlin.time.Clock
 
 import com.hojmoseit.wingmate.R
+
+internal const val BOARD_SET_CARD_TEST_TAG_PREFIX = "board-set-card-"
 
 private data class WorkspaceCellTarget(
     val row: Int,
@@ -520,7 +523,9 @@ private fun BoardSetLibraryCard(
 ) {
     Card(
         onClick = onOpen,
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("$BOARD_SET_CARD_TEST_TAG_PREFIX${boardSet.id}"),
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainer)
     ) {
         ListItem(

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/F0SetupScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/F0SetupScreen.kt
@@ -23,6 +23,8 @@ import io.github.jdreioe.wingmate.domain.ConfigRepository
 import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.TtsEngine
+import io.github.jdreioe.wingmate.infrastructure.AzureSpeechEndpoint
+import io.github.jdreioe.wingmate.infrastructure.AzureSpeechEndpointResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -70,6 +72,8 @@ fun F0SetupScreen(
     fun saveCredentials() {
         when {
             endpoint.isBlank() -> saveError = "endpoint"
+            AzureSpeechEndpoint.parse(endpoint) is AzureSpeechEndpointResult.Invalid ->
+                saveError = "endpoint"
             subscriptionKey.isBlank() -> saveError = "key"
             else -> scope.launch {
                 featureUsageReporter.reportEvent(FeatureUsageEvents.AZURE_F0_CREDENTIALS_SUBMITTED)

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
@@ -54,6 +54,8 @@ import io.github.jdreioe.wingmate.domain.obf.BoardReturnBehavior
 import io.github.jdreioe.wingmate.domain.SpeechPolicy
 import io.github.jdreioe.wingmate.infrastructure.ArasaacDownloadProgress
 import io.github.jdreioe.wingmate.infrastructure.ArasaacSymbolDownloadService
+import io.github.jdreioe.wingmate.infrastructure.AzureSpeechEndpoint
+import io.github.jdreioe.wingmate.infrastructure.AzureSpeechEndpointResult
 import io.github.jdreioe.wingmate.infrastructure.ImageCacher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CancellationException
@@ -107,6 +109,7 @@ fun SettingsScreen(
     var subscriptionKey by remember { mutableStateOf("") }
     var credentialConfigured by remember { mutableStateOf(false) }
     var replacingAzureCredentials by remember { mutableStateOf(false) }
+    var azureEndpointError by remember { mutableStateOf<String?>(null) }
     var ttsEngine by remember { mutableStateOf(TtsEngine.SYSTEM) }
     var virtualMic by remember { mutableStateOf(false) }
 
@@ -167,6 +170,7 @@ fun SettingsScreen(
     val settingsLoadFailed = stringResource(R.string.settings_load_failed)
     val settingsSaveFailed = stringResource(R.string.settings_save_failed)
     val voiceReadFailed = stringResource(R.string.voice_load_failed)
+    val invalidAzureEndpoint = stringResource(R.string.azure_setup_error_endpoint)
     val scope = rememberCoroutineScope()
     val settingsUpdateMutex = remember { Mutex() }
 
@@ -290,6 +294,10 @@ fun SettingsScreen(
             endpoint.isNotBlank() && subscriptionKey.isNotBlank()
         ) {
             delay(400)
+            if (AzureSpeechEndpoint.parse(endpoint) is AzureSpeechEndpointResult.Invalid) {
+                azureEndpointError = invalidAzureEndpoint
+                return@LaunchedEffect
+            }
             val repository = configRepo ?: return@LaunchedEffect
             val saved = runCatching {
                 repository.saveSpeechConfig(
@@ -297,6 +305,7 @@ fun SettingsScreen(
                 )
             }.isSuccess
             if (saved) {
+                azureEndpointError = null
                 credentialConfigured = true
                 replacingAzureCredentials = false
                 subscriptionKey = ""
@@ -484,9 +493,13 @@ fun SettingsScreen(
                                     updateSettings { it.copy(ttsEngine = engine) }
                                 },
                                 endpoint = endpoint,
-                                onEndpointChange = { endpoint = it },
+                                onEndpointChange = {
+                                    endpoint = it
+                                    azureEndpointError = null
+                                },
                                 subscriptionKey = subscriptionKey,
                                 onSubscriptionKeyChange = { subscriptionKey = it },
+                                endpointError = azureEndpointError,
                                 credentialConfigured = credentialConfigured,
                                 replacingCredentials = replacingAzureCredentials,
                                 onReplaceCredentials = {
@@ -1248,6 +1261,7 @@ private fun SpeechSection(
     onEndpointChange: (String) -> Unit,
     subscriptionKey: String,
     onSubscriptionKeyChange: (String) -> Unit,
+    endpointError: String?,
     credentialConfigured: Boolean,
     replacingCredentials: Boolean,
     onReplaceCredentials: () -> Unit,
@@ -1284,6 +1298,7 @@ private fun SpeechSection(
                 onEndpointChange = onEndpointChange,
                 subscriptionKey = subscriptionKey,
                 onSubscriptionKeyChange = onSubscriptionKeyChange,
+                endpointError = endpointError,
                 onReplaceCredentials = onReplaceCredentials,
                 modifier = Modifier.padding(vertical = 12.dp)
             )

--- a/androidApp/src/main/res/values-da-rDK/strings.xml
+++ b/androidApp/src/main/res/values-da-rDK/strings.xml
@@ -284,7 +284,7 @@
     <string name="azure_setup_complete_description">Dine Azure Speech-oplysninger er gemt sikkert på denne enhed.</string>
     <string name="azure_credentials_configured">Azure Speech-oplysningerne er konfigureret sikkert på denne enhed.</string>
     <string name="azure_credentials_replace">Erstat Azure-oplysninger</string>
-    <string name="azure_setup_error_endpoint">Indtast Speech-endpointet eller regionen.</string>
+    <string name="azure_setup_error_endpoint">Indtast en gyldig Azure Speech-region eller et officielt HTTPS-endpoint.</string>
     <string name="azure_setup_error_key">Indtast en Speech-abonnementsnøgle.</string>
     <string name="azure_setup_error_save">Azure-oplysningerne kunne ikke gemmes: %1$s</string>
     <string name="welcome_analytics_title">Hjælp med at forbedre Wingmate</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -292,7 +292,7 @@
     <string name="azure_setup_complete_description">Your Azure Speech credentials are saved securely on this device.</string>
     <string name="azure_credentials_configured">Azure Speech credentials are securely configured on this device.</string>
     <string name="azure_credentials_replace">Replace Azure credentials</string>
-    <string name="azure_setup_error_endpoint">Enter the Speech endpoint or region.</string>
+    <string name="azure_setup_error_endpoint">Enter a valid Azure Speech region or official HTTPS endpoint.</string>
     <string name="azure_setup_error_key">Enter a Speech subscription key.</string>
     <string name="azure_setup_error_save">Could not save the Azure credentials: %1$s</string>
     <string name="welcome_analytics_title">Help improve Wingmate</string>

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSpeechService.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSpeechService.kt
@@ -58,7 +58,9 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
         const val DEFAULT_AZURE_LANGUAGE = "en-US"
     }
 
-    private val client = HttpClient(OkHttp) {}
+    private val client = HttpClient(OkHttp) {
+        followRedirects = false
+    }
     // Removed SLF4J logger for cross-platform compatibility
 
     // Platform TTS (fallback)

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlConfigRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlConfigRepository.kt
@@ -24,7 +24,7 @@ class AndroidSqlConfigRepository(private val context: Context) : ConfigRepositor
     private val json = Json { ignoreUnknownKeys = true }
 
     override suspend fun getSpeechConfig(): SpeechServiceConfig? = withContext(Dispatchers.IO) {
-        readSecure()?.also {
+        readSecure()?.normalizedIfValid()?.also {
             // Also completes cleanup after a process died between secure write and legacy deletion.
             deleteLegacyPlaintext()
             return@withContext it
@@ -33,9 +33,9 @@ class AndroidSqlConfigRepository(private val context: Context) : ConfigRepositor
     }
 
     override suspend fun saveSpeechConfig(config: SpeechServiceConfig) = withContext(Dispatchers.IO) {
-        require(config.subscriptionKey.isNotBlank()) { "Azure subscription key must not be blank" }
-        writeSecure(config)
-        check(readSecure() == config) { "Secure Azure credential write could not be verified" }
+        val normalized = config.validatedForStorage()
+        writeSecure(normalized)
+        check(readSecure() == normalized) { "Secure Azure credential write could not be verified" }
         deleteLegacyPlaintext()
         OperationalLogger.info("speech_config.save", "succeeded", enabled = true)
     }
@@ -47,7 +47,7 @@ class AndroidSqlConfigRepository(private val context: Context) : ConfigRepositor
     }
 
     private fun migrateLegacy(): SpeechServiceConfig? {
-        val legacy = readLegacySqlite() ?: readLegacyPreferences() ?: return null
+        val legacy = (readLegacySqlite() ?: readLegacyPreferences() ?: return null).normalizedIfValid()
         migrateLegacySpeechConfig(legacy, ::writeSecure, ::readSecure, ::deleteLegacyPlaintext)
         OperationalLogger.info("speech_config.migrate", "succeeded")
         return legacy

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureSpeechEndpoint.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureSpeechEndpoint.kt
@@ -1,0 +1,209 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
+import io.ktor.http.URLProtocol
+import io.ktor.http.Url
+
+/**
+ * A validated Azure Speech authority that is safe to receive a BYOK subscription key.
+ *
+ * Microsoft documents regional TTS endpoints under `*.tts.speech.*`, Azure Portal
+ * regional endpoints under `*.api.cognitive.*`, and resource endpoints under
+ * `*.cognitiveservices.*`. Only those exact authority shapes are accepted; callers
+ * cannot supply paths, query strings, fragments, user-info, or non-HTTPS schemes.
+ */
+class AzureSpeechEndpoint private constructor(
+    /** Canonical value stored in the user's secure configuration. */
+    val persistedValue: String,
+    /** HTTPS origin used for credential-bearing requests. */
+    val baseUrl: String,
+    private val kind: Kind,
+) {
+    val synthesisUrl: String
+        get() = "$baseUrl/cognitiveservices/v1"
+
+    val voicesUrl: String
+        get() = when (kind) {
+            Kind.REGIONAL -> "$baseUrl/cognitiveservices/voices/list"
+            Kind.RESOURCE -> "$baseUrl/tts/cognitiveservices/voices/list"
+        }
+
+    private enum class Kind { REGIONAL, RESOURCE }
+
+    companion object {
+        fun parse(rawValue: String): AzureSpeechEndpointResult {
+            val value = rawValue.trim()
+            if (value.isEmpty()) {
+                return AzureSpeechEndpointResult.Invalid(AzureSpeechEndpointError.EMPTY)
+            }
+            if (value.any { it.code !in PRINTABLE_ASCII_RANGE } || '\\' in value || '%' in value) {
+                return AzureSpeechEndpointResult.Invalid(AzureSpeechEndpointError.INVALID_FORMAT)
+            }
+
+            if (SCHEME_SEPARATOR !in value && '.' !in value) {
+                return parseRegion(value)
+            }
+
+            if (SCHEME_SEPARATOR in value && !value.startsWith(HTTPS_PREFIX, ignoreCase = true)) {
+                return AzureSpeechEndpointResult.Invalid(AzureSpeechEndpointError.HTTPS_REQUIRED)
+            }
+
+            val candidate = if (SCHEME_SEPARATOR in value) value else "$HTTPS_PREFIX$value"
+            val authority = candidate.substringAfter(SCHEME_SEPARATOR).substringBefore('/')
+            if (':' in authority) {
+                return AzureSpeechEndpointResult.Invalid(AzureSpeechEndpointError.UNEXPECTED_URL_COMPONENT)
+            }
+            val url = runCatching { Url(candidate) }.getOrNull()
+                ?: return AzureSpeechEndpointResult.Invalid(AzureSpeechEndpointError.INVALID_FORMAT)
+
+            if (url.protocol != URLProtocol.HTTPS) {
+                return AzureSpeechEndpointResult.Invalid(AzureSpeechEndpointError.HTTPS_REQUIRED)
+            }
+            if (
+                url.user != null ||
+                url.password != null ||
+                url.port != HTTPS_PORT ||
+                url.encodedPath !in setOf("", "/") ||
+                !url.parameters.isEmpty() ||
+                url.trailingQuery ||
+                url.fragment.isNotEmpty() ||
+                '@' in value ||
+                '?' in value ||
+                '#' in value
+            ) {
+                return AzureSpeechEndpointResult.Invalid(AzureSpeechEndpointError.UNEXPECTED_URL_COMPONENT)
+            }
+
+            val host = url.host.lowercase()
+            if (!host.isValidHostName()) {
+                return AzureSpeechEndpointResult.Invalid(AzureSpeechEndpointError.INVALID_FORMAT)
+            }
+
+            GENERIC_REGIONAL_SUFFIXES.entries.firstOrNull { (suffix) ->
+                host.hasSingleLabelBefore(suffix)
+            }?.let { (genericSuffix, ttsSuffix) ->
+                val region = host.removeSuffix(genericSuffix)
+                return AzureSpeechEndpointResult.Valid(
+                    AzureSpeechEndpoint(
+                        persistedValue = region,
+                        baseUrl = "$HTTPS_PREFIX$region$ttsSuffix",
+                        kind = Kind.REGIONAL,
+                    )
+                )
+            }
+
+            val kind = when {
+                REGIONAL_SUFFIXES.any { host.hasSingleLabelBefore(it) } -> Kind.REGIONAL
+                RESOURCE_SUFFIXES.any { host.hasSingleLabelBefore(it) } -> Kind.RESOURCE
+                else -> return AzureSpeechEndpointResult.Invalid(AzureSpeechEndpointError.UNSUPPORTED_HOST)
+            }
+            return AzureSpeechEndpointResult.Valid(
+                AzureSpeechEndpoint(
+                    persistedValue = "$HTTPS_PREFIX$host",
+                    baseUrl = "$HTTPS_PREFIX$host",
+                    kind = kind,
+                )
+            )
+        }
+
+        private fun parseRegion(value: String): AzureSpeechEndpointResult {
+            val region = value.lowercase()
+            if (!region.isValidDnsLabel()) {
+                return AzureSpeechEndpointResult.Invalid(AzureSpeechEndpointError.INVALID_FORMAT)
+            }
+            val suffix = when (region) {
+                in AZURE_GOVERNMENT_REGIONS -> ".tts.speech.azure.us"
+                in AZURE_CHINA_REGIONS -> ".tts.speech.azure.cn"
+                else -> ".tts.speech.microsoft.com"
+            }
+            return AzureSpeechEndpointResult.Valid(
+                AzureSpeechEndpoint(
+                    persistedValue = region,
+                    baseUrl = "$HTTPS_PREFIX$region$suffix",
+                    kind = Kind.REGIONAL,
+                )
+            )
+        }
+
+        private val REGIONAL_SUFFIXES = setOf(
+            ".tts.speech.microsoft.com",
+            ".tts.speech.azure.us",
+            ".tts.speech.azure.cn",
+        )
+        private val RESOURCE_SUFFIXES = setOf(
+            ".cognitiveservices.azure.com",
+            ".cognitiveservices.azure.us",
+            ".cognitiveservices.azure.cn",
+        )
+        private val GENERIC_REGIONAL_SUFFIXES = mapOf(
+            ".api.cognitive.microsoft.com" to ".tts.speech.microsoft.com",
+            ".api.cognitive.microsoft.us" to ".tts.speech.azure.us",
+            ".api.cognitive.azure.cn" to ".tts.speech.azure.cn",
+        )
+        private val AZURE_GOVERNMENT_REGIONS = setOf("usgovarizona", "usgovvirginia")
+        private val AZURE_CHINA_REGIONS = setOf("chinaeast2", "chinanorth2", "chinanorth3")
+        private val PRINTABLE_ASCII_RANGE = 0x21..0x7e
+        private const val HTTPS_PREFIX = "https://"
+        private const val SCHEME_SEPARATOR = "://"
+        private const val HTTPS_PORT = 443
+    }
+}
+
+enum class AzureSpeechEndpointError {
+    EMPTY,
+    HTTPS_REQUIRED,
+    INVALID_FORMAT,
+    UNEXPECTED_URL_COMPONENT,
+    UNSUPPORTED_HOST,
+}
+
+sealed interface AzureSpeechEndpointResult {
+    data class Valid(val endpoint: AzureSpeechEndpoint) : AzureSpeechEndpointResult
+    data class Invalid(val error: AzureSpeechEndpointError) : AzureSpeechEndpointResult
+}
+
+fun requireAzureSpeechEndpoint(rawValue: String): AzureSpeechEndpoint =
+    when (val result = AzureSpeechEndpoint.parse(rawValue)) {
+        is AzureSpeechEndpointResult.Valid -> result.endpoint
+        is AzureSpeechEndpointResult.Invalid -> throw IllegalArgumentException(
+            "Enter a valid Azure Speech region or official HTTPS endpoint."
+        )
+    }
+
+/** Validates and canonicalizes new configuration before it reaches secure storage. */
+fun SpeechServiceConfig.validatedForStorage(): SpeechServiceConfig {
+    require(subscriptionKey.isNotBlank()) { "Azure subscription key must not be blank" }
+    val endpoint = requireAzureSpeechEndpoint(endpoint)
+    return copy(
+        endpoint = endpoint.persistedValue,
+        subscriptionKey = subscriptionKey.trim(),
+    )
+}
+
+/**
+ * Canonicalizes a readable legacy value without deleting an invalid saved credential.
+ * Invalid legacy endpoints remain visible in settings but are rejected before networking.
+ */
+fun SpeechServiceConfig.normalizedIfValid(): SpeechServiceConfig =
+    when (val result = AzureSpeechEndpoint.parse(endpoint)) {
+        is AzureSpeechEndpointResult.Valid -> copy(endpoint = result.endpoint.persistedValue)
+        is AzureSpeechEndpointResult.Invalid -> this
+    }
+
+private fun String.hasSingleLabelBefore(suffix: String): Boolean {
+    if (!endsWith(suffix)) return false
+    val prefix = removeSuffix(suffix)
+    return prefix.isValidDnsLabel()
+}
+
+private fun String.isValidHostName(): Boolean =
+    length <= 253 && split('.').all(String::isValidDnsLabel)
+
+private fun String.isValidDnsLabel(): Boolean =
+    length in 1..63 &&
+        first().isAsciiLetterOrDigit() &&
+        last().isAsciiLetterOrDigit() &&
+        all { it.isAsciiLetterOrDigit() || it == '-' }
+
+private fun Char.isAsciiLetterOrDigit(): Boolean =
+    this in 'a'..'z' || this in '0'..'9'

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureTtsClient.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureTtsClient.kt
@@ -8,6 +8,8 @@ import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.plugins.HttpRedirect
+import io.ktor.client.plugins.pluginOrNull
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -38,15 +40,9 @@ object AzureTtsClient {
         config: SpeechServiceConfig,
         audioFormat: AudioFormat = AudioFormat.MP3_24KHZ_160KBPS
     ): ByteArray {
-        // The stored config.endpoint may be either a short region (e.g. "westus")
-        // or a full host/URL. Support both forms:
-        val baseUrl = when {
-            config.endpoint.startsWith("http", ignoreCase = true) -> config.endpoint.trimEnd('/')
-            config.endpoint.contains("tts.speech.microsoft.com", ignoreCase = true) || 
-            config.endpoint.contains("cognitiveservices", ignoreCase = true) -> "https://${config.endpoint.trimEnd('/') }"
-            else -> "https://${config.endpoint}.tts.speech.microsoft.com"
-        }
-        val url = "$baseUrl/cognitiveservices/v1"
+        val endpoint = requireAzureSpeechEndpoint(config.endpoint)
+        requireCredentialSafeClient(client)
+        val url = endpoint.synthesisUrl
 
         OperationalLogger.info("azure_tts.synthesize", "started")
 
@@ -567,7 +563,9 @@ object AzureTtsClient {
         region: String,
         audioFormat: AudioFormat = AudioFormat.MP3_24KHZ_160KBPS
     ): ByteArray {
-        val url = "https://$region.tts.speech.microsoft.com/cognitiveservices/v1"
+        val endpoint = requireAzureSpeechEndpoint(region)
+        requireCredentialSafeClient(client)
+        val url = endpoint.synthesisUrl
         
         OperationalLogger.info("azure_tts.token_synthesize", "started")
         
@@ -632,15 +630,9 @@ object AzureTtsClient {
         client: HttpClient, 
         config: SpeechServiceConfig
     ): List<Voice> {
-        // The stored config.endpoint may be either a short region (e.g. "westus")
-        // or a full host/URL. Support both forms:
-        val baseUrl = when {
-            config.endpoint.startsWith("http", ignoreCase = true) -> config.endpoint.trimEnd('/')
-            config.endpoint.contains("tts.speech.microsoft.com", ignoreCase = true) || 
-            config.endpoint.contains("cognitiveservices", ignoreCase = true) -> "https://${config.endpoint.trimEnd('/') }"
-            else -> "https://${config.endpoint}.tts.speech.microsoft.com"
-        }
-        val url = "$baseUrl/cognitiveservices/voices/list"
+        val endpoint = requireAzureSpeechEndpoint(config.endpoint)
+        requireCredentialSafeClient(client)
+        val url = endpoint.voicesUrl
         
         OperationalLogger.info("azure_voice_catalog.fetch", "started")
         
@@ -700,6 +692,17 @@ object AzureTtsClient {
                 pitch = 1.0, 
                 rate = 1.0
             )
+        }
+    }
+
+    /**
+     * Ktor follows GET redirects by default and only strips its standard
+     * Authorization header when the authority changes. Azure's subscription-key
+     * header would otherwise be forwarded to the redirect target.
+     */
+    private fun requireCredentialSafeClient(client: HttpClient) {
+        check(client.pluginOrNull(HttpRedirect) == null) {
+            "Azure credential requests require an HTTP client with redirects disabled"
         }
     }
 }

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/inmemory.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/inmemory.kt
@@ -101,7 +101,7 @@ class InMemoryConfigRepository : ConfigRepository {
     }
     override suspend fun saveSpeechConfig(config: SpeechServiceConfig) {
         delay(10)
-        cfg = config
+        cfg = config.validatedForStorage()
     }
     override suspend fun clearSpeechConfig() {
         delay(10)

--- a/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureSpeechEndpointTest.kt
+++ b/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureSpeechEndpointTest.kt
@@ -1,0 +1,121 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class AzureSpeechEndpointTest {
+    @Test
+    fun publicRegionNormalizesToTheOfficialRegionalAuthority() {
+        val endpoint = valid("NorthEurope")
+
+        assertEquals("northeurope", endpoint.persistedValue)
+        assertEquals("https://northeurope.tts.speech.microsoft.com", endpoint.baseUrl)
+        assertEquals("https://northeurope.tts.speech.microsoft.com/cognitiveservices/v1", endpoint.synthesisUrl)
+        assertEquals(
+            "https://northeurope.tts.speech.microsoft.com/cognitiveservices/voices/list",
+            endpoint.voicesUrl,
+        )
+    }
+
+    @Test
+    fun sovereignRegionsUseTheirDocumentedCloudAuthorities() {
+        assertEquals(
+            "https://usgovvirginia.tts.speech.azure.us",
+            valid("USGovVirginia").baseUrl,
+        )
+        assertEquals(
+            "https://chinanorth3.tts.speech.azure.cn",
+            valid("ChinaNorth3").baseUrl,
+        )
+    }
+
+    @Test
+    fun officialRegionalHostsAreAcceptedWithOrWithoutScheme() {
+        assertEquals(
+            "https://westus2.tts.speech.microsoft.com",
+            valid("https://WestUS2.tts.speech.microsoft.com/").persistedValue,
+        )
+        assertEquals(
+            "https://usgovarizona.tts.speech.azure.us",
+            valid("usgovarizona.tts.speech.azure.us").persistedValue,
+        )
+    }
+
+    @Test
+    fun portalRegionalEndpointsNormalizeToTextToSpeechAuthorities() {
+        assertEquals(
+            "https://northeurope.tts.speech.microsoft.com",
+            valid("https://northeurope.api.cognitive.microsoft.com/").baseUrl,
+        )
+        assertEquals(
+            "https://usgovvirginia.tts.speech.azure.us",
+            valid("https://usgovvirginia.api.cognitive.microsoft.us").baseUrl,
+        )
+        assertEquals(
+            "https://chinanorth3.tts.speech.azure.cn",
+            valid("https://chinanorth3.api.cognitive.azure.cn").baseUrl,
+        )
+    }
+
+    @Test
+    fun resourceEndpointUsesTheResourceSpecificVoiceListPath() {
+        val endpoint = valid("https://my-speech-resource.cognitiveservices.azure.com")
+
+        assertEquals(
+            "https://my-speech-resource.cognitiveservices.azure.com/cognitiveservices/v1",
+            endpoint.synthesisUrl,
+        )
+        assertEquals(
+            "https://my-speech-resource.cognitiveservices.azure.com/tts/cognitiveservices/voices/list",
+            endpoint.voicesUrl,
+        )
+    }
+
+    @Test
+    fun officialResourceHostsForSovereignCloudsAreAccepted() {
+        assertEquals(
+            "https://resource-name.cognitiveservices.azure.us",
+            valid("https://resource-name.cognitiveservices.azure.us").baseUrl,
+        )
+        assertEquals(
+            "https://resource-name.cognitiveservices.azure.cn",
+            valid("https://resource-name.cognitiveservices.azure.cn").baseUrl,
+        )
+    }
+
+    @Test
+    fun arbitraryOrDeceptiveAuthoritiesAreRejected() {
+        listOf(
+            "https://attacker.example",
+            "https://northeurope.tts.speech.microsoft.com.attacker.example",
+            "https://tts.speech.microsoft.com",
+            "https://cognitiveservices.azure.com",
+            "https://resource.cognitiveservices.azure.com@attacker.example",
+            "https://attacker.example/tts.speech.microsoft.com",
+        ).forEach { value ->
+            assertIs<AzureSpeechEndpointResult.Invalid>(AzureSpeechEndpoint.parse(value), value)
+        }
+    }
+
+    @Test
+    fun insecureOrUnexpectedUrlComponentsAreRejected() {
+        listOf(
+            "http://northeurope.tts.speech.microsoft.com",
+            "https://northeurope.tts.speech.microsoft.com:443",
+            "https://northeurope.tts.speech.microsoft.com:444",
+            "https://northeurope.tts.speech.microsoft.com/cognitiveservices/v1",
+            "https://northeurope.tts.speech.microsoft.com?target=attacker",
+            "https://northeurope.tts.speech.microsoft.com#fragment",
+            "https://northeurope.tts.speech.microsoft.com/%2e%2e",
+            "https://north europe.tts.speech.microsoft.com",
+            "javascript:alert(1)",
+            "",
+        ).forEach { value ->
+            assertIs<AzureSpeechEndpointResult.Invalid>(AzureSpeechEndpoint.parse(value), value)
+        }
+    }
+
+    private fun valid(value: String): AzureSpeechEndpoint =
+        assertIs<AzureSpeechEndpointResult.Valid>(AzureSpeechEndpoint.parse(value)).endpoint
+}

--- a/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureTtsClientSecurityTest.kt
+++ b/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/AzureTtsClientSecurityTest.kt
@@ -1,0 +1,152 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AzureTtsClientSecurityTest {
+    @Test
+    fun invalidEndpointIsRejectedBeforeAnyRequest() = runBlocking {
+        var requests = 0
+        val client = HttpClient(MockEngine {
+            requests++
+            respond(ByteArray(1) { 1 })
+        }) {
+            followRedirects = false
+        }
+
+        assertFailsWith<IllegalArgumentException> {
+            AzureTtsClient.synthesize(
+                client = client,
+                ssml = "<speak>test</speak>",
+                config = SpeechServiceConfig("https://attacker.example", "azure-secret"),
+            )
+        }
+
+        assertEquals(0, requests)
+        client.close()
+    }
+
+    @Test
+    fun redirectEnabledClientIsRejectedBeforeAnyRequest() = runBlocking {
+        var requests = 0
+        val client = HttpClient(MockEngine {
+            requests++
+            respond(ByteArray(1) { 1 })
+        })
+
+        assertFailsWith<IllegalStateException> {
+            AzureTtsClient.synthesize(
+                client = client,
+                ssml = "<speak>test</speak>",
+                config = SpeechServiceConfig("northeurope", "azure-secret"),
+            )
+        }
+
+        assertEquals(0, requests)
+        client.close()
+    }
+
+    @Test
+    fun synthesisSendsCredentialOnlyToValidatedRegionalUrl() = runBlocking {
+        var requests = 0
+        val client = HttpClient(MockEngine { request ->
+            requests++
+            assertEquals(
+                "https://northeurope.tts.speech.microsoft.com/cognitiveservices/v1",
+                request.url.toString(),
+            )
+            assertEquals("azure-secret", request.headers[AZURE_SUBSCRIPTION_KEY_HEADER])
+            respond(
+                content = ByteArray(1) { 1 },
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "audio/mpeg"),
+            )
+        }) {
+            followRedirects = false
+        }
+
+        AzureTtsClient.synthesize(
+            client = client,
+            ssml = "<speak>test</speak>",
+            config = SpeechServiceConfig("NorthEurope", "azure-secret"),
+        )
+
+        assertEquals(1, requests)
+        client.close()
+    }
+
+    @Test
+    fun resourceEndpointUsesItsDocumentedVoiceListPath() = runBlocking {
+        val client = HttpClient(MockEngine { request ->
+            assertEquals(
+                "https://my-resource.cognitiveservices.azure.com/tts/cognitiveservices/voices/list",
+                request.url.toString(),
+            )
+            assertEquals("azure-secret", request.headers[AZURE_SUBSCRIPTION_KEY_HEADER])
+            respond(
+                content = "[]",
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }) {
+            followRedirects = false
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+        assertEquals(
+            emptyList(),
+            AzureTtsClient.getVoices(
+                client,
+                SpeechServiceConfig(
+                    "https://my-resource.cognitiveservices.azure.com",
+                    "azure-secret",
+                ),
+            ),
+        )
+        client.close()
+    }
+
+    @Test
+    fun redirectResponseIsNotFollowed() = runBlocking {
+        var requests = 0
+        val client = HttpClient(MockEngine {
+            requests++
+            respond(
+                content = "redirect",
+                status = HttpStatusCode.Found,
+                headers = headersOf(HttpHeaders.Location, "https://attacker.example/collect"),
+            )
+        }) {
+            followRedirects = false
+            install(ContentNegotiation) { json() }
+        }
+
+        assertFailsWith<RuntimeException> {
+            AzureTtsClient.getVoices(
+                client,
+                SpeechServiceConfig("northeurope", "azure-secret"),
+            )
+        }
+
+        assertEquals(1, requests)
+        client.close()
+    }
+
+    private companion object {
+        const val AZURE_SUBSCRIPTION_KEY_HEADER = "Ocp-Apim-Subscription-Key"
+    }
+}

--- a/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/ConfigRepositoryTest.kt
+++ b/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/ConfigRepositoryTest.kt
@@ -28,6 +28,41 @@ class ConfigRepositoryTest {
     }
 
     @Test
+    fun saveCanonicalizesEndpointAndCredential() = runBlocking {
+        val repository = InMemoryConfigRepository()
+
+        repository.saveSpeechConfig(
+            SpeechServiceConfig(
+                endpoint = "  HTTPS://NorthEurope.api.cognitive.microsoft.com/  ",
+                subscriptionKey = "  azure-secret  ",
+            )
+        )
+
+        assertEquals(
+            SpeechServiceConfig(
+                endpoint = "northeurope",
+                subscriptionKey = "azure-secret",
+            ),
+            repository.getSpeechConfig(),
+        )
+    }
+
+    @Test
+    fun saveRejectsUntrustedEndpointWithoutReplacingExistingConfig() = runBlocking {
+        val repository = InMemoryConfigRepository()
+        val existing = SpeechServiceConfig("northeurope", "existing-secret")
+        repository.saveSpeechConfig(existing)
+
+        assertFailsWith<IllegalArgumentException> {
+            repository.saveSpeechConfig(
+                SpeechServiceConfig("https://attacker.example", "new-secret")
+            )
+        }
+
+        assertEquals(existing, repository.getSpeechConfig())
+    }
+
+    @Test
     fun configStringRepresentationRedactsCredential() {
         val rendered = SpeechServiceConfig("northeurope", "azure-secret").toString()
 

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosConfigRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosConfigRepository.kt
@@ -50,7 +50,7 @@ class IosConfigRepository : ConfigRepository {
     private val json = Json { ignoreUnknownKeys = true }
 
     override suspend fun getSpeechConfig(): SpeechServiceConfig? = withContext(Dispatchers.Default) {
-        readKeychain()?.also {
+        readKeychain()?.normalizedIfValid()?.also {
             // Also completes cleanup after a process died between secure write and legacy deletion.
             defaults.removeObjectForKey(LEGACY_KEY)
             defaults.synchronize()
@@ -63,18 +63,19 @@ class IosConfigRepository : ConfigRepository {
             OperationalLogger.warn("speech_config.legacy_decode", "failed")
             return@withContext null
         }
-        migrateLegacySpeechConfig(legacy, ::writeKeychain, ::readKeychain) {
+        val normalizedLegacy = legacy.normalizedIfValid()
+        migrateLegacySpeechConfig(normalizedLegacy, ::writeKeychain, ::readKeychain) {
             defaults.removeObjectForKey(LEGACY_KEY)
             defaults.synchronize()
         }
         OperationalLogger.info("speech_config.migrate", "succeeded")
-        legacy
+        normalizedLegacy
     }
 
     override suspend fun saveSpeechConfig(config: SpeechServiceConfig) = withContext(Dispatchers.Default) {
-        require(config.subscriptionKey.isNotBlank()) { "Azure subscription key must not be blank" }
-        writeKeychain(config)
-        check(readKeychain() == config) { "Secure Azure credential write could not be verified" }
+        val normalized = config.validatedForStorage()
+        writeKeychain(normalized)
+        check(readKeychain() == normalized) { "Secure Azure credential write could not be verified" }
         defaults.removeObjectForKey(LEGACY_KEY)
         defaults.synchronize()
         OperationalLogger.info("speech_config.save", "succeeded", enabled = true)

--- a/feature/communication/data/build.gradle.kts
+++ b/feature/communication/data/build.gradle.kts
@@ -22,6 +22,7 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation(project(":core:domain"))
+                implementation(project(":core:data"))
                 implementation(project(":feature:communication:domain"))
                 implementation(libs.koin.core)
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")

--- a/feature/communication/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/azure.kt
+++ b/feature/communication/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/azure.kt
@@ -5,28 +5,15 @@ import io.github.jdreioe.wingmate.domain.ConfigRepository
 import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.ktor.client.*
-import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.*
-import io.ktor.client.request.*
-import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
 class AzureVoiceCatalog(private val configRepo: ConfigRepository) {
     private val client = HttpClient {
+        followRedirects = false
         install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
     }
-
-    @Serializable
-    private data class AzureVoice(
-        @SerialName("DisplayName") val displayName: String? = null,
-        @SerialName("ShortName") val shortName: String? = null,
-        @SerialName("Gender") val gender: String? = null,
-        @SerialName("Locale") val locale: String? = null,
-        @SerialName("SecondaryLocaleList") val secondary: List<String>? = null,
-    )
 
     suspend fun list(): List<Voice> {
         return try {
@@ -34,30 +21,11 @@ class AzureVoiceCatalog(private val configRepo: ConfigRepository) {
                 OperationalLogger.debug("azure_voice_catalog.load", "config_missing")
                 return emptyList()
             }
-            val endpoint = cfg.endpoint.trim()
-            val key = cfg.subscriptionKey.trim()
-            if (endpoint.isEmpty() || key.isEmpty()) {
+            if (cfg.endpoint.isBlank() || cfg.subscriptionKey.isBlank()) {
                 OperationalLogger.warn("azure_voice_catalog.load", "config_incomplete")
                 return emptyList()
             }
-            val host = endpoint.removePrefix("https://").removePrefix("http://").removeSuffix("/")
-            val url = "https://$host.tts.speech.microsoft.com/cognitiveservices/voices/list"
-
-            val res: List<AzureVoice> = client.get(url) {
-                header("Ocp-Apim-Subscription-Key", key)
-                header(HttpHeaders.UserAgent, "Wingmate 1.0")
-            }.body()
-
-            res.map {
-                Voice(
-                    name = it.shortName,
-                    displayName = it.displayName,
-                    gender = it.gender,
-                    primaryLanguage = it.locale,
-                    supportedLanguages = it.secondary ?: emptyList(),
-                    selectedLanguage = it.locale ?: "",
-                )
-            }
+            AzureTtsClient.getVoices(client, cfg)
         } catch (t: Throwable) {
             OperationalLogger.warn(
                 operation = "azure_voice_catalog.load",

--- a/iosApp/iosApp/Base.lproj/Localizable.strings
+++ b/iosApp/iosApp/Base.lproj/Localizable.strings
@@ -396,7 +396,7 @@
 "azure_setup.save_continue" = "Save & Continue";
 "azure_setup.complete.title" = "Azure Connected!";
 "azure_setup.complete.desc" = "Your Azure Speech credentials have been saved securely on this device.";
-"azure_setup.error.endpoint" = "Please enter the Speech endpoint or region.";
+"azure_setup.error.endpoint" = "Enter a valid Azure Speech region or official HTTPS endpoint.";
 "azure_setup.error.key" = "Please enter a Speech subscription key.";
 "azure_setup.error.save" = "Failed to save Azure credentials: %@";
 

--- a/iosApp/iosApp/Sheets/Sheets.swift
+++ b/iosApp/iosApp/Sheets/Sheets.swift
@@ -1164,11 +1164,16 @@ struct AzureSettingsSheet: View {
                     Section {
                         Button(saving ? "common.saving" : "common.save") {
                             Task {
+                                let trimmedEndpoint = endpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+                                guard bridge.isValidAzureSpeechEndpoint(endpoint: trimmedEndpoint) else {
+                                    self.error = NSLocalizedString("azure_setup.error.endpoint", comment: "")
+                                    return
+                                }
                                 saving = true
                                 defer { saving = false }
 
                                 do {
-                                    let cfg = Shared.SpeechServiceConfig(endpoint: endpoint.trimmingCharacters(in: .whitespacesAndNewlines),
+                                    let cfg = Shared.SpeechServiceConfig(endpoint: trimmedEndpoint,
                                                                          subscriptionKey: key.trimmingCharacters(in: .whitespacesAndNewlines))
                                     try await bridge.saveSpeechConfig(config: cfg)
                                     _ = try? await bridge.listVoices()

--- a/iosApp/iosApp/Views/F0SetupView.swift
+++ b/iosApp/iosApp/Views/F0SetupView.swift
@@ -318,6 +318,10 @@ struct F0SetupView: View {
             saveError = NSLocalizedString("azure_setup.error.endpoint", comment: "")
             return
         }
+        guard bridge.isValidAzureSpeechEndpoint(endpoint: ep) else {
+            saveError = NSLocalizedString("azure_setup.error.endpoint", comment: "")
+            return
+        }
         guard !key.isEmpty else {
             saveError = NSLocalizedString("azure_setup.error.key", comment: "")
             return

--- a/iosApp/iosApp/da.lproj/Localizable.strings
+++ b/iosApp/iosApp/da.lproj/Localizable.strings
@@ -329,7 +329,7 @@
 "azure_setup.save_continue" = "Gem og fortsæt";
 "azure_setup.complete.title" = "Sådan!";
 "azure_setup.complete.desc" = "Dine Azure Speech-oplysninger er gemt sikkert på denne enhed.";
-"azure_setup.error.endpoint" = "Indtast Speech-endpointet eller regionen.";
+"azure_setup.error.endpoint" = "Indtast en gyldig Azure Speech-region eller et officielt HTTPS-endpoint.";
 "azure_setup.error.key" = "Indtast en Speech-abonnementsnøgle.";
 "azure_setup.error.save" = "Azure-oplysningerne kunne ikke gemmes: %@";
 

--- a/iosApp/iosApp/de.lproj/Localizable.strings
+++ b/iosApp/iosApp/de.lproj/Localizable.strings
@@ -326,7 +326,7 @@
 "azure_setup.save_continue" = "Speichern und weiter";
 "azure_setup.complete.title" = "Alles eingerichtet!";
 "azure_setup.complete.desc" = "Deine Azure Speech-Zugangsdaten wurden sicher auf diesem Gerät gespeichert.";
-"azure_setup.error.endpoint" = "Gib den Speech-Endpunkt oder die Region ein.";
+"azure_setup.error.endpoint" = "Gib eine gültige Azure-Speech-Region oder einen offiziellen HTTPS-Endpunkt ein.";
 "azure_setup.error.key" = "Gib einen Speech-Abonnementschlüssel ein.";
 "azure_setup.error.save" = "Azure-Zugangsdaten konnten nicht gespeichert werden: %@";
 

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/AzureConfigManager.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/AzureConfigManager.kt
@@ -6,6 +6,7 @@ import org.koin.core.context.GlobalContext
 
 import io.github.jdreioe.wingmate.domain.VoiceRepository
 import io.github.jdreioe.wingmate.infrastructure.AzureTtsClient
+import io.github.jdreioe.wingmate.infrastructure.validatedForStorage
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
@@ -24,16 +25,18 @@ class AzureConfigManager {
         return configRepository.getSpeechConfig() ?: SpeechServiceConfig()
     }
     
-    suspend fun updateConfig(endpoint: String, key: String) {
+    suspend fun updateConfig(endpoint: String, key: String): SpeechServiceConfig {
         val newConfig = SpeechServiceConfig(
             endpoint = endpoint,
             subscriptionKey = key
-        )
+        ).validatedForStorage()
         configRepository.saveSpeechConfig(newConfig)
+        return newConfig
     }
     
     suspend fun fetchAndSaveVoices(config: SpeechServiceConfig) {
         val client = HttpClient {
+            followRedirects = false
             install(ContentNegotiation) {
                 json(Json { 
                     ignoreUnknownKeys = true 

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/AzureSpeechService.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/AzureSpeechService.kt
@@ -17,7 +17,9 @@ class AzureSpeechService(
 ) : SpeechService {
     
     // Uses default engine (should be OkHttp from shared dependency)
-    private val client = HttpClient()
+    private val client = HttpClient {
+        followRedirects = false
+    }
     @Volatile
     private var currentProcess: Process? = null
     @Volatile

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/JsonRepositories.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/JsonRepositories.kt
@@ -3,6 +3,8 @@ package io.github.jdreioe.wingmate.kde
 import io.github.jdreioe.wingmate.domain.*
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
 import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
+import io.github.jdreioe.wingmate.infrastructure.normalizedIfValid
+import io.github.jdreioe.wingmate.infrastructure.validatedForStorage
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.coroutines.Dispatchers
@@ -73,7 +75,7 @@ class JsonFileConfigRepository : ConfigRepository {
             // secure storage. This avoids silently selecting an older keyring
             // value if an earlier migration was interrupted or mismatched.
             if (file.exists()) {
-                val legacy = decode(file.readText())
+                val legacy = decode(file.readText()).normalizedIfValid()
                 secureStore.write(json.encodeToString(legacy))
                 val stored = secureStore.readAfterWrite()?.let(::decode)
                 check(stored == legacy) {
@@ -86,19 +88,19 @@ class JsonFileConfigRepository : ConfigRepository {
                 println("[PERSISTENCE] Migrated Azure speech configuration to the desktop keyring.")
                 return@withContext legacy
             }
-            secureStore.read()?.let(::decode)
+            secureStore.read()?.let(::decode)?.normalizedIfValid()
         }
     }
 
     override suspend fun saveSpeechConfig(config: SpeechServiceConfig) = mutex.withLock {
         withContext(Dispatchers.IO) {
-            require(config.subscriptionKey.isNotBlank()) { "Azure subscription key must not be blank" }
-            secureStore.write(json.encodeToString(config))
+            val normalized = config.validatedForStorage()
+            secureStore.write(json.encodeToString(normalized))
             val stored = secureStore.readAfterWrite()?.let(::decode)
-            check(stored == config) {
+            check(stored == normalized) {
                 "Secure Azure credential write could not be verified " +
-                    "(stored=${stored != null}, endpointMatches=${stored?.endpoint == config.endpoint}, " +
-                    "credentialMatches=${stored?.subscriptionKey == config.subscriptionKey})"
+                    "(stored=${stored != null}, endpointMatches=${stored?.endpoint == normalized.endpoint}, " +
+                    "credentialMatches=${stored?.subscriptionKey == normalized.subscriptionKey})"
             }
             check(file.delete() || !file.exists()) { "Could not delete legacy plaintext Azure configuration" }
             println("[PERSISTENCE] Saved Azure speech configuration securely; credentialConfigured=true")

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -530,16 +530,21 @@ class KotlinBridge(private val port: Int = 8765) {
                 val params = call.receive<Map<String, String>>()
                 val endpoint = params["endpoint"] ?: ""
                 val key = params["key"] ?: ""
-                azureConfigManager.updateConfig(endpoint, key)
-                
                 try {
-                    // Sync fetch voices
-                    azureConfigManager.fetchAndSaveVoices(SpeechServiceConfig(endpoint, key))
-                } catch (e: Exception) {
-                    println("Failed to fetch voices: ${e.message}")
+                    val normalizedConfig = azureConfigManager.updateConfig(endpoint, key)
+                    try {
+                        // Voice refresh is best-effort after the validated credential is saved.
+                        azureConfigManager.fetchAndSaveVoices(normalizedConfig)
+                    } catch (e: Exception) {
+                        println("Failed to fetch voices (${e::class.simpleName})")
+                    }
+                    call.respond(HttpStatusCode.OK)
+                } catch (_: IllegalArgumentException) {
+                    call.respondText(
+                        text = "Enter a valid Azure Speech region or official HTTPS endpoint.",
+                        status = HttpStatusCode.BadRequest,
+                    )
                 }
-                
-                call.respond(HttpStatusCode.OK)
             }
 
             delete("/api/azure-config") {

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
@@ -69,6 +69,8 @@ import io.github.jdreioe.wingmate.infrastructure.OpenSymbolsClient
 import io.github.jdreioe.wingmate.infrastructure.SymbolSearchClient
 import io.github.jdreioe.wingmate.infrastructure.QuickCorePresetService
 import io.github.jdreioe.wingmate.infrastructure.BoardImportResult
+import io.github.jdreioe.wingmate.infrastructure.AzureSpeechEndpoint
+import io.github.jdreioe.wingmate.infrastructure.AzureSpeechEndpointResult
 import kotlin.time.Clock
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
@@ -353,6 +355,9 @@ class KoinBridge : KoinComponent {
     suspend fun saveSpeechConfig(config: SpeechServiceConfig) {
         get<ConfigRepository>().saveSpeechConfig(config)
     }
+
+    fun isValidAzureSpeechEndpoint(endpoint: String): Boolean =
+        AzureSpeechEndpoint.parse(endpoint) is AzureSpeechEndpointResult.Valid
 
     suspend fun clearSpeechConfig() {
         get<ConfigRepository>().clearSpeechConfig()

--- a/shared/src/iosMain/kotlin/io/github/jdreioe/wingmate/IosDi.kt
+++ b/shared/src/iosMain/kotlin/io/github/jdreioe/wingmate/IosDi.kt
@@ -55,6 +55,7 @@ fun overrideIosSpeechService() {
             // Ktor client for iOS (Darwin engine)
             single<HttpClient> {
                 HttpClient(Darwin) {
+                    followRedirects = false
                     install(ContentNegotiation) {
                         json(Json { ignoreUnknownKeys = true })
                     }


### PR DESCRIPTION
## Summary

- Validate and canonicalize Azure Speech regions and official HTTPS endpoints.
- Prevent credential-bearing requests from following redirects.
- Reject invalid endpoints before storage or network requests.
- Add endpoint, client-security, and configuration repository coverage.
- Surface endpoint validation errors in Android setup and settings UI.

## Testing

- Added common tests for endpoint parsing, normalization, rejection, redirect handling, and credential safety.
- Added configuration repository tests for canonicalization and invalid endpoint rejection.
- Not run in this change request.