### PR TITLE
Fix iOS file storage failures and dictionary cache handling

### DIFF
--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/DictionaryLoader.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/DictionaryLoader.kt
@@ -1,6 +1,7 @@
 package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.OperationalLogger
+import io.github.jdreioe.wingmate.domain.loggingClassName
 import io.ktor.client.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -14,9 +15,12 @@ class DictionaryLoadException : Exception("Dictionary could not be loaded")
  * Loads language dictionaries from the AOSP dictionaries repository on Codeberg.
  * These are used to pretrain the N-Gram model with common words for a language.
  */
-class DictionaryLoader(private val fileStorage: io.github.jdreioe.wingmate.domain.FileStorage? = null) {
+class DictionaryLoader(
+    private val fileStorage: io.github.jdreioe.wingmate.domain.FileStorage? = null,
+    httpClient: HttpClient? = null,
+) {
     private val httpClient by lazy {
-        HttpClient {
+        httpClient ?: HttpClient {
             followRedirects = true
         }
     }
@@ -84,8 +88,18 @@ class DictionaryLoader(private val fileStorage: io.github.jdreioe.wingmate.domai
                     // Save to disk cache
                     if (fileStorage != null) {
                         val fileName = "$baseName.combined"
-                        fileStorage.save(fileName, responseText)
-                        OperationalLogger.debug("dictionary.cache", "write_succeeded", count = words.size)
+                        try {
+                            fileStorage.save(fileName, responseText)
+                            OperationalLogger.debug("dictionary.cache", "write_succeeded", count = words.size)
+                        } catch (failure: CancellationException) {
+                            throw failure
+                        } catch (failure: Exception) {
+                            OperationalLogger.warn(
+                                "dictionary.cache",
+                                "write_failed",
+                                exceptionClass = failure.loggingClassName(),
+                            )
+                        }
                     }
                 }
                 words

--- a/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/DictionaryLoaderTest.kt
+++ b/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/DictionaryLoaderTest.kt
@@ -1,0 +1,32 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.domain.FileStorage
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DictionaryLoaderTest {
+    @Test
+    fun cacheWriteFailure_doesNotFailNetworkLoad() = runBlocking {
+        val storage = object : FileStorage by InMemoryFileStorage() {
+            override suspend fun save(fileName: String, content: String) {
+                throw RuntimeException("cache is full")
+            }
+        }
+        val client = HttpClient(MockEngine {
+            respond(
+                content = "word=hello,f=215,flags=,originalFreq=215",
+                status = HttpStatusCode.OK,
+            )
+        })
+        val loader = DictionaryLoader(storage, client)
+
+        val result = loader.loadDictionary("en-US")
+
+        assertEquals(listOf("hello" to 215), result)
+    }
+}

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosFileStorage.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosFileStorage.kt
@@ -1,6 +1,8 @@
 package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.FileStorage
+import io.github.jdreioe.wingmate.domain.FileStorageWriteException
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
@@ -11,26 +13,16 @@ import platform.Foundation.NSString
 import platform.Foundation.NSUTF8StringEncoding
 import platform.Foundation.NSUserDomainMask
 import platform.Foundation.create
-import platform.Foundation.dataUsingEncoding
 import platform.Foundation.dataWithContentsOfFile
 import platform.Foundation.writeToFile
 import platform.posix.memcpy
 
-@OptIn(ExperimentalForeignApi::class)
-class IosFileStorage : FileStorage {
-    private val root: String by lazy {
-        val urls = NSFileManager.defaultManager.URLsForDirectory(
-            directory = NSDocumentDirectory,
-            inDomains = NSUserDomainMask
-        )
-        (urls.firstOrNull() as? platform.Foundation.NSURL)?.path ?: ""
-    }
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+class IosFileStorage internal constructor(private val root: String) : FileStorage {
+    constructor() : this(documentsDirectory())
 
     override suspend fun save(fileName: String, content: String) {
-        val path = resolve(fileName)
-        ensureParent(path)
-        val data = (content as NSString).dataUsingEncoding(NSUTF8StringEncoding) ?: return
-        data.writeToFile(path, atomically = true)
+        saveBytes(fileName, content.encodeToByteArray())
     }
 
     override suspend fun load(fileName: String): String? {
@@ -42,10 +34,16 @@ class IosFileStorage : FileStorage {
     override suspend fun saveBytes(fileName: String, content: ByteArray) {
         val path = resolve(fileName)
         ensureParent(path)
-        val data = content.usePinned { pinned ->
-            NSData.create(bytes = pinned.addressOf(0), length = content.size.toULong())
+        val data = if (content.isEmpty()) {
+            NSData.create(bytes = null, length = 0u)
+        } else {
+            content.usePinned { pinned ->
+                NSData.create(bytes = pinned.addressOf(0), length = content.size.toULong())
+            }
         }
-        data.writeToFile(path, atomically = true)
+        if (!data.writeToFile(path, atomically = true)) {
+            throw FileStorageWriteException()
+        }
     }
 
     override suspend fun loadBytes(fileName: String): ByteArray? {
@@ -78,13 +76,25 @@ class IosFileStorage : FileStorage {
 
     private fun ensureParent(path: String) {
         val parent = path.substringBeforeLast('/', missingDelimiterValue = "")
-        if (parent.isNotBlank()) {
-            NSFileManager.defaultManager.createDirectoryAtPath(
-                path = parent,
-                withIntermediateDirectories = true,
-                attributes = null,
-                error = null
+        if (parent.isBlank()) return
+        val created = NSFileManager.defaultManager.createDirectoryAtPath(
+            path = parent,
+            withIntermediateDirectories = true,
+            attributes = null,
+            error = null
+        )
+        if (!created) {
+            throw FileStorageWriteException()
+        }
+    }
+
+    companion object {
+        private fun documentsDirectory(): String {
+            val urls = NSFileManager.defaultManager.URLsForDirectory(
+                directory = NSDocumentDirectory,
+                inDomains = NSUserDomainMask
             )
+            return (urls.firstOrNull() as? platform.Foundation.NSURL)?.path ?: ""
         }
     }
 }

--- a/core/data/src/iosTest/kotlin/io/github/jdreioe/wingmate/infrastructure/IosFileStorageTest.kt
+++ b/core/data/src/iosTest/kotlin/io/github/jdreioe/wingmate/infrastructure/IosFileStorageTest.kt
@@ -1,0 +1,67 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.domain.FileStorageWriteException
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.runBlocking
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSUUID
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalForeignApi::class)
+class IosFileStorageTest {
+    private val root = "${NSTemporaryDirectory()}Wingmate-IosFileStorage-${NSUUID.UUID().UUIDString}"
+    private val storage = IosFileStorage(root)
+
+    @AfterTest
+    fun cleanUp() {
+        NSFileManager.defaultManager.removeItemAtPath(root, error = null)
+    }
+
+    @Test
+    fun textRoundTripsUnicodeEmptyContentAndOverwrite() = runBlocking {
+        val fileName = "nested/dictionary.txt"
+        val unicode = "Hej 👋 — 漢字"
+
+        storage.save(fileName, unicode)
+        assertEquals(unicode, storage.load(fileName))
+
+        storage.save(fileName, "")
+        assertEquals("", storage.load(fileName))
+    }
+
+    @Test
+    fun bytesRoundTripEmptyContentAndDelete() = runBlocking {
+        val fileName = "nested/media.bin"
+        val bytes = byteArrayOf(0, 1, 127, -1)
+
+        storage.saveBytes(fileName, bytes)
+        assertContentEquals(bytes, storage.loadBytes(fileName))
+        assertTrue(storage.exists(fileName))
+
+        storage.saveBytes(fileName, byteArrayOf())
+        assertContentEquals(byteArrayOf(), storage.loadBytes(fileName))
+
+        storage.delete(fileName)
+        assertFalse(storage.exists(fileName))
+    }
+
+    @Test
+    fun unwritableDestinationThrowsTypedFailure() = runBlocking {
+        val unwritableStorage = IosFileStorage("/dev")
+
+        assertFailsWith<FileStorageWriteException> {
+            unwritableStorage.save("wingmate-unwritable.txt", "content")
+        }
+
+        assertFailsWith<FileStorageWriteException> {
+            unwritableStorage.saveBytes("wingmate-unwritable.bin", byteArrayOf(1))
+        }
+    }
+}

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/FileStorage.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/FileStorage.kt
@@ -1,5 +1,8 @@
 package io.github.jdreioe.wingmate.domain
 
+/** Raised when app-private storage cannot persist a file. */
+class FileStorageWriteException : Exception("File could not be written")
+
 /**
  * Platform-agnostic interface for reading and writing files to app-private storage.
  */


### PR DESCRIPTION
## Summary

- Make iOS file writes report typed failures when directory creation or persistence fails.
- Support empty file content and reliable byte-array round trips on iOS.
- Keep dictionary loading successful when writing the disk cache fails.
- Add iOS storage and dictionary cache failure tests.

## Testing

- Added common test covering dictionary loading when cache writes fail.
- Added iOS tests for Unicode, empty content, overwrites, byte round trips, deletion, and unwritable destinations.
- Not run: full Gradle test suite.