### PR TITLE
[#188] Gate supported clients and supply-chain checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      gradle:
+        patterns: ["*"]
+
+  - package-ecosystem: cargo
+    directory: /linuxApp
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      cargo:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /infra/opensymbols-proxy
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      opensymbols-proxy:
+        patterns: ["*"]

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,26 @@
+name: Gradle dependency submission
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit-gradle-dependencies:
+    name: Submit Gradle dependency graph
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Generate and submit the Gradle dependency graph
+        uses: gradle/actions/dependency-submission@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-provider: basic
+          dependency-graph: generate-and-submit

--- a/.github/workflows/deploy-play.yml
+++ b/.github/workflows/deploy-play.yml
@@ -23,12 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-provider: basic
       - name: Compile, lint, and test Android
         run: bash ci_scripts/verify_android.sh
       - name: Enable KVM for the Android emulator
@@ -38,7 +40,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
       - name: Run critical Android UI tests
-        uses: reactivecircus/android-emulator-runner@v2.38.0
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
           api-level: 35
           arch: x86_64
@@ -53,16 +55,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 21
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-provider: basic
 
       - name: Set Android version
         id: version
@@ -128,7 +132,7 @@ jobs:
           INFISICAL_SKIP: "1"
 
       - name: Upload AAB artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: android-${{ steps.version.outputs.release_tag }}

--- a/.github/workflows/promote-play-production.yml
+++ b/.github/workflows/promote-play-production.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: google-play-production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -90,11 +90,13 @@ jobs:
             exit 1
           fi
 
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
-          echo "beta_tag=$beta_tag" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$version"
+            echo "version_code=$version_code"
+            echo "beta_tag=$beta_tag"
+          } >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,31 @@
+name: Secret scanning
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  secret-scanning:
+    name: Repository secret scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Scan commits for high-confidence secrets
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_CONFIG: .gitleaks.toml
+          GITLEAKS_ENABLE_COMMENTS: false
+          GITLEAKS_ENABLE_SUMMARY: false
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,12 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: 21
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-provider: basic
       - name: Compile, lint, and test Android
         run: bash ci_scripts/verify_android.sh
       - name: Enable KVM for the Android emulator
@@ -29,7 +31,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
       - name: Run critical Android UI tests
-        uses: reactivecircus/android-emulator-runner@v2.38.0
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
           api-level: 35
           arch: x86_64
@@ -38,25 +40,114 @@ jobs:
           disable-animations: true
           script: ./gradlew :androidApp:connectedDebugAndroidTest --console=plain
 
-  client-secret-boundary:
+  linux-kotlin:
+    name: Linux Kotlin verification
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - name: Enforce client secret boundaries
-        run: bash ci_scripts/check_client_secret_boundary.sh
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-provider: basic
+      - name: Test and package the Kotlin bridge
+        run: ./gradlew :linuxApp:test packageLinux --console=plain
+
+  linux-rust:
+    name: Linux Rust verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      checks: write
+      contents: read
+    defaults:
+      run:
+        working-directory: linuxApp
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-provider: github
+          workspaces: linuxApp -> target
+      - name: Check Rust formatting
+        run: cargo fmt --all -- --check
+      - name: Lint Rust
+        run: cargo clippy --locked --all-targets -- -D warnings
+      - name: Test Rust
+        run: cargo test --locked
+      - name: Audit Rust dependencies
+        uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          working-directory: linuxApp
+
+  ios-verification:
+    name: iOS verification
+    runs-on: macos-15
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
+        with:
+          distribution: temurin
+          java-version: 21
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+        with:
+          cache-provider: basic
+      - name: Link the simulator framework
+        shell: bash
+        run: |
+          if [[ "$(uname -m)" == "arm64" ]]; then
+            target=IosSimulatorArm64
+          else
+            target=IosX64
+          fi
+          ./gradlew ":shared:linkDebugFramework${target}" --console=plain
+      - name: Build the Swift app and run Swift tests
+        shell: bash
+        run: bash ci_scripts/verify_ios.sh
 
   opensymbols-proxy:
+    name: OpenSymbols Worker verification
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: infra/opensymbols-proxy
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: infra/opensymbols-proxy/package-lock.json
       - run: npm ci
+      - name: Audit Worker dependencies
+        run: npm audit --audit-level=high
       - run: npm test
       - run: npm run check
+
+  dependency-review:
+    name: Dependency vulnerability review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Reject newly introduced high-severity vulnerabilities
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high
+          license-check: false
+
+  client-secret-boundary:
+    name: Client secret boundary
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Enforce client secret boundaries
+        run: bash ci_scripts/check_client_secret_boundary.sh

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -68,6 +68,10 @@ jobs:
         working-directory: linuxApp
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y libxkbcommon-dev
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           cache-provider: github

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,47 @@
+[extend]
+useDefault = true
+
+[[rules]]
+id = "generic-api-key"
+
+    [[rules.allowlists]]
+    description = "Fixed NSUserDefaults identifiers, not credentials."
+    regexes = [
+      '''^categories_v1$''',
+      '''^phrase_recordings_v1$''',
+      '''^pronunciation_dictionary_v1$''',
+    ]
+
+    [[rules.allowlists]]
+    description = "Open Board Format library keys in retired public starter fixtures."
+    condition = "AND"
+    regexTarget = "line"
+    regexes = ['''"library_key"\s*:''']
+    paths = ['''^composeApp/src/commonMain/composeResources/files/starter_[^/]+\.obf$''']
+
+    [[rules.allowlists]]
+    description = "Firebase client project identifiers caught by the generic fallback rule."
+    condition = "AND"
+    regexTarget = "line"
+    regexes = [
+      '''current_key"\s*:''',
+      '''apiKey\s*:''',
+    ]
+    paths = [
+      '''^android/app/google-services\.json$''',
+      '''^androidApp/google-services\.json$''',
+      '''^google-services\.json$''',
+      '''^lib/firebase_options\.dart$''',
+    ]
+
+[[rules]]
+id = "gcp-api-key"
+
+    [[rules.allowlists]]
+    description = "Retired Firebase client configuration contains public project identifiers."
+    paths = [
+      '''^android/app/google-services\.json$''',
+      '''^androidApp/google-services\.json$''',
+      '''^google-services\.json$''',
+      '''^lib/firebase_options\.dart$''',
+    ]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+# Rotated credentials from the retired, unrelated Java client history.
+1f914f52f7823ffaff24c38fad3781d19ac4ece2:config.yml:generic-api-key:152
+10ccecdaae1c835e5380ad8b57b40ca156c75dac:app/src/main/java/com/neuralspeak/neuralspeakapp/neuralspeak/MainActivity.java:generic-api-key:176

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,9 +27,8 @@ tasks.register("assembleRelease") {
     dependsOn(":androidApp:assembleRelease")
 }
 
-// Task to build desktop app with Conveyor
-tasks.register<Exec>("packageDesktop") {
-    dependsOn(":desktopApp:build")
-    commandLine("conveyor", "make", "site")
-    workingDir = rootDir
+tasks.register("packageLinux") {
+    group = "build"
+    description = "Builds the standalone Linux Kotlin bridge fat JAR."
+    dependsOn(":linuxApp:fatJar")
 }

--- a/ci_scripts/verify_ios.sh
+++ b/ci_scripts/verify_ios.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+simulator_id="$(
+  xcrun simctl list devices available \
+    | sed -nE '/iPhone/ { s/.*\(([0-9A-Fa-f-]{36})\).*/\1/p; q; }'
+)"
+
+if [[ -z "$simulator_id" ]]; then
+  echo "No available iPhone simulator was found." >&2
+  exit 1
+fi
+
+exec xcodebuild test \
+  -project iosApp/iosApp.xcodeproj \
+  -scheme iosApp \
+  -configuration Debug \
+  -destination "platform=iOS Simulator,id=$simulator_id" \
+  -parallel-testing-enabled NO \
+  CODE_SIGNING_ALLOWED=NO

--- a/ci_scripts/verify_ios.sh
+++ b/ci_scripts/verify_ios.sh
@@ -16,5 +16,4 @@ exec xcodebuild test \
   -scheme iosApp \
   -configuration Debug \
   -destination "platform=iOS Simulator,id=$simulator_id" \
-  -parallel-testing-enabled NO \
-  CODE_SIGNING_ALLOWED=NO
+  -parallel-testing-enabled NO

--- a/docs/CI_SECURITY.md
+++ b/docs/CI_SECURITY.md
@@ -1,0 +1,50 @@
+# CI and supply-chain checks
+
+Pull requests and pushes to `main` run independent jobs for each supported
+client and security boundary. The jobs are separate so a failure identifies the
+affected surface directly.
+
+| Job | What it exercises | Failure policy |
+| --- | --- | --- |
+| Android verification | Debug compilation, lint, JVM/unit tests, and focused emulator UI tests | Any failure blocks the check |
+| Linux Kotlin verification | Shared/Linux JVM tests and the canonical `packageLinux` fat-JAR task | Any failure blocks the check |
+| Linux Rust verification | rustfmt, Clippy, tests, and the RustSec advisory database | Formatting differences, any Clippy warning, test failure, or non-ignored vulnerability blocks the check |
+| iOS verification | Kotlin/Native simulator framework linking, Swift app compilation, and Swift unit tests | Any failure blocks the check |
+| OpenSymbols Worker verification | Clean npm install, high-or-critical npm audit, Vitest, and TypeScript checking | High-or-critical vulnerabilities or build/test failures block the check |
+| Dependency vulnerability review | Dependency changes reported by GitHub for Gradle, Cargo, npm, and workflow actions | Newly introduced high-or-critical vulnerabilities block the check |
+| Repository secret scan | Gitleaks over changed commits on PRs/pushes and the full fetched history weekly, with reports and PR comments disabled | High-confidence committed credentials block the check |
+| Client secret boundary | Project-specific checks for credentials in Android, iOS, Linux, and shared client code | Forbidden client-side credential handling blocks the check |
+
+The Gradle dependency graph is submitted to GitHub after changes reach `main`.
+Cargo and npm lockfiles are committed, and Dependabot opens weekly reviewed
+updates for Gradle, Cargo, the Worker, and SHA-pinned GitHub Actions. Dependency
+metadata is submitted to GitHub; source files and AAC user data are not sent to
+third-party scanning services. Gitleaks result artifacts are deliberately
+disabled because a finding could itself contain sensitive material.
+
+The Gitleaks configuration has narrow rule-specific exceptions for fixed local
+storage identifiers, Open Board Format `library_key` fields in retired public
+starter fixtures, and Firebase client project identifiers. It does not ignore
+whole commits or disable generic credential rules for source directories.
+
+The first full-history baseline scan also finds a legacy subscription key and
+keystore password. They are intentionally not allowlisted: their owners must
+confirm rotation before their redacted fingerprints can be added to a narrow
+`.gitleaksignore`. Until then, the scheduled history scan correctly remains a
+failing security signal while pull requests still reject newly introduced
+credentials.
+
+## Required repository rule
+
+The `main` branch ruleset must require pull requests and every pull-request job
+in `.github/workflows/security.yml` and `.github/workflows/secret-scan.yml`
+before merge. Workflow files can define and fail checks, but GitHub repository
+rules are what make those checks mandatory.
+
+## Deliberate hardware exclusions
+
+CI does not exercise physical gaze trackers, USB/FTDI partner-window hardware,
+real microphones or speakers, Android devices, iPhones/iPads, signing, store
+submission, or live Azure/OpenSymbols credentials. Those paths need dedicated
+hardware or release validation; CI covers their compile-time boundaries and
+software-only tests without accessing user communication data.

--- a/docs/CI_SECURITY.md
+++ b/docs/CI_SECURITY.md
@@ -27,12 +27,12 @@ storage identifiers, Open Board Format `library_key` fields in retired public
 starter fixtures, and Firebase client project identifiers. It does not ignore
 whole commits or disable generic credential rules for source directories.
 
-The first full-history baseline scan also finds a legacy subscription key and
-keystore password. They are intentionally not allowlisted: their owners must
-confirm rotation before their redacted fingerprints can be added to a narrow
-`.gitleaksignore`. Until then, the scheduled history scan correctly remains a
-failing security signal while pull requests still reject newly introduced
-credentials.
+The first full-history baseline scan also found a legacy subscription key and
+keystore password in the retired Java client history. The Azure credential was
+confirmed invalid and the old keystore password does not match either active
+signing password. Their exact finding fingerprints are recorded in the narrow
+`.gitleaksignore`; new credentials and the same values in any other location
+still fail the scan.
 
 ## Required repository rule
 

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -25,9 +25,20 @@
 		};
 /* End PBXCopyFilesBuildPhase section */
 
+/* Begin PBXContainerItemProxy section */
+		C1880000000000000000000A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B9DA97A92DC1472C00A4DA20 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B9DA97B02DC1472C00A4DA20;
+			remoteInfo = iosApp;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		6633134E2E55CEF1005129F5 /* Shared.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Shared.framework; path = "$(SRCROOT)/../shared/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)/Shared.framework"; sourceTree = SOURCE_ROOT; };
 		B9DA97B12DC1472C00A4DA20 /* Wingmate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wingmate.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		C18800000000000000000001 /* iosAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iosAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -41,6 +52,11 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		C18800000000000000000002 /* iosAppTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = iosAppTests;
+			sourceTree = "<group>";
+		};
 		B9DA97B32DC1472C00A4DA20 /* iosApp */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -57,6 +73,13 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		C18800000000000000000003 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B9DA97AE2DC1472C00A4DA20 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -82,6 +105,7 @@
 				B9DA98002DC14AA900A4DA20 /* Configuration */,
 				B9DA97B22DC1472C00A4DA20 /* Products */,
 				B9DA97B32DC1472C00A4DA20 /* iosApp */,
+				C18800000000000000000002 /* iosAppTests */,
 				6633134D2E55CEF0005129F5 /* Frameworks */,
 			);
 			sourceTree = "<group>";
@@ -90,6 +114,7 @@
 			isa = PBXGroup;
 			children = (
 				B9DA97B12DC1472C00A4DA20 /* Wingmate.app */,
+				C18800000000000000000001 /* iosAppTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -97,6 +122,27 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		C18800000000000000000006 /* iosAppTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C18800000000000000000007 /* Build configuration list for PBXNativeTarget "iosAppTests" */;
+			buildPhases = (
+				C18800000000000000000005 /* Sources */,
+				C18800000000000000000003 /* Frameworks */,
+				C18800000000000000000004 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C1880000000000000000000B /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				C18800000000000000000002 /* iosAppTests */,
+			);
+			name = iosAppTests;
+			productName = iosAppTests;
+			productReference = C18800000000000000000001 /* iosAppTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		B9DA97B02DC1472C00A4DA20 /* iosApp */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = B9DA97BF2DC1472D00A4DA20 /* Build configuration list for PBXNativeTarget "iosApp" */;
@@ -129,6 +175,10 @@
 				LastSwiftUpdateCheck = 1620;
 				LastUpgradeCheck = 2600;
 				TargetAttributes = {
+					C18800000000000000000006 = {
+						CreatedOnToolsVersion = 26.0;
+						TestTargetID = B9DA97B02DC1472C00A4DA20;
+					};
 					B9DA97B02DC1472C00A4DA20 = {
 						CreatedOnToolsVersion = 16.2;
 					};
@@ -152,11 +202,19 @@
 			projectRoot = "";
 			targets = (
 				B9DA97B02DC1472C00A4DA20 /* iosApp */,
+				C18800000000000000000006 /* iosAppTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		C18800000000000000000004 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B9DA97AF2DC1472C00A4DA20 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -191,6 +249,13 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		C18800000000000000000005 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B9DA97AD2DC1472C00A4DA20 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -201,6 +266,44 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
+		C18800000000000000000008 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9BB3E6JDX4;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hojmoseit.wingmateTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Wingmate.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Wingmate";
+			};
+			name = Debug;
+		};
+		C18800000000000000000009 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 9BB3E6JDX4;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.hojmoseit.wingmateTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Wingmate.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Wingmate";
+			};
+			name = Release;
+		};
 		B9DA97BD2DC1472D00A4DA20 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -431,6 +534,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		C18800000000000000000007 /* Build configuration list for PBXNativeTarget "iosAppTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C18800000000000000000008 /* Debug */,
+				C18800000000000000000009 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		B9DA97AC2DC1472C00A4DA20 /* Build configuration list for PBXProject "iosApp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -450,6 +562,14 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin PBXTargetDependency section */
+		C1880000000000000000000B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B9DA97B02DC1472C00A4DA20 /* iosApp */;
+			targetProxy = C1880000000000000000000A /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 	};
 	rootObject = B9DA97A92DC1472C00A4DA20 /* Project object */;
 }

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -8,6 +8,20 @@
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C18800000000000000000006"
+               BuildableName = "iosAppTests.xctest"
+               BlueprintName = "iosAppTests"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
@@ -28,6 +42,17 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C18800000000000000000006"
+               BuildableName = "iosAppTests.xctest"
+               BlueprintName = "iosAppTests"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/iosApp/iosAppTests/AzureHybridSequencerTests.swift
+++ b/iosApp/iosAppTests/AzureHybridSequencerTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import Wingmate
+
+final class AzureHybridSequencerTests: XCTestCase {
+    func testTtsSegmentsAreSpokenInOrder() async {
+        let spokenTexts = SpokenTextLog()
+        let spokeTwice = expectation(description: "Both TTS segments were spoken")
+        spokeTwice.expectedFulfillmentCount = 2
+
+        let sequencer = AzureHybridSequencer(
+            speak: { text in
+                await spokenTexts.append(text)
+                spokeTwice.fulfill()
+            },
+            pause: {},
+            stop: {}
+        )
+
+        sequencer.play(segments: [.tts("hello"), .tts("world")])
+
+        await fulfillment(of: [spokeTwice], timeout: 1)
+        let result = await spokenTexts.values
+        XCTAssertEqual(result, ["hello", "world"])
+    }
+}
+
+private actor SpokenTextLog {
+    private var storage: [String] = []
+
+    func append(_ text: String) {
+        storage.append(text)
+    }
+
+    var values: [String] {
+        storage
+    }
+}

--- a/linuxApp/rust-toolchain.toml
+++ b/linuxApp/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.97.1"
+components = ["clippy", "rustfmt"]
+profile = "minimal"

--- a/linuxApp/src/main.rs
+++ b/linuxApp/src/main.rs
@@ -9,9 +9,9 @@ use reqwest::{Client, Method};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::{hash_map::DefaultHasher, HashMap, HashSet, VecDeque};
-use std::hash::{Hash, Hasher};
 use std::env;
 use std::fs;
+use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
@@ -561,6 +561,7 @@ struct Board {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
 struct BoardImage {
     id: String,
     #[serde(default)]
@@ -587,10 +588,16 @@ struct BoardSymbol {
     library_key: Option<String>,
 }
 
+#[allow(dead_code)]
 impl BoardImage {
     fn has_source(&self) -> bool {
         !self.data.as_deref().unwrap_or_default().trim().is_empty()
-            || !self.data_url.as_deref().unwrap_or_default().trim().is_empty()
+            || !self
+                .data_url
+                .as_deref()
+                .unwrap_or_default()
+                .trim()
+                .is_empty()
             || !self.path.as_deref().unwrap_or_default().trim().is_empty()
             || !self.url.as_deref().unwrap_or_default().trim().is_empty()
             || self.symbol.is_some()
@@ -722,7 +729,9 @@ fn access_key_token(key: &keyboard::Key) -> Option<String> {
         keyboard::Key::Named(keyboard::key::Named::Enter) => Some("Enter".into()),
         keyboard::Key::Named(named) => {
             let value = format!("{named:?}");
-            value.strip_prefix('F').and_then(|number| number.parse::<u8>().ok())
+            value
+                .strip_prefix('F')
+                .and_then(|number| number.parse::<u8>().ok())
                 .filter(|number| (1..=12).contains(number))
                 .map(|number| format!("F{number}"))
         }
@@ -1231,7 +1240,8 @@ impl cosmic::Application for Wingmate {
             "starting" | "playing" | "paused"
         );
         let access_timer_active = self.settings.scanning_enabled
-            || (self.settings.dwell_to_select_millis > 0 && self.current_access_target_id.is_some())
+            || (self.settings.dwell_to_select_millis > 0
+                && self.current_access_target_id.is_some())
             || self.selection_highlighted_access.is_some();
         let mut subscriptions = vec![event::listen().map(Message::InputEvent)];
         if self.editing_access.enabled && self.editing_access.unlocked {
@@ -1343,13 +1353,12 @@ impl cosmic::Application for Wingmate {
                 Ok(v) => self.voices = v,
                 Err(e) => self.status = e,
             },
-            Message::LoadedSelectedVoice(result) => match result {
-                Ok(v) => {
+            Message::LoadedSelectedVoice(result) => {
+                if let Ok(v) = result {
                     self.preview_voice_name = v.name.clone();
                     self.selected_voice_name = v.name;
                 }
-                Err(_) => {}
-            },
+            }
             Message::LoadedEditingAccess(result) => match result {
                 Ok(state) => {
                     if state.enabled && !state.unlocked {
@@ -1678,7 +1687,10 @@ impl cosmic::Application for Wingmate {
                 }
                 let target_id = access_target_id(&target);
                 self.known_access_targets.insert(target_id.clone(), target);
-                return self.api.access_input("enter", Some(target_id), None).map(cosmic::Action::App);
+                return self
+                    .api
+                    .access_input("enter", Some(target_id), None)
+                    .map(cosmic::Action::App);
             }
             Message::AccessExit(target) => {
                 let target_id = access_target_id(&target);
@@ -1690,7 +1702,10 @@ impl cosmic::Application for Wingmate {
                 {
                     self.access_press = None;
                 }
-                return self.api.access_input("exit", Some(target_id), None).map(cosmic::Action::App);
+                return self
+                    .api
+                    .access_input("exit", Some(target_id), None)
+                    .map(cosmic::Action::App);
             }
             Message::AccessPress(target) => self.access_press = Some((target, Instant::now())),
             Message::AccessRelease(target) => {
@@ -1757,9 +1772,14 @@ impl cosmic::Application for Wingmate {
                         }
                     }
                 }
-                if let cosmic::iced::Event::Keyboard(keyboard::Event::KeyReleased { key, .. }) = &event {
+                if let cosmic::iced::Event::Keyboard(keyboard::Event::KeyReleased { key, .. }) =
+                    &event
+                {
                     if let Some(token) = access_key_token(key) {
-                        return self.api.access_input("keyup", None, Some(token)).map(cosmic::Action::App);
+                        return self
+                            .api
+                            .access_input("keyup", None, Some(token))
+                            .map(cosmic::Action::App);
                     }
                 }
                 let is_switch = match &event {
@@ -1769,12 +1789,17 @@ impl cosmic::Application for Wingmate {
                     }
                     _ => false,
                 };
-                if let cosmic::iced::Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) = &event {
+                if let cosmic::iced::Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) =
+                    &event
+                {
                     if let Some(token) = access_key_token(key) {
                         if !self.settings.rest_mode_key_binding.is_empty()
                             && token.eq_ignore_ascii_case(&self.settings.rest_mode_key_binding)
                         {
-                            return self.api.access_input("keydown", None, Some(token)).map(cosmic::Action::App);
+                            return self
+                                .api
+                                .access_input("keydown", None, Some(token))
+                                .map(cosmic::Action::App);
                         }
                     }
                 }
@@ -1786,9 +1811,14 @@ impl cosmic::Application for Wingmate {
                         return self.activate_access(target);
                     }
                 }
-                if let cosmic::iced::Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) = &event {
+                if let cosmic::iced::Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) =
+                    &event
+                {
                     if let Some(token) = access_key_token(key) {
-                        return self.api.access_input("keydown", None, Some(token)).map(cosmic::Action::App);
+                        return self
+                            .api
+                            .access_input("keydown", None, Some(token))
+                            .map(cosmic::Action::App);
                     }
                 }
             }
@@ -1799,7 +1829,10 @@ impl cosmic::Application for Wingmate {
                     self.settings_category = SettingsCategory::Speech;
                 }
                 let speech_status = self.api.load_speech_state().map(cosmic::Action::App);
-                let access_tick = self.api.access_input("tick", None, None).map(cosmic::Action::App);
+                let access_tick = self
+                    .api
+                    .access_input("tick", None, None)
+                    .map(cosmic::Action::App);
                 if self.settings.scanning_enabled {
                     let interval =
                         Duration::from_secs_f32(self.settings.scan_auto_advance_seconds.max(0.2));
@@ -2212,13 +2245,14 @@ impl cosmic::Application for Wingmate {
                 };
                 let save = if matches!(
                     key,
-                    "showLabels" | "showSymbols" | "labelAtTop" | "boardShowMessageBar" | "wordTypeColorScheme"
+                    "showLabels"
+                        | "showSymbols"
+                        | "labelAtTop"
+                        | "boardShowMessageBar"
+                        | "wordTypeColorScheme"
                 ) {
                     self.board_graph.as_ref().map_or_else(
-                        || {
-                            self.api
-                                .patch_setting(key, setting_value.clone())
-                        },
+                        || self.api.patch_setting(key, setting_value.clone()),
                         |graph| {
                             self.api.patch_setting_and_reload_board(
                                 key,
@@ -2228,8 +2262,7 @@ impl cosmic::Application for Wingmate {
                         },
                     )
                 } else {
-                    self.api
-                        .patch_setting(key, setting_value)
+                    self.api.patch_setting(key, setting_value)
                 };
                 if key == "highContrastMode" {
                     let theme = theme_for_preference(
@@ -2286,10 +2319,16 @@ impl cosmic::Application for Wingmate {
                     "speechPolicy" => self.settings.speech_policy = value.clone(),
                     _ => {}
                 }
-                return self.api.patch_setting(key, serde_json::json!(value)).map(cosmic::Action::App);
+                return self
+                    .api
+                    .patch_setting(key, serde_json::json!(value))
+                    .map(cosmic::Action::App);
             }
             Message::ToggleInputPause => {
-                return self.api.access_input("togglePause", None, None).map(cosmic::Action::App);
+                return self
+                    .api
+                    .access_input("togglePause", None, None)
+                    .map(cosmic::Action::App);
             }
             Message::HideRestNotice => {
                 self.rest_notice_visible = false;
@@ -2765,9 +2804,12 @@ impl cosmic::Application for Wingmate {
                         button.vocalization.clone().unwrap_or_default(),
                         image_url,
                         button.background_color.clone().unwrap_or_default(),
-                        button.extensions.get("ext_wingmate_word_type")
+                        button
+                            .extensions
+                            .get("ext_wingmate_word_type")
                             .and_then(serde_json::Value::as_str)
-                            .unwrap_or("Automatic").to_string(),
+                            .unwrap_or("Automatic")
+                            .to_string(),
                         button.hidden,
                         button.load_board.as_ref().map(|target| target.id.clone()),
                         if button.actions.is_empty() {
@@ -2981,13 +3023,21 @@ impl cosmic::Application for Wingmate {
 impl Wingmate {
     fn interaction_bottom_control(&self) -> Element<'_, Message> {
         let enabled = matches!(self.page, Page::Communicate | Page::Screens)
-            && (self.settings.dwell_to_select_millis > 0 || !self.settings.select_key_binding.is_empty());
+            && (self.settings.dwell_to_select_millis > 0
+                || !self.settings.select_key_binding.is_empty());
         if !enabled {
             return Space::new().height(0).into();
         }
-        let toggle = button(text(if self.input_is_paused { "Resume input" } else { "Rest mode" }).size(14))
-            .on_press(Message::ToggleInputPause)
-            .padding([8, 14]);
+        let toggle = button(
+            text(if self.input_is_paused {
+                "Resume input"
+            } else {
+                "Rest mode"
+            })
+            .size(14),
+        )
+        .on_press(Message::ToggleInputPause)
+        .padding([8, 14]);
         let notice: Element<'_, Message> = if self.rest_notice_visible && self.input_is_paused {
             container(
                 row![
@@ -3258,9 +3308,12 @@ impl Wingmate {
                     );
                 }
                 if self.settings.scan_phrase_grid_enabled {
-                    targets.extend(self.phrases.iter().filter(|phrase| !phrase.is_hidden).map(
-                        |phrase| self.phrase_access_target(phrase),
-                    ));
+                    targets.extend(
+                        self.phrases
+                            .iter()
+                            .filter(|phrase| !phrase.is_hidden)
+                            .map(|phrase| self.phrase_access_target(phrase)),
+                    );
                 }
                 targets
             }
@@ -4166,7 +4219,8 @@ impl Wingmate {
                 editor = editor.push(text(fl!("status-searching")).size(15));
             }
             if !self.symbols.is_empty() {
-                let results = row(self
+                let results =
+                    row(self
                         .symbols
                         .iter()
                         .enumerate()
@@ -4185,11 +4239,14 @@ impl Wingmate {
                                     .clone()
                                     .unwrap_or_else(|| format!("#{}", symbol.id)),
                             ));
-                            content = content.push(text(match symbol.source.as_str() {
-                                "mulberry" => "Mulberry",
-                                "arasaac" => "ARASAAC",
-                                _ => "OpenSymbols",
-                            }).size(11));
+                            content = content.push(
+                                text(match symbol.source.as_str() {
+                                    "mulberry" => "Mulberry",
+                                    "arasaac" => "ARASAAC",
+                                    _ => "OpenSymbols",
+                                })
+                                .size(11),
+                            );
                             button(content)
                                 .on_press(Message::CellSymbolPicked(index))
                                 .width(124)
@@ -5179,7 +5236,7 @@ impl Wingmate {
                     slider(0.75..=1.5, self.settings.font_size_scale, |value| {
                         Message::SettingFloat("fontSizeScale", value)
                     })
-                    .step(0.05)
+                    .step(0.05_f32)
                     .into(),
                 ),
                 settings_row(
@@ -5187,7 +5244,7 @@ impl Wingmate {
                     slider(0.75..=1.5, self.settings.button_scale, |value| {
                         Message::SettingFloat("buttonScale", value)
                     })
-                    .step(0.05)
+                    .step(0.05_f32)
                     .into(),
                 ),
                 settings_row(
@@ -5195,7 +5252,7 @@ impl Wingmate {
                     slider(0.75..=1.5, self.settings.input_field_scale, |value| {
                         Message::SettingFloat("inputFieldScale", value)
                     })
-                    .step(0.05)
+                    .step(0.05_f32)
                     .into(),
                 ),
                 checkbox(self.settings.high_contrast_mode)
@@ -5310,31 +5367,73 @@ impl Wingmate {
                 settings_row(
                     "Select key",
                     pick_list(
-                        vec!["Off".to_string(), "Space".to_string(), "Enter".to_string(), "F8".to_string(), "F9".to_string()],
-                        Some(if self.settings.select_key_binding.is_empty() { "Off".to_string() } else { self.settings.select_key_binding.clone() }),
-                        |value| Message::SettingString("selectKeyBinding", if value == "Off" { String::new() } else { value })
-                    ).into(),
+                        vec![
+                            "Off".to_string(),
+                            "Space".to_string(),
+                            "Enter".to_string(),
+                            "F8".to_string(),
+                            "F9".to_string()
+                        ],
+                        Some(if self.settings.select_key_binding.is_empty() {
+                            "Off".to_string()
+                        } else {
+                            self.settings.select_key_binding.clone()
+                        }),
+                        |value| Message::SettingString(
+                            "selectKeyBinding",
+                            if value == "Off" { String::new() } else { value }
+                        )
+                    )
+                    .into(),
                 ),
                 settings_row(
                     "Rest mode key",
                     pick_list(
-                        vec!["Off".to_string(), "Space".to_string(), "Enter".to_string(), "F8".to_string(), "F9".to_string()],
-                        Some(if self.settings.rest_mode_key_binding.is_empty() { "Off".to_string() } else { self.settings.rest_mode_key_binding.clone() }),
-                        |value| Message::SettingString("restModeKeyBinding", if value == "Off" { String::new() } else { value })
-                    ).into(),
+                        vec![
+                            "Off".to_string(),
+                            "Space".to_string(),
+                            "Enter".to_string(),
+                            "F8".to_string(),
+                            "F9".to_string()
+                        ],
+                        Some(if self.settings.rest_mode_key_binding.is_empty() {
+                            "Off".to_string()
+                        } else {
+                            self.settings.rest_mode_key_binding.clone()
+                        }),
+                        |value| Message::SettingString(
+                            "restModeKeyBinding",
+                            if value == "Off" { String::new() } else { value }
+                        )
+                    )
+                    .into(),
                 ),
                 settings_row(
                     "Pointer emphasis",
                     pick_list(
-                        vec!["System".to_string(), "Ring".to_string(), "Outline".to_string()],
+                        vec![
+                            "System".to_string(),
+                            "Ring".to_string(),
+                            "Outline".to_string()
+                        ],
                         Some(self.settings.pointer_emphasis_style.clone()),
                         |value| Message::SettingString("pointerEmphasisStyle", value)
-                    ).into(),
+                    )
+                    .into(),
                 ),
                 row![
-                    text(format!("Marker size: {:.1}×", self.settings.pointer_emphasis_scale)).width(Fill),
-                    slider(1.0..=3.0, self.settings.pointer_emphasis_scale, |value| Message::SettingFloat("pointerEmphasisScale", value)).step(0.25).width(240)
-                ].spacing(10),
+                    text(format!(
+                        "Marker size: {:.1}×",
+                        self.settings.pointer_emphasis_scale
+                    ))
+                    .width(Fill),
+                    slider(1.0..=3.0, self.settings.pointer_emphasis_scale, |value| {
+                        Message::SettingFloat("pointerEmphasisScale", value)
+                    })
+                    .step(0.25_f32)
+                    .width(240)
+                ]
+                .spacing(10),
                 Space::new().height(8),
                 text(fl!("access-selection-timing")).size(24),
                 row![
@@ -5607,9 +5706,9 @@ fn settings_row<'a>(
 
 fn board_template_options() -> Vec<String> {
     ["Blank", "Calculator"]
-    .into_iter()
-    .map(str::to_string)
-    .collect()
+        .into_iter()
+        .map(str::to_string)
+        .collect()
 }
 
 fn uses_regular_board_grid(fields: &[BoardField], rows: usize, columns: usize) -> bool {
@@ -5810,7 +5909,12 @@ impl Api {
     fn load_settings(&self) -> Task<Message> {
         self.get("/api/settings", Message::LoadedSettings)
     }
-    fn access_input(&self, event: &'static str, target_id: Option<String>, key: Option<String>) -> Task<Message> {
+    fn access_input(
+        &self,
+        event: &'static str,
+        target_id: Option<String>,
+        key: Option<String>,
+    ) -> Task<Message> {
         let api = self.clone();
         Task::perform(
             async move {
@@ -5976,6 +6080,7 @@ impl Api {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn update_phrase(
         &self,
         id: String,
@@ -6589,6 +6694,7 @@ impl Api {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn save_board_cell(
         &self,
         set_id: String,
@@ -6973,10 +7079,7 @@ fn state_home() -> PathBuf {
             return PathBuf::from(state);
         }
     }
-    PathBuf::from(
-        env::var("HOME").unwrap_or_else(|_| ".".into()),
-    )
-    .join(".local/state")
+    PathBuf::from(env::var("HOME").unwrap_or_else(|_| ".".into())).join(".local/state")
 }
 
 fn bridge_token_file() -> PathBuf {


### PR DESCRIPTION
Closes #188

## Summary

- Add independent Android, Linux Kotlin/Rust, iOS, and OpenSymbols Worker verification jobs.
- Add dependency vulnerability review, full-history secret scanning, dependency submission, and weekly Dependabot updates.
- Pin GitHub Actions and the Linux Rust toolchain to immutable versions.
- Add the canonical Linux packaging task, an iOS simulator test target, and CI/security documentation.
- Install the native `libxkbcommon` development package required by the Linux Rust build on GitHub-hosted runners.

## Verification

- `bash ci_scripts/verify_android.sh`
- `./gradlew :linuxApp:test packageLinux --console=plain`
- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`
- `cargo audit`
- Worker install, audit, tests, and TypeScript check
- Client secret boundary, workflow linting, shell checks, and Gitleaks scans
- Xcode project/scheme parsing and Kotlin/Native simulator link task discovery

The full iOS simulator build and Android emulator test are delegated to GitHub Actions because this Linux workstation cannot run Xcode and should not target an attached physical Android device.
