### PR TITLE
#182 Harden cross-platform persistence and recovery

### DIFF
--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/PhraseScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/PhraseScreen.kt
@@ -675,9 +675,20 @@ fun PhraseScreen(
                     if (state.loading) Text(stringResource(R.string.phrase_screen_loading), style = MaterialTheme.typography.bodyLarge.copy(
                         fontSize = MaterialTheme.typography.bodyLarge.fontSize * settings.fontSizeScale
                     ))
-                    state.error?.let { Text(stringResource(R.string.phrase_screen_error, it), color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyLarge.copy(
-                        fontSize = MaterialTheme.typography.bodyLarge.fontSize * settings.fontSizeScale
-                    )) }
+                    state.error?.let {
+                        Column {
+                            Text(
+                                stringResource(R.string.phrase_screen_error, it),
+                                color = MaterialTheme.colorScheme.error,
+                                style = MaterialTheme.typography.bodyLarge.copy(
+                                    fontSize = MaterialTheme.typography.bodyLarge.fontSize * settings.fontSizeScale
+                                ),
+                            )
+                            Button(onClick = { bloc.dispatch(PhraseEvent.Load) }) {
+                                Text(stringResource(R.string.common_retry))
+                            }
+                        }
+                    }
 
                     // Dynamically resolve CategoryUseCase; it might be registered after initial composition (platform overrides)
                     val categoryUseCaseState = remember { mutableStateOf<io.github.jdreioe.wingmate.application.CategoryUseCase?>(null) }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidBoardRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidBoardRepository.kt
@@ -2,6 +2,8 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import android.content.Context
 import io.github.jdreioe.wingmate.domain.BoardRepository
+import io.github.jdreioe.wingmate.domain.PersistenceError
+import io.github.jdreioe.wingmate.domain.PersistenceException
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -42,22 +44,35 @@ class AndroidBoardRepository(context: Context) : BoardRepository {
         withContext(Dispatchers.IO) {
             mutex.withLock {
                 val encoded = json.encodeToString(ListSerializer(ObfBoard.serializer()), transform(decodeBoards()))
-                check(preferences.edit().putString(BOARDS_KEY, encoded).commit()) {
-                    "Unable to persist boards"
+                if (!preferences.edit().putString(BOARDS_KEY, encoded).commit()) {
+                    throw PersistenceException(PersistenceError.Io)
                 }
             }
         }
     }
 
     private fun decodeBoards(): List<ObfBoard> {
-        val encoded = preferences.getString(BOARDS_KEY, null) ?: return emptyList()
-        return runCatching {
+        val encoded = try {
+            preferences.getString(BOARDS_KEY, null)
+        } catch (error: ClassCastException) {
+            throw PersistenceException(PersistenceError.CorruptOrUnsupported, error)
+        } ?: return emptyList()
+        return try {
             json.decodeFromString(ListSerializer(ObfBoard.serializer()), encoded)
-        }.getOrDefault(emptyList())
+        } catch (error: Exception) {
+            quarantine(encoded)
+            throw PersistenceException(PersistenceError.CorruptOrUnsupported, error)
+        }
+    }
+
+    private fun quarantine(encoded: String) {
+        if (preferences.contains(CORRUPT_BOARDS_KEY)) return
+        preferences.edit().putString(CORRUPT_BOARDS_KEY, encoded).commit()
     }
 
     private companion object {
         const val PREFERENCES_NAME = "wingmate_board_storage"
         const val BOARDS_KEY = "obf_boards_v1"
+        const val CORRUPT_BOARDS_KEY = "obf_boards_v1_corrupt_backup"
     }
 }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidBoardSetRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidBoardSetRepository.kt
@@ -2,6 +2,8 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import android.content.Context
 import io.github.jdreioe.wingmate.domain.BoardSetRepository
+import io.github.jdreioe.wingmate.domain.PersistenceError
+import io.github.jdreioe.wingmate.domain.PersistenceException
 import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
@@ -41,22 +43,35 @@ class AndroidBoardSetRepository(context: Context) : BoardSetRepository {
                     ListSerializer(ObfBoardSet.serializer()),
                     transform(decodeBoardSets())
                 )
-                check(preferences.edit().putString(BOARD_SETS_KEY, encoded).commit()) {
-                    "Unable to persist board sets"
+                if (!preferences.edit().putString(BOARD_SETS_KEY, encoded).commit()) {
+                    throw PersistenceException(PersistenceError.Io)
                 }
             }
         }
     }
 
     private fun decodeBoardSets(): List<ObfBoardSet> {
-        val encoded = preferences.getString(BOARD_SETS_KEY, null) ?: return emptyList()
-        return runCatching {
+        val encoded = try {
+            preferences.getString(BOARD_SETS_KEY, null)
+        } catch (error: ClassCastException) {
+            throw PersistenceException(PersistenceError.CorruptOrUnsupported, error)
+        } ?: return emptyList()
+        return try {
             json.decodeFromString(ListSerializer(ObfBoardSet.serializer()), encoded)
-        }.getOrDefault(emptyList())
+        } catch (error: Exception) {
+            quarantine(encoded)
+            throw PersistenceException(PersistenceError.CorruptOrUnsupported, error)
+        }
+    }
+
+    private fun quarantine(encoded: String) {
+        if (preferences.contains(CORRUPT_BOARD_SETS_KEY)) return
+        preferences.edit().putString(CORRUPT_BOARD_SETS_KEY, encoded).commit()
     }
 
     private companion object {
         const val PREFERENCES_NAME = "wingmate_board_storage"
         const val BOARD_SETS_KEY = "obf_board_sets_v1"
+        const val CORRUPT_BOARD_SETS_KEY = "obf_board_sets_v1_corrupt_backup"
     }
 }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidFileStorage.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidFileStorage.kt
@@ -1,17 +1,19 @@
 package io.github.jdreioe.wingmate.infrastructure
 
 import android.content.Context
+import android.system.Os
 import io.github.jdreioe.wingmate.domain.FileStorage
+import io.github.jdreioe.wingmate.domain.FileStorageWriteException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
 
 class AndroidFileStorage(private val context: Context) : FileStorage {
-    override suspend fun save(fileName: String, content: String) = withContext(Dispatchers.IO) {
-        val file = resolve(fileName)
-        file.parentFile?.mkdirs()
-        file.writeText(content)
-    }
+    override suspend fun save(fileName: String, content: String) =
+        saveBytes(fileName, content.encodeToByteArray())
 
     override suspend fun load(fileName: String): String? = withContext(Dispatchers.IO) {
         val file = resolve(fileName)
@@ -19,18 +21,14 @@ class AndroidFileStorage(private val context: Context) : FileStorage {
     }
 
     override suspend fun saveBytes(fileName: String, content: ByteArray) = withContext(Dispatchers.IO) {
-        val file = resolve(fileName)
-        file.parentFile?.mkdirs()
-        file.writeBytes(content)
+        writeAtomically(resolve(fileName)) { it.write(content) }
     }
 
     override suspend fun saveStream(
         fileName: String,
         producer: suspend (suspend (ByteArray) -> Unit) -> Unit
     ) = withContext(Dispatchers.IO) {
-        val file = resolve(fileName)
-        file.parentFile?.mkdirs()
-        file.outputStream().buffered().use { output ->
+        writeAtomically(resolve(fileName)) { output ->
             producer { chunk -> output.write(chunk) }
         }
     }
@@ -50,4 +48,29 @@ class AndroidFileStorage(private val context: Context) : FileStorage {
     }
 
     private fun resolve(fileName: String): File = File(context.filesDir, fileName)
+
+    private suspend fun writeAtomically(file: File, write: suspend (OutputStream) -> Unit) {
+        val parent = file.absoluteFile.parentFile ?: throw FileStorageWriteException()
+        var temporary: File? = null
+        try {
+            check(parent.mkdirs() || parent.isDirectory)
+            val temp = File.createTempFile(".${file.name}.", ".tmp", parent)
+            temporary = temp
+            FileOutputStream(temp).use { raw ->
+                val output = raw.buffered()
+                write(output)
+                output.flush()
+                raw.fd.sync()
+            }
+            Os.rename(temp.path, file.path)
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: FileStorageWriteException) {
+            throw error
+        } catch (_: Exception) {
+            throw FileStorageWriteException()
+        } finally {
+            temporary?.delete()
+        }
+    }
 }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlCategoryRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlCategoryRepository.kt
@@ -11,8 +11,9 @@ import java.util.UUID
 
 class AndroidSqlCategoryRepository(private val context: Context) : CategoryRepository {
     private val helper by lazy { AndroidSqlOpenHelper(context) }
+    private val repositoryDispatcher = Dispatchers.IO.limitedParallelism(1)
 
-    override suspend fun getAll(): List<CategoryItem> = withContext(Dispatchers.IO) {
+    override suspend fun getAll(): List<CategoryItem> = withContext(repositoryDispatcher) {
         val db = helper.readableDatabase
         // Removed SLF4J logger for cross-platform compatibility
         val cursor = db.query("categories", null, null, null, null, null, "ordering ASC")
@@ -28,7 +29,7 @@ class AndroidSqlCategoryRepository(private val context: Context) : CategoryRepos
         return@withContext list
     }
 
-    override suspend fun add(category: CategoryItem): CategoryItem = withContext(Dispatchers.IO) {
+    override suspend fun add(category: CategoryItem): CategoryItem = withContext(repositoryDispatcher) {
         val db = helper.writableDatabase
         val id = category.id.ifBlank { UUID.randomUUID().toString() }
         // Determine next ordering as max + 1
@@ -42,11 +43,11 @@ class AndroidSqlCategoryRepository(private val context: Context) : CategoryRepos
             put("selectedLanguage", category.selectedLanguage)
             put("ordering", next + 1)
         }
-        db.insert("categories", null, values)
+        db.insertOrThrow("categories", null, values)
         return@withContext category.copy(id = id)
     }
 
-    override suspend fun update(category: CategoryItem): CategoryItem = withContext(Dispatchers.IO) {
+    override suspend fun update(category: CategoryItem): CategoryItem = withContext(repositoryDispatcher) {
         val db = helper.writableDatabase
         val values = ContentValues().apply {
             put("name", category.name)
@@ -56,13 +57,13 @@ class AndroidSqlCategoryRepository(private val context: Context) : CategoryRepos
         return@withContext category
     }
 
-    override suspend fun delete(id: String) = withContext(Dispatchers.IO) {
+    override suspend fun delete(id: String) = withContext(repositoryDispatcher) {
         val db = helper.writableDatabase
         db.delete("categories", "id = ?", arrayOf(id))
         Unit
     }
 
-    override suspend fun move(fromIndex: Int, toIndex: Int) = withContext(Dispatchers.IO) {
+    override suspend fun move(fromIndex: Int, toIndex: Int) = withContext(repositoryDispatcher) {
         val db = helper.writableDatabase
         val cursor = db.query("categories", arrayOf("id"), null, null, null, null, "ordering ASC")
         val ids = mutableListOf<String>()

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlPhraseRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlPhraseRepository.kt
@@ -11,8 +11,9 @@ import java.util.UUID
 
 class AndroidSqlPhraseRepository(private val context: Context) : PhraseRepository {
     private val helper by lazy { AndroidSqlOpenHelper(context) }
+    private val repositoryDispatcher = Dispatchers.IO.limitedParallelism(1)
 
-    override suspend fun getAll(): List<Phrase> = withContext(Dispatchers.IO) {
+    override suspend fun getAll(): List<Phrase> = withContext(repositoryDispatcher) {
         val db = helper.readableDatabase
         val cursor = db.query("phrases", null, null, null, null, null, "ordering ASC")
         val list = mutableListOf<Phrase>()
@@ -49,7 +50,7 @@ class AndroidSqlPhraseRepository(private val context: Context) : PhraseRepositor
         return@withContext list
     }
 
-    override suspend fun add(phrase: Phrase): Phrase = withContext(Dispatchers.IO) {
+    override suspend fun add(phrase: Phrase): Phrase = withContext(repositoryDispatcher) {
         val db = helper.writableDatabase
         val id = phrase.id.ifBlank { UUID.randomUUID().toString() }
         val createdAt = if (phrase.createdAt == 0L) System.currentTimeMillis() else phrase.createdAt
@@ -86,7 +87,7 @@ class AndroidSqlPhraseRepository(private val context: Context) : PhraseRepositor
         )
     }
 
-    override suspend fun update(phrase: Phrase): Phrase = withContext(Dispatchers.IO) {
+    override suspend fun update(phrase: Phrase): Phrase = withContext(repositoryDispatcher) {
         val db = helper.writableDatabase
         val values = ContentValues().apply {
             put("text", phrase.text)
@@ -102,13 +103,13 @@ class AndroidSqlPhraseRepository(private val context: Context) : PhraseRepositor
         return@withContext phrase
     }
 
-    override suspend fun delete(id: String) = withContext(Dispatchers.IO) {
+    override suspend fun delete(id: String) = withContext(repositoryDispatcher) {
         val db = helper.writableDatabase
         db.delete("phrases", "id = ?", arrayOf(id))
         Unit
     }
 
-    override suspend fun move(fromIndex: Int, toIndex: Int) = withContext(Dispatchers.IO) {
+    override suspend fun move(fromIndex: Int, toIndex: Int) = withContext(repositoryDispatcher) {
         // Simple ordering swap implementation: read all ids and reorder
         val db = helper.writableDatabase
         val cursor = db.query("phrases", arrayOf("id"), null, null, null, null, "ordering ASC")

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlPronunciationDictionaryRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlPronunciationDictionaryRepository.kt
@@ -3,7 +3,11 @@ package io.github.jdreioe.wingmate.infrastructure
 import android.content.Context
 import io.github.jdreioe.wingmate.domain.PronunciationDictionaryRepository
 import io.github.jdreioe.wingmate.domain.PronunciationEntry
+import io.github.jdreioe.wingmate.domain.PersistenceError
+import io.github.jdreioe.wingmate.domain.PersistenceException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
@@ -12,6 +16,7 @@ class AndroidSqlPronunciationDictionaryRepository(
     private val context: Context
 ) : PronunciationDictionaryRepository {
     private val helper by lazy { AndroidSqlOpenHelper(context) }
+    private val mutex = Mutex()
     private val json = Json {
         ignoreUnknownKeys = true
         prettyPrint = false
@@ -26,27 +31,48 @@ class AndroidSqlPronunciationDictionaryRepository(
             )
             """.trimIndent()
         )
+        helper.writableDatabase.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS pronunciation_dictionary_corrupt (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                data TEXT NOT NULL
+            )
+            """.trimIndent()
+        )
     }
 
     override suspend fun getAll(): List<PronunciationEntry> = withContext(Dispatchers.IO) {
-        loadAll()
+        mutex.withLock { persistenceOperation { loadAll() } }
     }
 
     override suspend fun add(entry: PronunciationEntry) = withContext(Dispatchers.IO) {
-        val list = loadAll().toMutableList()
-        list.removeAll { it.word.equals(entry.word, ignoreCase = true) }
-        list.add(entry.copy(word = entry.word.trim(), phoneme = entry.phoneme.trim()))
-        saveAll(list)
+        mutex.withLock {
+            persistenceOperation {
+                val list = loadAll().toMutableList()
+                list.removeAll { it.word.equals(entry.word, ignoreCase = true) }
+                list.add(entry.copy(word = entry.word.trim(), phoneme = entry.phoneme.trim()))
+                saveAll(list)
+            }
+        }
     }
 
     override suspend fun delete(word: String) = withContext(Dispatchers.IO) {
-        val list = loadAll().toMutableList()
-        list.removeAll { it.word.equals(word, ignoreCase = true) }
-        saveAll(list)
+        mutex.withLock {
+            persistenceOperation {
+                val list = loadAll().toMutableList()
+                list.removeAll { it.word.equals(word, ignoreCase = true) }
+                saveAll(list)
+            }
+        }
     }
 
     override suspend fun clear() = withContext(Dispatchers.IO) {
-        saveAll(emptyList())
+        mutex.withLock {
+            persistenceOperation {
+                loadAll()
+                saveAll(emptyList())
+            }
+        }
     }
 
     private fun loadAll(): List<PronunciationEntry> {
@@ -63,10 +89,13 @@ class AndroidSqlPronunciationDictionaryRepository(
         return try {
             if (!cursor.moveToFirst()) return emptyList()
             val text = cursor.getString(cursor.getColumnIndexOrThrow("data")) ?: return emptyList()
-            json.decodeFromString(ListSerializer(PronunciationEntry.serializer()), text)
-                .sortedBy { it.word.lowercase() }
-        } catch (_: Throwable) {
-            emptyList()
+            try {
+                json.decodeFromString(ListSerializer(PronunciationEntry.serializer()), text)
+                    .sortedBy { it.word.lowercase() }
+            } catch (error: kotlinx.serialization.SerializationException) {
+                quarantine(text)
+                throw PersistenceException(PersistenceError.CorruptOrUnsupported, error)
+            }
         } finally {
             cursor.close()
         }
@@ -79,5 +108,24 @@ class AndroidSqlPronunciationDictionaryRepository(
             "INSERT OR REPLACE INTO pronunciation_dictionary (id, data) VALUES (1, ?)",
             arrayOf(text)
         )
+    }
+
+    private fun quarantine(text: String) {
+        runCatching {
+            helper.writableDatabase.execSQL(
+                "INSERT OR IGNORE INTO pronunciation_dictionary_corrupt (id, data) VALUES (1, ?)",
+                arrayOf(text),
+            )
+        }
+    }
+
+    private inline fun <T> persistenceOperation(block: () -> T): T = try {
+        block()
+    } catch (error: PersistenceException) {
+        throw error
+    } catch (error: kotlinx.serialization.SerializationException) {
+        throw PersistenceException(PersistenceError.CorruptOrUnsupported, error)
+    } catch (error: Exception) {
+        throw PersistenceException(PersistenceError.Io, error)
     }
 }

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlSaidTextRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlSaidTextRepository.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.Json
 
 class AndroidSqlSaidTextRepository(private val context: Context) : SaidTextRepository {
     private val helper by lazy { AndroidSqlOpenHelper(context) }
+    private val repositoryDispatcher = Dispatchers.IO.limitedParallelism(1)
     private val json = Json { prettyPrint = true }
 
     init {
@@ -33,7 +34,7 @@ class AndroidSqlSaidTextRepository(private val context: Context) : SaidTextRepos
         runCatching { db.execSQL("ALTER TABLE said_texts ADD COLUMN visible_in_history INTEGER NOT NULL DEFAULT 1") }
     }
 
-    override suspend fun add(item: SaidText): SaidText = withContext(Dispatchers.IO) {
+    override suspend fun add(item: SaidText): SaidText = withContext(repositoryDispatcher) {
         val db = helper.writableDatabase
         val values = ContentValues().apply {
             put("date", item.date)
@@ -47,11 +48,11 @@ class AndroidSqlSaidTextRepository(private val context: Context) : SaidTextRepos
             put("primary_language", item.primaryLanguage)
             put("visible_in_history", if (item.visibleInHistory) 1 else 0)
         }
-        val id = db.insert("said_texts", null, values)
+        val id = db.insertOrThrow("said_texts", null, values)
         return@withContext item.copy(id = id.toInt())
     }
 
-    override suspend fun list(): List<SaidText> = withContext(Dispatchers.IO) {
+    override suspend fun list(): List<SaidText> = withContext(repositoryDispatcher) {
         val db = helper.readableDatabase
         val cursor = db.query("said_texts", null, null, null, null, null, "date DESC")
         val list = mutableListOf<SaidText>()
@@ -73,13 +74,13 @@ class AndroidSqlSaidTextRepository(private val context: Context) : SaidTextRepos
         return@withContext list
     }
 
-    override suspend fun deleteAll() = withContext(Dispatchers.IO) {
+    override suspend fun deleteAll() = withContext(repositoryDispatcher) {
         val db = helper.writableDatabase
         db.delete("said_texts", null, null)
         Unit
     }
 
-    override suspend fun addAll(items: List<SaidText>) = withContext(Dispatchers.IO) {
+    override suspend fun addAll(items: List<SaidText>) = withContext(repositoryDispatcher) {
         val db = helper.writableDatabase
         db.beginTransaction()
         try {
@@ -96,7 +97,7 @@ class AndroidSqlSaidTextRepository(private val context: Context) : SaidTextRepos
                     put("primary_language", item.primaryLanguage)
                     put("visible_in_history", if (item.visibleInHistory) 1 else 0)
                 }
-                db.insert("said_texts", null, values)
+                db.insertOrThrow("said_texts", null, values)
             }
             db.setTransactionSuccessful()
         } finally {

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlSettingsRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlSettingsRepository.kt
@@ -9,6 +9,7 @@ import kotlinx.serialization.json.Json
 
 class AndroidSqlSettingsRepository(private val context: Context) : SettingsRepository {
     private val helper by lazy { AndroidSqlOpenHelper(context) }
+    private val repositoryDispatcher = Dispatchers.IO.limitedParallelism(1)
     private val json = Json {
         prettyPrint = true
         ignoreUnknownKeys = true
@@ -25,7 +26,7 @@ class AndroidSqlSettingsRepository(private val context: Context) : SettingsRepos
         """.trimIndent())
     }
 
-    override suspend fun get(): Settings = withContext(Dispatchers.IO) {
+    override suspend fun get(): Settings = withContext(repositoryDispatcher) {
         val db = helper.readableDatabase
         // Removed SLF4J logger for cross-platform compatibility
         val cursor = db.query("ui_settings", arrayOf("data"), "id = 1", null, null, null, null)
@@ -38,7 +39,7 @@ class AndroidSqlSettingsRepository(private val context: Context) : SettingsRepos
         return@withContext Settings()
     }
 
-    override suspend fun update(settings: Settings): Settings = withContext(Dispatchers.IO) {
+    override suspend fun update(settings: Settings): Settings = withContext(repositoryDispatcher) {
         val db = helper.writableDatabase
         // Removed SLF4J logger for cross-platform compatibility
         val text = json.encodeToString(Settings.serializer(), settings)

--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlVoiceRepository.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSqlVoiceRepository.kt
@@ -10,9 +10,10 @@ import kotlinx.serialization.json.Json
 
 class AndroidSqlVoiceRepository(private val context: Context) : VoiceRepository {
     private val helper by lazy { AndroidSqlOpenHelper(context) }
+    private val repositoryDispatcher = Dispatchers.IO.limitedParallelism(1)
     private val json = Json { ignoreUnknownKeys = true }
 
-    override suspend fun getVoices(): List<Voice> = withContext(Dispatchers.IO) {
+    override suspend fun getVoices(): List<Voice> = withContext(repositoryDispatcher) {
         val db = helper.readableDatabase
         val cursor = db.query("voice_catalog", arrayOf("list"), "id = ?", arrayOf("1"), null, null, null)
         cursor.use {
@@ -25,19 +26,19 @@ class AndroidSqlVoiceRepository(private val context: Context) : VoiceRepository 
         }
     }
 
-    override suspend fun saveVoices(list: List<Voice>) = withContext(Dispatchers.IO) {
+    override suspend fun saveVoices(list: List<Voice>) = withContext(repositoryDispatcher) {
         val jsonList = json.encodeToString(ListSerializer(Voice.serializer()), list)
         val db = helper.writableDatabase
         db.execSQL("INSERT OR REPLACE INTO voice_catalog (id, list) VALUES (1, ?)", arrayOf(jsonList))
     }
 
-    override suspend fun saveSelected(voice: Voice) = withContext(Dispatchers.IO) {
+    override suspend fun saveSelected(voice: Voice) = withContext(repositoryDispatcher) {
         val text = json.encodeToString(Voice.serializer(), voice)
         val db = helper.writableDatabase
         db.execSQL("INSERT OR REPLACE INTO voices (id, data) VALUES (1, ?)", arrayOf(text))
     }
 
-    override suspend fun getSelected(): Voice? = withContext(Dispatchers.IO) {
+    override suspend fun getSelected(): Voice? = withContext(repositoryDispatcher) {
         val db = helper.readableDatabase
         val cursor = db.query("voices", arrayOf("data"), "id = ?", arrayOf("1"), null, null, null)
         cursor.use {

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosBoardRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosBoardRepository.kt
@@ -2,13 +2,8 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.BoardRepository
 import io.github.jdreioe.wingmate.domain.obf.ObfBoard
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
-import platform.Foundation.NSUserDefaults
 
 class IosBoardRepository : BoardRepository {
     private val json = Json {
@@ -16,52 +11,34 @@ class IosBoardRepository : BoardRepository {
         encodeDefaults = true
         prettyPrint = false
     }
-    private val prefs by lazy { NSUserDefaults.standardUserDefaults() }
-    private val mutex = Mutex()
-    private val key = "obf_boards_v1"
-
-    private suspend fun loadAll(): List<ObfBoard> = withContext(Dispatchers.Default) {
-        mutex.withLock { decodeAll() }
-    }
-
-    private suspend fun updateAll(transform: (List<ObfBoard>) -> List<ObfBoard>) {
-        withContext(Dispatchers.Default) {
-            mutex.withLock {
-                val text = json.encodeToString(ListSerializer(ObfBoard.serializer()), transform(decodeAll()))
-                prefs.setObject(text, forKey = key)
-                check(prefs.synchronize()) { "Unable to persist boards" }
-            }
-        }
-    }
-
-    private fun decodeAll(): List<ObfBoard> {
-        val text = prefs.stringForKey(key) ?: return emptyList()
-        return runCatching {
-            json.decodeFromString(ListSerializer(ObfBoard.serializer()), text)
-        }.getOrDefault(emptyList())
-    }
+    private val serializer = ListSerializer(ObfBoard.serializer())
+    private val store = IosPreferencesJsonStore(
+        key = "obf_boards_v1",
+        encode = { json.encodeToString(serializer, it) },
+        decode = { json.decodeFromString(serializer, it) },
+    )
 
     override suspend fun getBoard(id: String): ObfBoard? {
-        return loadAll().firstOrNull { it.id == id }
+        return store.read(::emptyList).firstOrNull { it.id == id }
     }
 
     override suspend fun saveBoard(board: ObfBoard) {
-        updateAll { boards -> boards.filterNot { it.id == board.id } + board }
+        store.update(::emptyList) { boards -> boards.filterNot { it.id == board.id } + board }
     }
 
     override suspend fun saveBoards(boards: List<ObfBoard>) {
         if (boards.isEmpty()) return
-        updateAll { existing ->
+        store.update(::emptyList) { existing ->
             val savedIds = boards.map { it.id }.toSet()
             existing.filterNot { it.id in savedIds } + boards
         }
     }
 
     override suspend fun listBoards(): List<ObfBoard> {
-        return loadAll()
+        return store.read(::emptyList)
     }
 
     override suspend fun deleteBoard(id: String) {
-        updateAll { boards -> boards.filterNot { it.id == id } }
+        store.update(::emptyList) { boards -> boards.filterNot { it.id == id } }
     }
 }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosBoardSetRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosBoardSetRepository.kt
@@ -2,56 +2,35 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.BoardSetRepository
 import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
-import platform.Foundation.NSUserDefaults
 
 /** Persists the board-set library metadata across iOS app launches. */
 class IosBoardSetRepository : BoardSetRepository {
     private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
-    private val preferences by lazy { NSUserDefaults.standardUserDefaults() }
-    private val mutex = Mutex()
+    private val serializer = ListSerializer(ObfBoardSet.serializer())
+    private val store = IosPreferencesJsonStore(
+        key = BOARD_SETS_KEY,
+        encode = { json.encodeToString(serializer, it) },
+        decode = { json.decodeFromString(serializer, it) },
+    )
 
     override suspend fun getBoardSet(id: String): ObfBoardSet? =
-        readBoardSets().firstOrNull { it.id == id }
+        store.read(::emptyList).firstOrNull { it.id == id }
 
-    override suspend fun saveBoardSet(boardSet: ObfBoardSet) = updateBoardSets { boardSets ->
-        boardSets.filterNot { it.id == boardSet.id } + boardSet
-    }
-
-    override suspend fun listBoardSets(): List<ObfBoardSet> =
-        readBoardSets().sortedByDescending { it.updatedAt }
-
-    override suspend fun deleteBoardSet(id: String) = updateBoardSets { boardSets ->
-        boardSets.filterNot { it.id == id }
-    }
-
-    private suspend fun readBoardSets(): List<ObfBoardSet> = withContext(Dispatchers.Default) {
-        mutex.withLock { decodeBoardSets() }
-    }
-
-    private suspend fun updateBoardSets(transform: (List<ObfBoardSet>) -> List<ObfBoardSet>) {
-        withContext(Dispatchers.Default) {
-            mutex.withLock {
-                val encoded = json.encodeToString(
-                    ListSerializer(ObfBoardSet.serializer()),
-                    transform(decodeBoardSets())
-                )
-                preferences.setObject(encoded, forKey = BOARD_SETS_KEY)
-                check(preferences.synchronize()) { "Unable to persist board sets" }
-            }
+    override suspend fun saveBoardSet(boardSet: ObfBoardSet) {
+        store.update(::emptyList) { boardSets ->
+            boardSets.filterNot { it.id == boardSet.id } + boardSet
         }
     }
 
-    private fun decodeBoardSets(): List<ObfBoardSet> {
-        val encoded = preferences.stringForKey(BOARD_SETS_KEY) ?: return emptyList()
-        return runCatching {
-            json.decodeFromString(ListSerializer(ObfBoardSet.serializer()), encoded)
-        }.getOrDefault(emptyList())
+    override suspend fun listBoardSets(): List<ObfBoardSet> =
+        store.read(::emptyList).sortedByDescending { it.updatedAt }
+
+    override suspend fun deleteBoardSet(id: String) {
+        store.update(::emptyList) { boardSets ->
+            boardSets.filterNot { it.id == id }
+        }
     }
 
     private companion object {

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosCategoryRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosCategoryRepository.kt
@@ -2,63 +2,42 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.CategoryItem
 import io.github.jdreioe.wingmate.domain.CategoryRepository
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
-import platform.Foundation.NSUserDefaults
 import kotlin.random.Random
 
 class IosCategoryRepository : CategoryRepository {
     private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
-    private val prefs by lazy { NSUserDefaults.standardUserDefaults() }
-    private val key = "categories_v1"
+    private val serializer = ListSerializer(CategoryItem.serializer())
+    private val store = IosPreferencesJsonStore(
+        key = "categories_v1",
+        encode = { json.encodeToString(serializer, it) },
+        decode = { json.decodeFromString(serializer, it) },
+    )
 
-    private suspend fun loadAll(): MutableList<CategoryItem> = withContext(Dispatchers.Default) {
-        val text = prefs.stringForKey(key) ?: return@withContext mutableListOf()
-        runCatching { json.decodeFromString(ListSerializer(CategoryItem.serializer()), text) }
-            .getOrNull()?.toMutableList() ?: mutableListOf()
-    }
-
-    private suspend fun saveAll(list: List<CategoryItem>) = withContext(Dispatchers.Default) {
-        val text = json.encodeToString(ListSerializer(CategoryItem.serializer()), list)
-        prefs.setObject(text, forKey = key)
-        prefs.synchronize()
-        Unit
-    }
-
-    override suspend fun getAll(): List<CategoryItem> = loadAll()
+    override suspend fun getAll(): List<CategoryItem> = store.read(::emptyList)
 
     override suspend fun add(category: CategoryItem): CategoryItem {
-        val list = loadAll()
         val c = category.copy(id = category.id.ifBlank { Random.nextInt().toString() })
-        list.add(c)
-        saveAll(list)
+        store.update(::emptyList) { it + c }
         return c
     }
 
     override suspend fun update(category: CategoryItem): CategoryItem {
-        val list = loadAll()
-        val idx = list.indexOfFirst { it.id == category.id }
-        if (idx >= 0) {
-            list[idx] = category
-            saveAll(list)
+        store.update(::emptyList) { existing ->
+            existing.map { if (it.id == category.id) category else it }
         }
         return category
     }
 
     override suspend fun delete(id: String) {
-        val list = loadAll()
-        val newList = list.filterNot { it.id == id }
-        saveAll(newList)
-        Unit
+        store.update(::emptyList) { it.filterNot { category -> category.id == id } }
     }
 
     override suspend fun move(fromIndex: Int, toIndex: Int) {
-        val list = loadAll().toMutableList()
-        if (fromIndex !in list.indices || toIndex !in list.indices) return
-        val item = list.removeAt(fromIndex)
-        list.add(toIndex, item)
-        saveAll(list)
+        store.update(::emptyList) { existing ->
+            if (fromIndex !in existing.indices || toIndex !in existing.indices) return@update existing
+            existing.toMutableList().apply { add(toIndex, removeAt(fromIndex)) }
+        }
     }
 }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPhraseAudioRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPhraseAudioRepository.kt
@@ -1,9 +1,12 @@
 package io.github.jdreioe.wingmate.infrastructure
 
+import io.github.jdreioe.wingmate.domain.PersistenceError
+import io.github.jdreioe.wingmate.domain.PersistenceException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import platform.Foundation.NSUserDefaults
+import platform.Foundation.NSLock
 
 /**
  * Simple iOS-only repository that maps phraseId -> local audio file path.
@@ -14,33 +17,71 @@ class IosPhraseAudioRepository {
     private val key = "phrase_audio_v1"
     private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
     private val ser = MapSerializer(String.serializer(), String.serializer())
+    private val lock = NSLock()
 
     private fun load(): MutableMap<String, String> {
-        val text = prefs.stringForKey(key) ?: return mutableMapOf()
-        return runCatching { json.decodeFromString(ser, text) }.getOrElse { mutableMapOf() }.toMutableMap()
+        val text = prefs.stringForKey(key)
+        if (text == null) {
+            if (prefs.objectForKey(key) != null) {
+                throw PersistenceException(PersistenceError.CorruptOrUnsupported)
+            }
+            return mutableMapOf()
+        }
+        return try {
+            json.decodeFromString(ser, text).toMutableMap()
+        } catch (error: Exception) {
+            if (prefs.objectForKey(CORRUPT_KEY) == null) {
+                prefs.setObject(text, forKey = CORRUPT_KEY)
+                prefs.synchronize()
+            }
+            throw PersistenceException(PersistenceError.CorruptOrUnsupported, error)
+        }
     }
 
     private fun save(map: Map<String, String>) {
         val text = json.encodeToString(ser, map)
+        val previous = prefs.objectForKey(key)
         prefs.setObject(text, forKey = key)
-        prefs.synchronize()
+        if (!prefs.synchronize()) {
+            if (previous == null) prefs.removeObjectForKey(key)
+            else prefs.setObject(previous, forKey = key)
+            prefs.synchronize()
+            throw PersistenceException(PersistenceError.Io)
+        }
     }
 
-    fun getPath(phraseId: String): String? = load()[phraseId]
+    fun getPath(phraseId: String): String? = locked { load()[phraseId] }
 
     fun hasRecording(phraseId: String): Boolean = getPath(phraseId) != null
 
     fun savePath(phraseId: String, path: String) {
-        val map = load()
-        map[phraseId] = path
-        save(map)
+        locked {
+            val map = load()
+            map[phraseId] = path
+            save(map)
+        }
     }
 
     fun deletePath(phraseId: String) {
-        val map = load()
-        map.remove(phraseId)
-        save(map)
+        locked {
+            val map = load()
+            map.remove(phraseId)
+            save(map)
+        }
     }
 
-    fun all(): Map<String, String> = load()
+    fun all(): Map<String, String> = locked { load() }
+
+    private inline fun <T> locked(block: () -> T): T {
+        lock.lock()
+        return try {
+            block()
+        } finally {
+            lock.unlock()
+        }
+    }
+
+    private companion object {
+        const val CORRUPT_KEY = "phrase_audio_v1_corrupt_backup"
+    }
 }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPhraseRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPhraseRepository.kt
@@ -2,69 +2,49 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.Phrase
 import io.github.jdreioe.wingmate.domain.PhraseRepository
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
-import platform.Foundation.NSUserDefaults
 import kotlin.random.Random
 import kotlin.time.Clock
 
 class IosPhraseRepository : PhraseRepository {
     private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
-    private val prefs by lazy { NSUserDefaults.standardUserDefaults() }
-    private val key = "phrases_v1"
+    private val serializer = ListSerializer(Phrase.serializer())
+    private val store = IosPreferencesJsonStore(
+        key = "phrases_v1",
+        encode = { json.encodeToString(serializer, it) },
+        decode = { json.decodeFromString(serializer, it) },
+    )
 
-    private suspend fun loadAll(): MutableList<Phrase> = withContext(Dispatchers.Default) {
-        val text = prefs.stringForKey(key) ?: return@withContext mutableListOf()
-        runCatching { json.decodeFromString(ListSerializer(Phrase.serializer()), text) }
-            .getOrNull()?.toMutableList() ?: mutableListOf()
-    }
-
-    private suspend fun saveAll(list: List<Phrase>) = withContext(Dispatchers.Default) {
-        val text = json.encodeToString(ListSerializer(Phrase.serializer()), list)
-        prefs.setObject(text, forKey = key)
-        prefs.synchronize()
-        Unit
-    }
-
-    override suspend fun getAll(): List<Phrase> = loadAll()
+    override suspend fun getAll(): List<Phrase> = store.read(::emptyList)
 
     override suspend fun add(phrase: Phrase): Phrase {
-        val list = loadAll()
         val p = phrase.copy(
             id = phrase.id.ifBlank { Random.nextInt().toString() },
             createdAt = if (phrase.createdAt == 0L) Clock.System.now().toEpochMilliseconds() else phrase.createdAt
         )
-        list.add(p)
-        saveAll(list)
+        store.update(::emptyList) { it + p }
         return p
     }
 
     override suspend fun update(phrase: Phrase): Phrase {
-        val list = loadAll()
-        val idx = list.indexOfFirst { it.id == phrase.id }
-        if (idx >= 0) {
-            list[idx] = phrase
-            saveAll(list)
+        store.update(::emptyList) { existing ->
+            existing.map { if (it.id == phrase.id) phrase else it }
         }
         return phrase
     }
 
     override suspend fun delete(id: String) {
-        val list = loadAll()
-        val newList = list.filterNot { it.id == id }
-        saveAll(newList)
-        Unit
+        store.update(::emptyList) { it.filterNot { phrase -> phrase.id == id } }
     }
 
     override suspend fun move(fromIndex: Int, toIndex: Int) {
-        val list = loadAll()
-        if (fromIndex < 0 || fromIndex >= list.size) return
-        val item = list.removeAt(fromIndex)
-        val insertIndex = toIndex.coerceIn(0, list.size)
-        list.add(insertIndex, item)
-        saveAll(list)
-        Unit
+        store.update(::emptyList) { existing ->
+            if (fromIndex !in existing.indices) return@update existing
+            existing.toMutableList().apply {
+                val item = removeAt(fromIndex)
+                add(toIndex.coerceIn(0, size), item)
+            }
+        }
     }
 }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPreferencesJsonStore.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPreferencesJsonStore.kt
@@ -1,0 +1,92 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.domain.PersistenceError
+import io.github.jdreioe.wingmate.domain.PersistenceException
+import io.github.jdreioe.wingmate.domain.PersistenceRead
+import io.github.jdreioe.wingmate.domain.valueOr
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import platform.Foundation.NSUserDefaults
+
+/** Serializes read-modify-write operations and never treats malformed preferences as absent. */
+internal class IosPreferencesJsonStore<T>(
+    private val key: String,
+    private val encode: (T) -> String,
+    private val decode: (String) -> T,
+    private val defaults: NSUserDefaults = NSUserDefaults.standardUserDefaults(),
+    private val synchronize: () -> Boolean = { defaults.synchronize() },
+) {
+    private val mutex = Mutex()
+
+    suspend fun read(defaultValue: () -> T): T = withContext(Dispatchers.Default) {
+        mutex.withLock { readLocked().valueOr(defaultValue) }
+    }
+
+    suspend fun readNullable(): T? = withContext(Dispatchers.Default) {
+        mutex.withLock {
+            when (val result = readLocked()) {
+                PersistenceRead.Absent -> null
+                is PersistenceRead.Loaded -> result.value
+                is PersistenceRead.Failed -> throw PersistenceException(result.error, result.cause)
+            }
+        }
+    }
+
+    suspend fun update(defaultValue: () -> T, transform: (T) -> T): T =
+        withContext(Dispatchers.Default) {
+            mutex.withLock {
+                val updated = transform(readLocked().valueOr(defaultValue))
+                writeLocked(updated)
+                updated
+            }
+        }
+
+    suspend fun replace(value: T, defaultValue: () -> T) = withContext(Dispatchers.Default) {
+        mutex.withLock {
+            readLocked().valueOr(defaultValue) // Guard against replacing an unreadable payload.
+            writeLocked(value)
+        }
+    }
+
+    private fun readLocked(): PersistenceRead<T> {
+        val raw = defaults.stringForKey(key)
+        if (raw == null) {
+            return if (defaults.objectForKey(key) == null) {
+                PersistenceRead.Absent
+            } else {
+                PersistenceRead.Failed(PersistenceError.CorruptOrUnsupported)
+            }
+        }
+        return try {
+            PersistenceRead.Loaded(decode(raw))
+        } catch (error: Exception) {
+            quarantine(raw)
+            PersistenceRead.Failed(PersistenceError.CorruptOrUnsupported, error)
+        }
+    }
+
+    private fun writeLocked(value: T) {
+        val raw = try {
+            encode(value)
+        } catch (error: Exception) {
+            throw PersistenceException(PersistenceError.Io, error)
+        }
+        val previous = defaults.objectForKey(key)
+        defaults.setObject(raw, forKey = key)
+        if (!synchronize()) {
+            if (previous == null) defaults.removeObjectForKey(key)
+            else defaults.setObject(previous, forKey = key)
+            defaults.synchronize()
+            throw PersistenceException(PersistenceError.Io)
+        }
+    }
+
+    private fun quarantine(raw: String) {
+        val quarantineKey = "${key}_corrupt_backup"
+        if (defaults.objectForKey(quarantineKey) != null) return
+        defaults.setObject(raw, forKey = quarantineKey)
+        defaults.synchronize()
+    }
+}

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPronunciationDictionaryRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPronunciationDictionaryRepository.kt
@@ -2,72 +2,33 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.PronunciationDictionaryRepository
 import io.github.jdreioe.wingmate.domain.PronunciationEntry
-import io.github.jdreioe.wingmate.domain.OperationalLogger
-import io.github.jdreioe.wingmate.domain.loggingClassName
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
-import platform.Foundation.NSUserDefaults
 
 class IosPronunciationDictionaryRepository : PronunciationDictionaryRepository {
-    private val defaults by lazy { NSUserDefaults.standardUserDefaults() }
     private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
-    private val storageKey = "pronunciation_dictionary_v1"
+    private val serializer = ListSerializer(PronunciationEntry.serializer())
+    private val store = IosPreferencesJsonStore(
+        key = "pronunciation_dictionary_v1",
+        encode = { json.encodeToString(serializer, it) },
+        decode = { json.decodeFromString(serializer, it) },
+    )
 
-    override suspend fun getAll(): List<PronunciationEntry> = withContext(Dispatchers.Default) {
-        loadAll()
-    }
+    override suspend fun getAll(): List<PronunciationEntry> = store.read(::emptyList)
 
     override suspend fun add(entry: PronunciationEntry) {
-        withContext(Dispatchers.Default) {
-            val list = loadAll().toMutableList()
-            // Remove existing for same word to overwrite
-            list.removeAll { it.word.equals(entry.word, ignoreCase = true) }
-            list.add(entry)
-            saveAll(list)
+        store.update(::emptyList) { existing ->
+            existing.filterNot { it.word.equals(entry.word, ignoreCase = true) } + entry
         }
     }
 
     override suspend fun delete(word: String) {
-        withContext(Dispatchers.Default) {
-            val list = loadAll().toMutableList()
-            list.removeAll { it.word.equals(word, ignoreCase = true) }
-            saveAll(list)
+        store.update(::emptyList) { existing ->
+            existing.filterNot { it.word.equals(word, ignoreCase = true) }
         }
     }
 
     override suspend fun clear() {
-        withContext(Dispatchers.Default) {
-            saveAll(emptyList())
-        }
-    }
-
-    private fun loadAll(): List<PronunciationEntry> {
-        val text = defaults.stringForKey(storageKey) ?: return emptyList()
-        return try {
-            json.decodeFromString(ListSerializer(PronunciationEntry.serializer()), text)
-        } catch (t: Throwable) {
-            OperationalLogger.warn(
-                operation = "pronunciation_dictionary.load",
-                outcome = "failed",
-                exceptionClass = t.loggingClassName(),
-            )
-            emptyList()
-        }
-    }
-
-    private fun saveAll(list: List<PronunciationEntry>) {
-        try {
-            val text = json.encodeToString(ListSerializer(PronunciationEntry.serializer()), list)
-            defaults.setObject(text, storageKey)
-            // defaults.synchronize() is deprecated and often unnecessary, but can call if needed
-        } catch (t: Throwable) {
-            OperationalLogger.warn(
-                operation = "pronunciation_dictionary.save",
-                outcome = "failed",
-                exceptionClass = t.loggingClassName(),
-            )
-        }
+        store.replace(emptyList(), ::emptyList)
     }
 }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSaidTextRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSaidTextRepository.kt
@@ -3,70 +3,43 @@ package io.github.jdreioe.wingmate.infrastructure
 import io.github.jdreioe.wingmate.domain.SaidText
 import io.github.jdreioe.wingmate.domain.SaidTextRepository
 import io.github.jdreioe.wingmate.domain.OperationalLogger
-import io.github.jdreioe.wingmate.domain.loggingClassName
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import kotlinx.datetime.Clock
-import platform.Foundation.NSUserDefaults
 
 class IosSaidTextRepository : SaidTextRepository {
-    private val defaults by lazy { NSUserDefaults.standardUserDefaults() }
     private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
-    private val storageKey = "said_text_list_v1"
+    private val serializer = ListSerializer(SaidText.serializer())
+    private val store = IosPreferencesJsonStore(
+        key = "said_text_list_v1",
+        encode = { json.encodeToString(serializer, it) },
+        decode = { json.decodeFromString(serializer, it) },
+    )
 
-    override suspend fun add(item: SaidText): SaidText = withContext(Dispatchers.Default) {
-    val now = Clock.System.now().toEpochMilliseconds()
-        val existing = loadAll().toMutableList()
-        val nextPos = (existing.maxOfOrNull { it.position ?: 0 } ?: 0) + 1
-        val enriched = item.copy(
-            id = item.id ?: nextPos,
-            date = item.date ?: now,
-            createdAt = item.createdAt ?: now,
-            position = item.position ?: nextPos,
-        )
-        existing.add(enriched)
-        saveAll(existing)
-        OperationalLogger.debug("speech_history.save", "succeeded", count = existing.size)
-        enriched
-    }
-
-    override suspend fun list(): List<SaidText> = withContext(Dispatchers.Default) { loadAll() }
-
-    override suspend fun deleteAll() = withContext(Dispatchers.Default) {
-        saveAll(emptyList())
-    }
-
-    override suspend fun addAll(items: List<SaidText>) = withContext(Dispatchers.Default) {
-        saveAll(items)
-    }
-
-    private fun loadAll(): List<SaidText> {
-        val text = defaults.stringForKey(storageKey) ?: return emptyList()
-        return try {
-            json.decodeFromString(ListSerializer(SaidText.serializer()), text)
-        } catch (t: Throwable) {
-            OperationalLogger.warn(
-                operation = "speech_history.load",
-                outcome = "failed",
-                exceptionClass = t.loggingClassName(),
+    override suspend fun add(item: SaidText): SaidText {
+        var stored = item
+        val updated = store.update(::emptyList) { existing ->
+            val now = Clock.System.now().toEpochMilliseconds()
+            val nextPos = (existing.maxOfOrNull { it.position ?: 0 } ?: 0) + 1
+            stored = item.copy(
+                id = item.id ?: nextPos,
+                date = item.date ?: now,
+                createdAt = item.createdAt ?: now,
+                position = item.position ?: nextPos,
             )
-            emptyList()
+            existing + stored
         }
+        OperationalLogger.debug("speech_history.save", "succeeded", count = updated.size)
+        return stored
     }
 
-    private fun saveAll(list: List<SaidText>) {
-        try {
-            val text = json.encodeToString(ListSerializer(SaidText.serializer()), list)
-            defaults.setObject(text, storageKey)
-            defaults.synchronize()
-        } catch (t: Throwable) {
-            OperationalLogger.warn(
-                operation = "speech_history.save",
-                outcome = "failed",
-                exceptionClass = t.loggingClassName(),
-            )
-        }
+    override suspend fun list(): List<SaidText> = store.read(::emptyList)
+
+    override suspend fun deleteAll() {
+        store.replace(emptyList(), ::emptyList)
+    }
+
+    override suspend fun addAll(items: List<SaidText>) {
+        store.replace(items, ::emptyList)
     }
 }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSettingsRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSettingsRepository.kt
@@ -2,25 +2,20 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.Settings
 import io.github.jdreioe.wingmate.domain.SettingsRepository
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
-import platform.Foundation.NSUserDefaults
 
 class IosSettingsRepository : SettingsRepository {
-    private val prefs by lazy { NSUserDefaults.standardUserDefaults() }
     private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
-    private val key = "ui_settings_v1"
+    private val store = IosPreferencesJsonStore(
+        key = "ui_settings_v1",
+        encode = { json.encodeToString(Settings.serializer(), it) },
+        decode = { json.decodeFromString(Settings.serializer(), it) },
+    )
 
-    override suspend fun get(): Settings = withContext(Dispatchers.Default) {
-        val text = prefs.stringForKey(key)
-        if (text == null) Settings() else runCatching { json.decodeFromString(Settings.serializer(), text) }.getOrElse { Settings() }
-    }
+    override suspend fun get(): Settings = store.read(::Settings)
 
-    override suspend fun update(settings: Settings): Settings = withContext(Dispatchers.Default) {
-        val text = json.encodeToString(Settings.serializer(), settings)
-        prefs.setObject(text, forKey = key)
-        prefs.synchronize()
-        settings
+    override suspend fun update(settings: Settings): Settings {
+        store.replace(settings, ::Settings)
+        return settings
     }
 }

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosVoiceRepository.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosVoiceRepository.kt
@@ -2,11 +2,8 @@ package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.domain.VoiceRepository
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
-import platform.Foundation.NSUserDefaults
 
 /**
  * iOS implementation that persists the selected voice using NSUserDefaults.
@@ -14,31 +11,27 @@ import platform.Foundation.NSUserDefaults
  */
 class IosVoiceRepository : VoiceRepository {
     private val json = Json { ignoreUnknownKeys = true; prettyPrint = false }
-    private val prefs by lazy { NSUserDefaults.standardUserDefaults() }
-    private val keySelected = "selected_voice"
-    private val keyList = "voice_list"
+    private val listSerializer = ListSerializer(Voice.serializer())
+    private val voices = IosPreferencesJsonStore(
+        key = "voice_list",
+        encode = { json.encodeToString(listSerializer, it) },
+        decode = { json.decodeFromString(listSerializer, it) },
+    )
+    private val selected = IosPreferencesJsonStore(
+        key = "selected_voice",
+        encode = { json.encodeToString(Voice.serializer(), it) },
+        decode = { json.decodeFromString(Voice.serializer(), it) },
+    )
 
-    override suspend fun getVoices(): List<Voice> = withContext(Dispatchers.Default) {
-        val text = prefs.stringForKey(keyList) ?: return@withContext emptyList()
-        return@withContext runCatching { json.decodeFromString(ListSerializer(Voice.serializer()), text) }.getOrNull() ?: emptyList()
+    override suspend fun getVoices(): List<Voice> = voices.read(::emptyList)
+
+    override suspend fun saveVoices(list: List<Voice>) {
+        voices.replace(list, ::emptyList)
     }
 
-    override suspend fun saveVoices(list: List<Voice>) = withContext(Dispatchers.Default) {
-        val text = json.encodeToString(ListSerializer(Voice.serializer()), list)
-        prefs.setObject(text, forKey = keyList)
-        prefs.synchronize()
-        Unit
+    override suspend fun saveSelected(voice: Voice) {
+        selected.replace(voice) { voice }
     }
 
-    override suspend fun saveSelected(voice: Voice) = withContext(Dispatchers.Default) {
-        val text = json.encodeToString(Voice.serializer(), voice)
-        prefs.setObject(text, forKey = keySelected)
-        prefs.synchronize()
-        Unit
-    }
-
-    override suspend fun getSelected(): Voice? = withContext(Dispatchers.Default) {
-        val text = prefs.stringForKey(keySelected) ?: return@withContext null
-        return@withContext runCatching { json.decodeFromString(Voice.serializer(), text) }.getOrNull()
-    }
+    override suspend fun getSelected(): Voice? = selected.readNullable()
 }

--- a/core/data/src/iosTest/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPreferencesJsonStoreTest.kt
+++ b/core/data/src/iosTest/kotlin/io/github/jdreioe/wingmate/infrastructure/IosPreferencesJsonStoreTest.kt
@@ -1,0 +1,79 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.domain.PersistenceError
+import io.github.jdreioe.wingmate.domain.PersistenceException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import platform.Foundation.NSUserDefaults
+import platform.Foundation.NSUUID
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+
+class IosPreferencesJsonStoreTest {
+    private val suiteName = "wingmate.persistence.${NSUUID.UUID().UUIDString}"
+    private val defaults = assertNotNull(NSUserDefaults(suiteName = suiteName))
+    private val serializer = ListSerializer(String.serializer())
+    private val json = Json
+
+    @AfterTest
+    fun cleanUp() {
+        defaults.removePersistentDomainForName(suiteName)
+    }
+
+    @Test
+    fun corruptPayloadIsQuarantinedAndNotOverwritten() = runBlocking {
+        defaults.setObject("[\"truncated", forKey = "items")
+        val store = store()
+
+        val failure = assertFailsWith<PersistenceException> {
+            store.update(::emptyList) { it + "new" }
+        }
+
+        assertEquals(PersistenceError.CorruptOrUnsupported, failure.error)
+        assertEquals("[\"truncated", defaults.stringForKey("items"))
+        assertEquals("[\"truncated", defaults.stringForKey("items_corrupt_backup"))
+    }
+
+    @Test
+    fun failedNativeWriteRestoresPreviousPayload() = runBlocking {
+        defaults.setObject("[\"existing\"]", forKey = "items")
+        val store = store(synchronize = { false })
+
+        val failure = assertFailsWith<PersistenceException> {
+            store.update(::emptyList) { it + "new" }
+        }
+
+        assertEquals(PersistenceError.Io, failure.error)
+        assertEquals("[\"existing\"]", defaults.stringForKey("items"))
+    }
+
+    @Test
+    fun overlappingMutationsAreLinearized() = runBlocking {
+        val store = store()
+
+        coroutineScope {
+            (0 until 40).map { index ->
+                async { store.update(::emptyList) { it + index.toString() } }
+            }.awaitAll()
+        }
+
+        assertEquals(40, store.read(::emptyList).toSet().size)
+    }
+
+    private fun store(synchronize: () -> Boolean = { defaults.synchronize() }) =
+        IosPreferencesJsonStore(
+            key = "items",
+            encode = { json.encodeToString(serializer, it) },
+            decode = { json.decodeFromString(serializer, it) },
+            defaults = defaults,
+            synchronize = synchronize,
+        )
+}

--- a/core/data/src/jvmMain/kotlin/io/github/jdreioe/wingmate/infrastructure/JvmFileStorage.kt
+++ b/core/data/src/jvmMain/kotlin/io/github/jdreioe/wingmate/infrastructure/JvmFileStorage.kt
@@ -1,9 +1,15 @@
 package io.github.jdreioe.wingmate.infrastructure
 
 import io.github.jdreioe.wingmate.domain.FileStorage
+import io.github.jdreioe.wingmate.domain.FileStorageWriteException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 class JvmFileStorage(
     private val rootDir: File = File(System.getProperty("user.home"), ".wingmate/files")
@@ -12,11 +18,8 @@ class JvmFileStorage(
         rootDir.mkdirs()
     }
 
-    override suspend fun save(fileName: String, content: String) = withContext(Dispatchers.IO) {
-        val file = resolve(fileName)
-        file.parentFile?.mkdirs()
-        file.writeText(content)
-    }
+    override suspend fun save(fileName: String, content: String) =
+        saveBytes(fileName, content.encodeToByteArray())
 
     override suspend fun load(fileName: String): String? = withContext(Dispatchers.IO) {
         val file = resolve(fileName)
@@ -24,18 +27,14 @@ class JvmFileStorage(
     }
 
     override suspend fun saveBytes(fileName: String, content: ByteArray) = withContext(Dispatchers.IO) {
-        val file = resolve(fileName)
-        file.parentFile?.mkdirs()
-        file.writeBytes(content)
+        writeAtomically(resolve(fileName)) { it.write(content) }
     }
 
     override suspend fun saveStream(
         fileName: String,
         producer: suspend (suspend (ByteArray) -> Unit) -> Unit
     ) = withContext(Dispatchers.IO) {
-        val file = resolve(fileName)
-        file.parentFile?.mkdirs()
-        file.outputStream().buffered().use { output ->
+        writeAtomically(resolve(fileName)) { output ->
             producer { chunk -> output.write(chunk) }
         }
     }
@@ -55,4 +54,34 @@ class JvmFileStorage(
     }
 
     private fun resolve(fileName: String): File = File(rootDir, fileName)
+
+    private suspend fun writeAtomically(file: File, write: suspend (OutputStream) -> Unit) {
+        val parent = file.absoluteFile.parentFile ?: throw FileStorageWriteException()
+        var temporary: File? = null
+        try {
+            check(parent.mkdirs() || parent.isDirectory)
+            val temp = Files.createTempFile(parent.toPath(), ".${file.name}.", ".tmp").toFile()
+            temporary = temp
+            FileOutputStream(temp).use { raw ->
+                val output = raw.buffered()
+                write(output)
+                output.flush()
+                raw.fd.sync()
+            }
+            Files.move(
+                temp.toPath(),
+                file.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: FileStorageWriteException) {
+            throw error
+        } catch (_: Exception) {
+            throw FileStorageWriteException()
+        } finally {
+            temporary?.delete()
+        }
+    }
 }

--- a/core/data/src/jvmTest/kotlin/io/github/jdreioe/wingmate/infrastructure/JvmFileStorageTest.kt
+++ b/core/data/src/jvmTest/kotlin/io/github/jdreioe/wingmate/infrastructure/JvmFileStorageTest.kt
@@ -1,0 +1,27 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import io.github.jdreioe.wingmate.domain.FileStorageWriteException
+import java.io.IOException
+import java.nio.file.Files
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class JvmFileStorageTest {
+    @Test
+    fun failedStreamWriteLeavesPreviousFileIntact() = runBlocking {
+        val root = Files.createTempDirectory("wingmate-file-storage-").toFile()
+        val storage = JvmFileStorage(root)
+        storage.save("user-data.json", "previous")
+
+        assertFailsWith<FileStorageWriteException> {
+            storage.saveStream("user-data.json") { emit ->
+                emit("partial".encodeToByteArray())
+                throw IOException("simulated interrupted write")
+            }
+        }
+
+        assertEquals("previous", storage.load("user-data.json"))
+    }
+}

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/Persistence.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/Persistence.kt
@@ -1,0 +1,37 @@
+package io.github.jdreioe.wingmate.domain
+
+/** Privacy-safe categories for failures while reading or writing user data. */
+enum class PersistenceError {
+    CorruptOrUnsupported,
+    Io,
+    SecureStorage,
+}
+
+/**
+ * Thrown by repository adapters when persisted user data cannot be trusted.
+ * Callers may safely use [error] for UI state; the message never contains payload data.
+ */
+class PersistenceException(
+    val error: PersistenceError,
+    cause: Throwable? = null,
+) : Exception(
+    when (error) {
+        PersistenceError.CorruptOrUnsupported -> "Stored data is corrupt or unsupported"
+        PersistenceError.Io -> "Stored data could not be read or saved"
+        PersistenceError.SecureStorage -> "Secure storage is unavailable"
+    },
+    cause,
+)
+
+/** Distinguishes first run from a successfully loaded value, including an empty value. */
+sealed interface PersistenceRead<out T> {
+    data object Absent : PersistenceRead<Nothing>
+    data class Loaded<T>(val value: T) : PersistenceRead<T>
+    data class Failed(val error: PersistenceError, val cause: Throwable? = null) : PersistenceRead<Nothing>
+}
+
+fun <T> PersistenceRead<T>.valueOr(defaultValue: () -> T): T = when (this) {
+    PersistenceRead.Absent -> defaultValue()
+    is PersistenceRead.Loaded -> value
+    is PersistenceRead.Failed -> throw PersistenceException(error, cause)
+}

--- a/feature/communication/presentation/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/bloc/PhraseListStoreFactory.kt
+++ b/feature/communication/presentation/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/bloc/PhraseListStoreFactory.kt
@@ -36,6 +36,7 @@ class PhraseListStoreFactory(
         ) {}
 
     private sealed class Msg {
+        data object Loading : Msg()
         data class PhrasesAndCategoriesLoaded(val phrases: List<Phrase>, val categories: List<Phrase>) : Msg()
         data class CategorySelected(val categoryId: String?) : Msg()
         data class ErrorOccurred(val error: String) : Msg()
@@ -65,6 +66,7 @@ class PhraseListStoreFactory(
         }
 
         private fun loadPhrasesAndCategories() {
+            dispatch(Msg.Loading)
             scope.launch {
                 try {
                     val (phrases, categories) = getPhrasesAndCategoriesUseCase()
@@ -197,7 +199,13 @@ class PhraseListStoreFactory(
     private object ReducerImpl : Reducer<PhraseListStore.State, Msg> {
         override fun PhraseListStore.State.reduce(msg: Msg): PhraseListStore.State =
             when (msg) {
-                is Msg.PhrasesAndCategoriesLoaded -> copy(phrases = msg.phrases, categories = msg.categories, isLoading = false)
+                Msg.Loading -> copy(isLoading = true, error = null)
+                is Msg.PhrasesAndCategoriesLoaded -> copy(
+                    phrases = msg.phrases,
+                    categories = msg.categories,
+                    isLoading = false,
+                    error = null,
+                )
                 is Msg.CategorySelected -> copy(selectedCategoryId = msg.categoryId)
                 is Msg.ErrorOccurred -> copy(error = msg.error, isLoading = false)
                 is Msg.PhraseUpdated -> copy(phrases = phrases.map { if (it.id == msg.phrase.id) msg.phrase else it })

--- a/iosApp/iosApp/Base.lproj/Localizable.strings
+++ b/iosApp/iosApp/Base.lproj/Localizable.strings
@@ -74,6 +74,7 @@
 "azure.credentials.configured" = "Azure Speech credentials are securely configured on this device.";
 "azure.credentials.replace" = "Replace Azure credentials";
 "common.error" = "Error";
+"common.retry" = "Retry";
 "common.ok" = "OK";
 "common.saving" = "Saving…";
 "common.save" = "Save";

--- a/iosApp/iosApp/ViewModels/IosViewModel.swift
+++ b/iosApp/iosApp/ViewModels/IosViewModel.swift
@@ -414,6 +414,10 @@ final class IosViewModel: ObservableObject {
     _ = try? await bridge.cacheAllBoardSetFields()
     }
 
+    func retryPhraseLoad() {
+        bridge.refreshPhrases()
+    }
+
     func refreshAzureConfiguration() async {
         do {
             let cfg = try await bridge.getSpeechConfig()

--- a/iosApp/iosApp/Views/MainContentView.swift
+++ b/iosApp/iosApp/Views/MainContentView.swift
@@ -152,7 +152,10 @@ struct MainContentView: View {
                 .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color(.separator)))
             }
             if let err = model.state.error {
-                HStack(spacing: 4) { Text("common.error"); Text(err) }.foregroundStyle(.red)
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 4) { Text("common.error"); Text(err) }.foregroundStyle(.red)
+                    Button("common.retry") { model.retryPhraseLoad() }
+                }
             }
             if model.state.isLoading { ProgressView().frame(maxWidth: .infinity, alignment: .center) }
 

--- a/iosApp/iosApp/da.lproj/Localizable.strings
+++ b/iosApp/iosApp/da.lproj/Localizable.strings
@@ -85,6 +85,7 @@
 "azure.credentials.replace" = "Erstat Azure-legitimationsoplysninger";
 
 "common.error" = "FEJL";
+"common.retry" = "Prøv igen";
 "common.ok" = "OK";
 "common.saving" = "Gemmmer";
 "common.save" = "Gem";

--- a/iosApp/iosApp/de.lproj/Localizable.strings
+++ b/iosApp/iosApp/de.lproj/Localizable.strings
@@ -83,6 +83,7 @@
 "azure.credentials.configured" = "Die Azure Speech-Anmeldedaten sind auf diesem Gerät sicher konfiguriert.";
 "azure.credentials.replace" = "Azure-Anmeldedaten ersetzen";
 "common.error" = "Fehler";
+"common.retry" = "Erneut versuchen";
 "common.ok" = "OK";
 "common.saving" = "Speichern…";
 "common.save" = "Speichern";

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/JsonRepositories.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/JsonRepositories.kt
@@ -15,6 +15,10 @@ import org.freedesktop.dbus.annotations.DBusInterfaceName
 import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
 import org.freedesktop.dbus.interfaces.DBusInterface
 import java.io.File
+import java.io.FileOutputStream
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 private val configDir = File(System.getProperty("user.home"), ".config/wingmate").apply { mkdirs() }
 private val json = Json { 
@@ -23,43 +27,19 @@ private val json = Json {
     encodeDefaults = true
 }
 
-class JsonFileSettingsRepository : SettingsRepository {
-    private val file = File(configDir, "settings.json")
-    private var cached: Settings = Settings()
+class JsonFileSettingsRepository(
+    private val file: File = File(configDir, "settings.json"),
+    private val writer: suspend (File, String) -> Unit = ::writeTextAtomically,
+) : SettingsRepository {
+    private val mutex = Mutex()
 
-    init {
-        println("[PERSISTENCE] JsonFileSettingsRepository init. File: ${file.absolutePath}")
-        if (file.exists()) {
-            try {
-                val text = file.readText()
-                println("[PERSISTENCE] Read settings content: $text")
-                cached = json.decodeFromString<Settings>(text)
-                println("[PERSISTENCE] Decoded settings successfully.")
-            } catch (e: Exception) {
-                println("[PERSISTENCE] Error reading settings: ${e.message}")
-                e.printStackTrace()
-            }
-        } else {
-            println("[PERSISTENCE] Settings file does not exist, using defaults.")
-        }
+    override suspend fun get(): Settings = mutex.withLock {
+        readJson<Settings>(file).valueOr(::Settings)
     }
 
-    override suspend fun get(): Settings = withContext(Dispatchers.IO) {
-        println("[PERSISTENCE] getSettings called. Current value: $cached")
-        cached
-    }
-
-    override suspend fun update(settings: Settings): Settings = withContext(Dispatchers.IO) {
-        println("[PERSISTENCE] updateSettings called with: $settings")
-        cached = settings
-        try {
-            val text = json.encodeToString(settings)
-            file.writeText(text)
-            println("[PERSISTENCE] Saved settings to disk: $text")
-        } catch (e: Exception) {
-            println("[PERSISTENCE] Error saving settings: ${e.message}")
-            e.printStackTrace()
-        }
+    override suspend fun update(settings: Settings): Settings = mutex.withLock {
+        readJson<Settings>(file).valueOr(::Settings) // Never replace an unreadable store.
+        writeJson(file, settings, writer)
         settings
     }
 }
@@ -274,258 +254,286 @@ interface KWalletDbus : DBusInterface {
     fun removeEntry(handle: Int, folder: String, entry: String, appId: String): Int
 }
 
-class JsonFileVoiceRepository : VoiceRepository {
-    private val file = File(configDir, "voices.json")
-    private val selectedFile = File(configDir, "selected-voice.json")
-    private val voices = mutableListOf<Voice>()
-    private var selectedVoice: Voice? = null
+class JsonFileVoiceRepository(
+    private val file: File = File(configDir, "voices.json"),
+    private val selectedFile: File = File(configDir, "selected-voice.json"),
+    private val writer: suspend (File, String) -> Unit = ::writeTextAtomically,
+) : VoiceRepository {
+    private val mutex = Mutex()
 
-    init {
-        println("[PERSISTENCE] JsonFileVoiceRepository init. File: ${file.absolutePath}")
-        if (file.exists()) {
-            try {
-                val list = json.decodeFromString<List<Voice>>(file.readText())
-                voices.addAll(list)
-                println("[PERSISTENCE] Loaded ${voices.size} voices from disk.")
-            } catch (e: Exception) {
-                println("[PERSISTENCE] Error loading voices: ${e.message}")
-                e.printStackTrace()
-            }
-        }
-        if (selectedFile.exists()) {
-            try {
-                selectedVoice = json.decodeFromString<Voice>(selectedFile.readText())
-                println("[PERSISTENCE] Loaded selected voice: ${selectedVoice?.name}")
-            } catch (e: Exception) {
-                println("[PERSISTENCE] Error loading selected voice: ${e.message}")
-                e.printStackTrace()
-            }
-        }
+    override suspend fun getVoices(): List<Voice> = mutex.withLock {
+        readJson<List<Voice>>(file).valueOr(::emptyList)
     }
 
-    override suspend fun getVoices(): List<Voice> = withContext(Dispatchers.IO) {
-        println("[PERSISTENCE] getVoices called. Count: ${voices.size}")
-        voices.toList()
+    override suspend fun saveVoices(list: List<Voice>) = mutex.withLock {
+        readJson<List<Voice>>(file).valueOr(::emptyList)
+        writeJson(file, list, writer)
     }
 
-    override suspend fun saveVoices(list: List<Voice>) = withContext(Dispatchers.IO) {
-        println("[PERSISTENCE] saveVoices called with ${list.size} voices.")
-        voices.clear()
-        voices.addAll(list)
-        try {
-            file.writeText(json.encodeToString(voices))
-            println("[PERSISTENCE] Saved voices to disk.")
-        } catch (e: Exception) {
-            println("[PERSISTENCE] Error saving voices: ${e.message}")
-            e.printStackTrace()
-        }
+    override suspend fun saveSelected(voice: Voice) = mutex.withLock {
+        readJson<Voice>(selectedFile).nullableValue()
+        writeJson(selectedFile, voice, writer)
     }
 
-    override suspend fun saveSelected(voice: Voice) = withContext(Dispatchers.IO) {
-        println("[PERSISTENCE] saveSelected voice: ${voice.name}")
-        selectedVoice = voice
-        try {
-            selectedFile.writeText(json.encodeToString(voice))
-        } catch (e: Exception) {
-            println("[PERSISTENCE] Error saving selected voice: ${e.message}")
-        }
-    }
-
-    override suspend fun getSelected(): Voice? = withContext(Dispatchers.IO) {
-        selectedVoice
+    override suspend fun getSelected(): Voice? = mutex.withLock {
+        readJson<Voice>(selectedFile).nullableValue()
     }
 }
 
 class JsonFilePronunciationDictionaryRepository(
     private val file: File = File(configDir, "pronunciations.json"),
+    private val writer: suspend (File, String) -> Unit = ::writeTextAtomically,
 ) : PronunciationDictionaryRepository {
     private val mutex = Mutex()
-    private val entries = runCatching {
-        if (file.exists()) {
-            json.decodeFromString<List<PronunciationEntry>>(file.readText())
-                .associateBy { it.word.lowercase() }
-                .toMutableMap()
-        } else {
-            mutableMapOf()
-        }
-    }.getOrElse { error ->
-        System.err.println("[PERSISTENCE] Could not load pronunciation dictionary: ${error.message}")
-        mutableMapOf()
-    }
 
     override suspend fun getAll(): List<PronunciationEntry> = mutex.withLock {
-        entries.values.sortedBy { it.word.lowercase() }
+        readEntries().values.sortedBy { it.word.lowercase() }
     }
 
     override suspend fun add(entry: PronunciationEntry) = mutex.withLock {
+        val entries = readEntries().toMutableMap()
         entries[entry.word.lowercase()] = entry
-        save()
+        save(entries.values)
     }
 
     override suspend fun delete(word: String) = mutex.withLock {
-        if (entries.remove(word.lowercase()) != null) save()
+        val entries = readEntries().toMutableMap()
+        if (entries.remove(word.lowercase()) != null) save(entries.values)
     }
 
     override suspend fun clear() = mutex.withLock {
-        entries.clear()
-        save()
+        readEntries()
+        save(emptyList())
     }
 
-    private suspend fun save() = withContext(Dispatchers.IO) {
-        file.parentFile?.mkdirs()
-        val temporary = File(file.parentFile, "${file.name}.tmp")
-        temporary.writeText(json.encodeToString(entries.values.sortedBy { it.word.lowercase() }))
-        check(temporary.renameTo(file) || runCatching {
-            temporary.copyTo(file, overwrite = true)
-            temporary.delete()
-            true
-        }.getOrDefault(false)) {
-            "Could not save pronunciation dictionary"
-        }
-    }
+    private fun readEntries(): Map<String, PronunciationEntry> =
+        readJson<List<PronunciationEntry>>(file)
+            .valueOr(::emptyList)
+            .associateBy { it.word.lowercase() }
+
+    private suspend fun save(entries: Collection<PronunciationEntry>) =
+        writeJson(file, entries.sortedBy { it.word.lowercase() }, writer)
 }
 
 class JsonFilePhraseRepository(
     private val file: File = File(configDir, "phrases.json"),
+    private val writer: suspend (File, String) -> Unit = ::writeTextAtomically,
 ) : PhraseRepository {
     private val mutex = Mutex()
-    private val phrases = runCatching {
-        if (file.exists()) json.decodeFromString<List<Phrase>>(file.readText()).toMutableList()
-        else mutableListOf()
-    }.getOrElse { error ->
-        System.err.println("[PERSISTENCE] Could not load phrases: ${error.message}")
-        mutableListOf()
-    }
 
-    override suspend fun getAll(): List<Phrase> = mutex.withLock { phrases.toList() }
+    override suspend fun getAll(): List<Phrase> = mutex.withLock { readPhrases() }
 
     override suspend fun add(phrase: Phrase): Phrase = mutex.withLock {
+        val phrases = readPhrases().toMutableList()
         val stored = phrase.copy(
             id = phrase.id.ifBlank { "phrase-${java.util.UUID.randomUUID()}" },
             createdAt = phrase.createdAt.takeIf { it > 0 } ?: System.currentTimeMillis(),
         )
         phrases += stored
-        save()
+        save(phrases)
         stored
     }
 
     override suspend fun update(phrase: Phrase): Phrase = mutex.withLock {
+        val phrases = readPhrases().toMutableList()
         val index = phrases.indexOfFirst { it.id == phrase.id }
         if (index >= 0) phrases[index] = phrase else phrases += phrase
-        save()
+        save(phrases)
         phrase
     }
 
     override suspend fun delete(id: String) = mutex.withLock {
-        if (phrases.removeAll { it.id == id }) save()
+        val phrases = readPhrases().toMutableList()
+        if (phrases.removeAll { it.id == id }) save(phrases)
     }
 
     override suspend fun move(fromIndex: Int, toIndex: Int) = mutex.withLock {
+        val phrases = readPhrases().toMutableList()
         if (fromIndex !in phrases.indices) return@withLock
         val item = phrases.removeAt(fromIndex)
         phrases.add(toIndex.coerceIn(0, phrases.size), item)
-        save()
+        save(phrases)
     }
 
-    private suspend fun save() = writeJsonAtomically(file, phrases)
+    private fun readPhrases() = readJson<List<Phrase>>(file).valueOr(::emptyList)
+    private suspend fun save(phrases: List<Phrase>) = writeJson(file, phrases, writer)
 }
 
 class JsonFileCategoryRepository(
     private val file: File = File(configDir, "categories.json"),
+    private val writer: suspend (File, String) -> Unit = ::writeTextAtomically,
 ) : CategoryRepository {
     private val mutex = Mutex()
-    private val categories = runCatching {
-        if (file.exists()) json.decodeFromString<List<CategoryItem>>(file.readText()).toMutableList()
-        else mutableListOf()
-    }.getOrElse { error ->
-        System.err.println("[PERSISTENCE] Could not load categories: ${error.message}")
-        mutableListOf()
-    }
 
-    override suspend fun getAll(): List<CategoryItem> = mutex.withLock { categories.toList() }
+    override suspend fun getAll(): List<CategoryItem> = mutex.withLock { readCategories() }
 
     override suspend fun add(category: CategoryItem): CategoryItem = mutex.withLock {
+        val categories = readCategories().toMutableList()
         val stored = category.copy(id = category.id.ifBlank { "category-${java.util.UUID.randomUUID()}" })
         categories += stored
-        save()
+        save(categories)
         stored
     }
 
     override suspend fun update(category: CategoryItem): CategoryItem = mutex.withLock {
+        val categories = readCategories().toMutableList()
         val index = categories.indexOfFirst { it.id == category.id }
         if (index >= 0) categories[index] = category else categories += category
-        save()
+        save(categories)
         category
     }
 
     override suspend fun delete(id: String) = mutex.withLock {
-        if (categories.removeAll { it.id == id }) save()
+        val categories = readCategories().toMutableList()
+        if (categories.removeAll { it.id == id }) save(categories)
     }
 
     override suspend fun move(fromIndex: Int, toIndex: Int) = mutex.withLock {
+        val categories = readCategories().toMutableList()
         if (fromIndex !in categories.indices) return@withLock
         val item = categories.removeAt(fromIndex)
         categories.add(toIndex.coerceIn(0, categories.size), item)
-        save()
+        save(categories)
     }
 
-    private suspend fun save() = writeJsonAtomically(file, categories)
+    private fun readCategories() = readJson<List<CategoryItem>>(file).valueOr(::emptyList)
+    private suspend fun save(categories: List<CategoryItem>) = writeJson(file, categories, writer)
 }
 
-private suspend inline fun <reified T> writeJsonAtomically(file: File, value: T) =
-    withContext(Dispatchers.IO) {
-        file.parentFile?.mkdirs()
-        val temporary = File(file.parentFile, "${file.name}.tmp")
-        temporary.writeText(json.encodeToString(value))
-        check(temporary.renameTo(file) || runCatching {
-            temporary.copyTo(file, overwrite = true)
-            temporary.delete()
-            true
-        }.getOrDefault(false)) { "Could not save ${file.name}" }
-    }
+class JsonFileBoardRepository(
+    private val file: File = File(configDir, "boards.json"),
+    private val writer: suspend (File, String) -> Unit = ::writeTextAtomically,
+) : BoardRepository {
+    private val mutex = Mutex()
 
-class JsonFileBoardRepository : BoardRepository {
-    private val file = File(configDir, "boards.json")
-    private val boards = runCatching {
-        if (file.exists()) json.decodeFromString<List<ObfBoard>>(file.readText()).associateBy { it.id }.toMutableMap()
-        else mutableMapOf()
-    }.getOrElse { mutableMapOf() }
+    override suspend fun getBoard(id: String): ObfBoard? = mutex.withLock { readBoards()[id] }
 
-    override suspend fun getBoard(id: String): ObfBoard? = withContext(Dispatchers.IO) { boards[id] }
-
-    override suspend fun saveBoard(board: ObfBoard) = withContext(Dispatchers.IO) {
+    override suspend fun saveBoard(board: ObfBoard) = mutex.withLock {
+        val boards = readBoards().toMutableMap()
         boards[board.id] = board
-        file.writeText(json.encodeToString(boards.values.toList()))
+        save(boards.values)
     }
 
-    override suspend fun listBoards(): List<ObfBoard> = withContext(Dispatchers.IO) { boards.values.toList() }
+    override suspend fun saveBoards(boards: List<ObfBoard>) = mutex.withLock {
+        if (boards.isEmpty()) return@withLock
+        val updated = readBoards().toMutableMap()
+        boards.forEach { updated[it.id] = it }
+        save(updated.values)
+    }
 
-    override suspend fun deleteBoard(id: String) = withContext(Dispatchers.IO) {
-        boards.remove(id)
-        file.writeText(json.encodeToString(boards.values.toList()))
+    override suspend fun listBoards(): List<ObfBoard> = mutex.withLock { readBoards().values.toList() }
+
+    override suspend fun deleteBoard(id: String) = mutex.withLock {
+        val boards = readBoards().toMutableMap()
+        if (boards.remove(id) != null) save(boards.values)
+    }
+
+    private fun readBoards() = readJson<List<ObfBoard>>(file).valueOr(::emptyList).associateBy { it.id }
+    private suspend fun save(boards: Collection<ObfBoard>) = writeJson(file, boards.toList(), writer)
+}
+
+class JsonFileBoardSetRepository(
+    private val file: File = File(configDir, "board-sets.json"),
+    private val writer: suspend (File, String) -> Unit = ::writeTextAtomically,
+) : BoardSetRepository {
+    private val mutex = Mutex()
+
+    override suspend fun getBoardSet(id: String): ObfBoardSet? = mutex.withLock { readBoardSets()[id] }
+
+    override suspend fun saveBoardSet(boardSet: ObfBoardSet) = mutex.withLock {
+        val boardSets = readBoardSets().toMutableMap()
+        boardSets[boardSet.id] = boardSet
+        save(boardSets.values)
+    }
+
+    override suspend fun listBoardSets(): List<ObfBoardSet> = mutex.withLock {
+        readBoardSets().values.sortedByDescending { it.updatedAt }
+    }
+
+    override suspend fun deleteBoardSet(id: String) = mutex.withLock {
+        val boardSets = readBoardSets().toMutableMap()
+        if (boardSets.remove(id) != null) save(boardSets.values)
+    }
+
+    private fun readBoardSets() =
+        readJson<List<ObfBoardSet>>(file).valueOr(::emptyList).associateBy { it.id }
+
+    private suspend fun save(boardSets: Collection<ObfBoardSet>) = writeJson(file, boardSets.toList(), writer)
+}
+
+private inline fun <reified T> readJson(file: File): PersistenceRead<T> {
+    if (!file.exists()) return PersistenceRead.Absent
+    val text = try {
+        file.readText()
+    } catch (error: Exception) {
+        return PersistenceRead.Failed(PersistenceError.Io, error)
+    }
+    return try {
+        PersistenceRead.Loaded(json.decodeFromString<T>(text))
+    } catch (error: Exception) {
+        quarantineCorruptFile(file)
+        PersistenceRead.Failed(PersistenceError.CorruptOrUnsupported, error)
     }
 }
 
-class JsonFileBoardSetRepository : BoardSetRepository {
-    private val file = File(configDir, "board-sets.json")
-    private val boardSets = runCatching {
-        if (file.exists()) json.decodeFromString<List<ObfBoardSet>>(file.readText()).associateBy { it.id }.toMutableMap()
-        else mutableMapOf()
-    }.getOrElse { mutableMapOf() }
+private fun <T> PersistenceRead<T>.nullableValue(): T? = when (this) {
+    PersistenceRead.Absent -> null
+    is PersistenceRead.Loaded -> value
+    is PersistenceRead.Failed -> throw PersistenceException(error, cause)
+}
 
-    override suspend fun getBoardSet(id: String): ObfBoardSet? = withContext(Dispatchers.IO) { boardSets[id] }
-
-    override suspend fun saveBoardSet(boardSet: ObfBoardSet) = withContext(Dispatchers.IO) {
-        boardSets[boardSet.id] = boardSet
-        file.writeText(json.encodeToString(boardSets.values.toList()))
+private fun quarantineCorruptFile(file: File) {
+    runCatching {
+        val prefix = "${file.name}.corrupt-"
+        if (file.parentFile?.listFiles().orEmpty().any { it.name.startsWith(prefix) }) return
+        val quarantine = File(file.parentFile, "${file.name}.corrupt-${System.currentTimeMillis()}")
+        Files.copy(file.toPath(), quarantine.toPath())
     }
+}
 
-    override suspend fun listBoardSets(): List<ObfBoardSet> = withContext(Dispatchers.IO) {
-        boardSets.values.sortedByDescending { it.updatedAt }
+private suspend inline fun <reified T> writeJson(
+    file: File,
+    value: T,
+    noinline writer: suspend (File, String) -> Unit,
+) {
+    val encoded = try {
+        json.encodeToString(value)
+    } catch (error: Exception) {
+        throw PersistenceException(PersistenceError.Io, error)
     }
+    try {
+        writer(file, encoded)
+    } catch (error: PersistenceException) {
+        throw error
+    } catch (error: Exception) {
+        throw PersistenceException(PersistenceError.Io, error)
+    }
+}
 
-    override suspend fun deleteBoardSet(id: String) = withContext(Dispatchers.IO) {
-        boardSets.remove(id)
-        file.writeText(json.encodeToString(boardSets.values.toList()))
+private suspend fun writeTextAtomically(file: File, text: String) = withContext(Dispatchers.IO) {
+    val parent = file.absoluteFile.parentFile
+    try {
+        check(parent.mkdirs() || parent.isDirectory) { "Could not create persistence directory" }
+        val temporary = Files.createTempFile(parent.toPath(), ".${file.name}.", ".tmp").toFile()
+        try {
+            FileOutputStream(temporary).use { output ->
+                output.write(text.encodeToByteArray())
+                output.fd.sync()
+            }
+            Files.move(
+                temporary.toPath(),
+                file.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+            )
+        } finally {
+            temporary.delete()
+        }
+    } catch (error: AtomicMoveNotSupportedException) {
+        throw PersistenceException(PersistenceError.Io, error)
+    } catch (error: PersistenceException) {
+        throw error
+    } catch (error: Exception) {
+        throw PersistenceException(PersistenceError.Io, error)
     }
 }

--- a/linuxApp/src/test/kotlin/io/github/jdreioe/wingmate/kde/JsonFilePronunciationDictionaryRepositoryTest.kt
+++ b/linuxApp/src/test/kotlin/io/github/jdreioe/wingmate/kde/JsonFilePronunciationDictionaryRepositoryTest.kt
@@ -3,10 +3,22 @@ package io.github.jdreioe.wingmate.kde
 import io.github.jdreioe.wingmate.domain.PronunciationEntry
 import io.github.jdreioe.wingmate.domain.Phrase
 import io.github.jdreioe.wingmate.domain.CategoryItem
+import io.github.jdreioe.wingmate.domain.PersistenceError
+import io.github.jdreioe.wingmate.domain.PersistenceException
+import io.github.jdreioe.wingmate.domain.Settings
+import io.github.jdreioe.wingmate.domain.Voice
+import io.github.jdreioe.wingmate.domain.obf.ObfBoard
+import io.github.jdreioe.wingmate.domain.obf.ObfBoardSet
+import java.io.IOException
 import java.nio.file.Files
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class JsonFilePronunciationDictionaryRepositoryTest {
     @Test
@@ -66,5 +78,82 @@ class JsonFilePronunciationDictionaryRepositoryTest {
             listOf("Second", "Renamed"),
             JsonFileCategoryRepository(file).getAll().map { it.name },
         )
+    }
+
+    @Test
+    fun `corrupt phrase store is quarantined and never overwritten by add`() = runBlocking {
+        val directory = Files.createTempDirectory("wingmate-corrupt-phrases-").toFile()
+        val file = directory.resolve("phrases.json")
+        val corruptPayload = "[{\"id\":\"truncated"
+        file.writeText(corruptPayload)
+
+        val failure = assertFailsWith<PersistenceException> {
+            JsonFilePhraseRepository(file).add(Phrase(id = "new", text = "New", createdAt = 1))
+        }
+
+        assertEquals(PersistenceError.CorruptOrUnsupported, failure.error)
+        assertEquals(corruptPayload, file.readText())
+        assertTrue(directory.listFiles().orEmpty().any { it.name.startsWith("phrases.json.corrupt-") })
+    }
+
+    @Test
+    fun `failed atomic phrase write leaves previous store readable`() = runBlocking {
+        val file = Files.createTempDirectory("wingmate-failed-write-").resolve("phrases.json").toFile()
+        JsonFilePhraseRepository(file).add(Phrase(id = "existing", text = "Existing", createdAt = 1))
+        val previousPayload = file.readText()
+        val repository = JsonFilePhraseRepository(
+            file = file,
+            writer = { _, _ -> throw IOException("simulated write failure") },
+        )
+
+        val failure = assertFailsWith<PersistenceException> {
+            repository.add(Phrase(id = "new", text = "New", createdAt = 2))
+        }
+
+        assertEquals(PersistenceError.Io, failure.error)
+        assertEquals(previousPayload, file.readText())
+        assertEquals(listOf("existing"), JsonFilePhraseRepository(file).getAll().map { it.id })
+    }
+
+    @Test
+    fun `overlapping phrase mutations are linearized`() = runBlocking {
+        val file = Files.createTempDirectory("wingmate-concurrent-phrases-").resolve("phrases.json").toFile()
+        val repository = JsonFilePhraseRepository(file)
+
+        coroutineScope {
+            (0 until 40).map { index ->
+                async { repository.add(Phrase(id = "phrase-$index", text = "Phrase $index", createdAt = index + 1L)) }
+            }.awaitAll()
+        }
+
+        assertEquals(40, JsonFilePhraseRepository(file).getAll().map { it.id }.toSet().size)
+    }
+
+    @Test
+    fun `every Linux JSON repository rejects corrupt data before mutation`() = runBlocking {
+        suspend fun verify(name: String, mutation: suspend (java.io.File) -> Unit) {
+            val file = Files.createTempDirectory("wingmate-corrupt-$name-").resolve("$name.json").toFile()
+            val corruptPayload = "{truncated"
+            file.writeText(corruptPayload)
+            val failure = runCatching { mutation(file) }.exceptionOrNull()
+            assertTrue(failure is PersistenceException, "$name did not return a typed persistence failure")
+            assertEquals(PersistenceError.CorruptOrUnsupported, failure.error)
+            assertEquals(corruptPayload, file.readText(), "$name overwrote its corrupt payload")
+        }
+
+        verify("settings") { JsonFileSettingsRepository(it).update(Settings()) }
+        verify("voices") { JsonFileVoiceRepository(file = it).saveVoices(listOf(Voice(name = "Test"))) }
+        verify("pronunciations") {
+            JsonFilePronunciationDictionaryRepository(it).add(PronunciationEntry("word", "wɜːd", "ipa"))
+        }
+        verify("categories") { JsonFileCategoryRepository(it).add(CategoryItem("new", "New")) }
+        verify("boards") {
+            JsonFileBoardRepository(it).saveBoard(ObfBoard(format = "open-board-0.1", id = "new"))
+        }
+        verify("board-sets") {
+            JsonFileBoardSetRepository(it).saveBoardSet(
+                ObfBoardSet("new", "New", "root", listOf("root"), createdAt = 1, updatedAt = 1),
+            )
+        }
     }
 }

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
@@ -87,6 +87,9 @@ class KoinBridge : KoinComponent {
     fun phraseListStore(): PhraseListStore = get()
     // Safe variant to avoid throwing across Swift bridge
     fun phraseListStoreOrNull(): PhraseListStore? = try { get<PhraseListStore>() } catch (_: Throwable) { null }
+    fun refreshPhrases() {
+        phraseListStoreOrNull()?.accept(PhraseListStore.Intent.Refresh)
+    }
 
     // --- Shared native text-editing policy ---
     fun mergeTextSpans(spans: List<TextSpan>, textLength: Int): List<TextSpan> =


### PR DESCRIPTION
## Summary

- Add atomic file writes and explicit persistence errors across platforms.
- Detect, quarantine, and surface corrupt persisted data instead of silently resetting it.
- Serialize repository access to prevent concurrent persistence races.
- Add retry feedback for phrase-loading failures.

## Testing

- Added JVM and iOS persistence tests.
- Added pronunciation dictionary recovery tests.
- Full test suite not run.