### PR TITLE
Harden cross-platform speech playback and cache recovery

### DIFF
--- a/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSpeechService.kt
+++ b/core/data/src/androidMain/kotlin/io/github/jdreioe/wingmate/infrastructure/AndroidSpeechService.kt
@@ -19,6 +19,8 @@ import android.os.Handler
 import android.os.Looper
 import android.widget.Toast
 import io.github.jdreioe.wingmate.domain.SpeechService
+import io.github.jdreioe.wingmate.domain.SpeechPlaybackState
+import io.github.jdreioe.wingmate.domain.SpeechPlaybackStatus
 import io.github.jdreioe.wingmate.domain.OperationalLogger
 import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
@@ -32,6 +34,10 @@ import io.ktor.client.statement.*
 import kotlinx.serialization.json.*
 import io.ktor.client.engine.okhttp.*
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -44,6 +50,7 @@ import androidx.annotation.RequiresPermission
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.coroutines.resume
 
@@ -65,7 +72,7 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
 
     // Platform TTS (fallback)
     private var tts: TextToSpeech? = null
-    private val ttsReady = AtomicBoolean(false)
+    private var ttsInitialization: CompletableDeferred<Boolean>? = null
     private var activeTtsEnginePackage: String? = null
 
     // MediaPlayer based playback for Azure synthesized audio
@@ -141,8 +148,11 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
     private var currentPitch: Double? = null
     private var currentRate: Double? = null
     private var pausedAtSegment = false
-    private var isPlaying = false
-    private var isPaused = false
+    @Volatile private var isPlaying = false
+    @Volatile private var isPaused = false
+    private val requestGeneration = AtomicLong(0)
+    @Volatile private var activeRequestJob: Job? = null
+    @Volatile private var state = SpeechPlaybackState()
     private val pendingTtsUtterances = AtomicInteger(0)
     private val mediaSession: MediaSession by lazy {
         MediaSession(context, "WingmateSpeechSession").apply {
@@ -197,32 +207,43 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
         }
     }
 
-    private fun markPlaybackStarted(text: String?, voice: Voice?) {
+    private fun markPlaybackStarted(text: String?, voice: Voice?, requestId: Long = requestGeneration.get()) {
+        if (requestGeneration.get() != requestId) return
         isPlaying = true
         isPaused = false
+        state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.PLAYING)
         updateNowPlaying(text, voice)
         updatePlaybackState(PlaybackState.STATE_PLAYING)
     }
 
-    private fun finishPlayback() {
+    private fun finishPlayback(requestId: Long = requestGeneration.get()) {
+        if (requestGeneration.get() != requestId) return
         isPlaying = false
         isPaused = false
+        state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.IDLE)
         pausedAtSegment = false
         updatePlaybackState(PlaybackState.STATE_STOPPED)
         abandonAudioFocus()
     }
 
-    private fun onTtsUtteranceFinished() {
+    private fun onTtsUtteranceFinished(utteranceId: String?) {
+        val requestId = utteranceId?.substringAfter("wingmate-", "")
+            ?.substringBefore('-')?.toLongOrNull() ?: return
+        if (requestGeneration.get() != requestId) return
         val remaining = pendingTtsUtterances.updateAndGet { count -> if (count > 0) count - 1 else 0 }
         if (remaining == 0) {
-            finishPlayback()
+            finishPlayback(requestId)
         }
     }
 
-    private fun ensureTts(enginePackageName: String? = null): TextToSpeech {
+    private suspend fun ensureTts(enginePackageName: String? = null): TextToSpeech = withContext(Dispatchers.Main) {
         val normalizedEngine = enginePackageName?.takeIf { it.isNotBlank() }
         val cur = tts
-        if (cur != null && activeTtsEnginePackage == normalizedEngine) return cur
+        if (cur != null && activeTtsEnginePackage == normalizedEngine) {
+            val ready = ttsInitialization?.let { awaitSpeechInitialization(it, 5_000) } == true
+            check(ready) { "Device text-to-speech did not become ready" }
+            return@withContext cur
+        }
 
         if (cur != null) {
             try {
@@ -238,39 +259,83 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
             tts = null
         }
 
-        ttsReady.set(false)
+        val initialization = CompletableDeferred<Boolean>()
+        ttsInitialization = initialization
         val created = if (normalizedEngine.isNullOrBlank()) {
             TextToSpeech(context) { status ->
-                ttsReady.set(status == TextToSpeech.SUCCESS)
+                initialization.complete(status == TextToSpeech.SUCCESS)
             }
         } else {
             TextToSpeech(context, { status ->
-                ttsReady.set(status == TextToSpeech.SUCCESS)
+                initialization.complete(status == TextToSpeech.SUCCESS)
             }, normalizedEngine)
         }
 
         created.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
             override fun onStart(utteranceId: String?) {
-                updatePlaybackState(PlaybackState.STATE_PLAYING)
+                val requestId = utteranceId?.substringAfter("wingmate-", "")
+                    ?.substringBefore('-')?.toLongOrNull()
+                if (requestId == requestGeneration.get()) {
+                    updatePlaybackState(PlaybackState.STATE_PLAYING)
+                }
             }
 
             override fun onDone(utteranceId: String?) {
-                onTtsUtteranceFinished()
+                onTtsUtteranceFinished(utteranceId)
             }
 
             override fun onError(utteranceId: String?, errorCode: Int) {
-                onTtsUtteranceFinished()
+                onTtsUtteranceFinished(utteranceId)
             }
 
             @Deprecated("Deprecated in Java")
             override fun onError(utteranceId: String?) {
-                onTtsUtteranceFinished()
+                onTtsUtteranceFinished(utteranceId)
             }
         })
 
         tts = created
         activeTtsEnginePackage = normalizedEngine
-        return created
+        val ready = awaitSpeechInitialization(initialization, 5_000)
+        if (!ready) {
+            if (tts === created) {
+                tts = null
+                activeTtsEnginePackage = null
+                ttsInitialization = null
+            }
+            runCatching { created.shutdown() }
+            error("Device text-to-speech failed to initialize")
+        }
+        created
+    }
+
+    private suspend fun beginRequest(): Long {
+        val job = currentCoroutineContext()[Job]
+        activeRequestJob?.takeIf { it !== job }?.cancel()
+        activeRequestJob = job
+        val requestId = requestGeneration.incrementAndGet()
+        stopNativePlayback()
+        state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.PREPARING)
+        return requestId
+    }
+
+    private suspend fun <T> executeRequest(requestId: Long, block: suspend () -> T): T = try {
+        block()
+    } catch (cancelled: CancellationException) {
+        if (requestGeneration.get() == requestId) {
+            stopNativePlayback()
+            state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.IDLE)
+        }
+        throw cancelled
+    } catch (error: Throwable) {
+        if (requestGeneration.get() == requestId) {
+            stopNativePlayback()
+            state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.FAILED, "Speech could not be played")
+            Handler(Looper.getMainLooper()).post {
+                Toast.makeText(context, "Speech could not be played. Please try again.", Toast.LENGTH_LONG).show()
+            }
+        }
+        throw error
     }
     
     /**
@@ -330,17 +395,25 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
     }
 
     override suspend fun speakWithCachePolicy(text: String, voice: Voice?, pitch: Double?, rate: Double?, cacheAudio: Boolean) {
-        // Process text to extract pause tags and create segments
-        val segments = SpeechTextProcessor.processText(text)
-        speakSegmentsInternal(segments, voice, pitch, rate, cacheAudio)
+        val requestId = beginRequest()
+        executeRequest(requestId) {
+            val segments = SpeechTextProcessor.processText(text)
+            speakSegmentsInternal(requestId, segments, voice, pitch, rate, cacheAudio)
+        }
     }
 
     override suspend fun speakSegments(segments: List<SpeechSegment>, voice: Voice?, pitch: Double?, rate: Double?) {
-        speakSegmentsInternal(segments, voice, pitch, rate, cacheAudio = true)
+        val requestId = beginRequest()
+        executeRequest(requestId) {
+            speakSegmentsInternal(requestId, segments, voice, pitch, rate, cacheAudio = true)
+        }
     }
 
     override suspend fun speakSegmentsWithCachePolicy(segments: List<SpeechSegment>, voice: Voice?, pitch: Double?, rate: Double?, cacheAudio: Boolean) {
-        speakSegmentsInternal(segments, voice, pitch, rate, cacheAudio)
+        val requestId = beginRequest()
+        executeRequest(requestId) {
+            speakSegmentsInternal(requestId, segments, voice, pitch, rate, cacheAudio)
+        }
     }
 
     override suspend fun cacheSpeech(text: String, voice: Voice?, pitch: Double?, rate: Double?): Boolean {
@@ -368,11 +441,20 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
             val dictionary = runCatching {
                 GlobalContext.get().get<io.github.jdreioe.wingmate.domain.PronunciationDictionaryRepository>().getAll()
             }.getOrDefault(emptyList())
-            val dictionaryHash = dictionary.joinToString("|") { "${it.word}:${it.phoneme}:${it.alphabet}" }.hashCode()
-            val cacheKey = "${normalizedText}_${voiceForSsml.name}_${voiceForSsml.primaryLanguage}_${voiceForSsml.selectedLanguage}_${pitch}_${rate}_${voiceForSsml.mathMode}_${dictionaryHash}".hashCode()
+            val dictionaryIdentity = dictionary.joinToString("\u001f") { "${it.word}\u001e${it.phoneme}\u001e${it.alphabet}" }
+            val cacheKey = SpeechCacheIdentity.digest(
+                normalizedText,
+                voiceForSsml.name,
+                voiceForSsml.primaryLanguage,
+                voiceForSsml.selectedLanguage,
+                pitch?.toString(),
+                rate?.toString(),
+                voiceForSsml.mathMode.toString(),
+                dictionaryIdentity,
+            )
             val root = context.getExternalFilesDir(Environment.DIRECTORY_MUSIC) ?: context.filesDir
             val directory = File(root, "wingmate/audio").apply { mkdirs() }
-            val file = File(directory, "tts_$cacheKey.mp3")
+            val file = File(directory, "tts_v2_$cacheKey.mp3")
                 if (!file.exists() || file.length() == 0L) {
                     val segments = SpeechTextProcessor.processText(normalizedText)
                     val ssml = if (segments.any { !it.languageTag.isNullOrBlank() || it.pauseDurationMs > 0 }) {
@@ -395,7 +477,7 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
         pendingSpeechCache.toList().forEach { cacheSpeech(it.text, it.voice, it.pitch, it.rate) }
     }
 
-    private suspend fun speakSegmentsInternal(segments: List<SpeechSegment>, voice: Voice?, pitch: Double?, rate: Double?, cacheAudio: Boolean) {
+    private suspend fun speakSegmentsInternal(requestId: Long, segments: List<SpeechSegment>, voice: Voice?, pitch: Double?, rate: Double?, cacheAudio: Boolean) {
         // Check user preference for TTS engine first
         val koin = GlobalContext.getOrNull()
         val settingsRepo = koin?.let { runCatching { it.get<io.github.jdreioe.wingmate.domain.SettingsRepository>() }.getOrNull() }
@@ -416,13 +498,13 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
 
         // If user prefers system TTS, use it directly
         if (uiSettings?.ttsEngine == io.github.jdreioe.wingmate.domain.TtsEngine.SYSTEM) {
-            recordHistory(combinedText, voice) // Record ONCE for the whole sentence
-            playSegmentsWithPlatformTts(segments, voice, pitch, rate)
+            playSegmentsWithPlatformTts(requestId, segments, voice, pitch, rate)
+            recordHistory(combinedText, voice)
             return
         }
 
         // Try to reuse a cached audio file from history to save API calls (works even offline)
-        if (cacheAudio && maybePlayFromHistoryCache(combinedText, voice, pitch, rate, uiSettings?.primaryLanguage)) {
+        if (cacheAudio && maybePlayFromHistoryCache(requestId, combinedText, voice, pitch, rate, uiSettings?.primaryLanguage)) {
             return
         }
 
@@ -431,17 +513,17 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
         if (cfg == null) {
             // No Azure configuration - fall back to system TTS with warning
             showConfigWarning()
+            speakWithPlatformTts(requestId, combinedText, voice, pitch, rate)
             recordHistory(combinedText, voice)
-            speakWithPlatformTts(combinedText, voice, pitch, rate)
             return
         }
         
         // Check if we're online before attempting Azure TTS
         if (!isOnline()) {
             showOfflineWarning()
-            recordHistory(combinedText, voice)
             // Fall back to system TTS when offline
-            speakWithPlatformTts(combinedText, voice, pitch, rate)
+            speakWithPlatformTts(requestId, combinedText, voice, pitch, rate)
+            recordHistory(combinedText, voice)
             return
         }
         
@@ -480,17 +562,24 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                 val outDir = File(musicRoot, "wingmate/audio").apply { if (!exists()) mkdirs() }
                 
                 // Calculate hash early to check if file already exists
-                val dictHash = dict.joinToString("|") { "${it.word}:${it.phoneme}:${it.alphabet}" }.hashCode()
-                val cacheKey = "${combinedText}_${vForSsml.name}_${vForSsml.primaryLanguage}_${vForSsml.selectedLanguage}_${pitch}_${rate}_${vForSsml.mathMode}_${dictHash}".hashCode()
-                val fileName = if (cacheAudio) "tts_$cacheKey.mp3" else "tts_session_${System.nanoTime()}.mp3"
+                val dictionaryIdentity = dict.joinToString("\u001f") { "${it.word}\u001e${it.phoneme}\u001e${it.alphabet}" }
+                val cacheKey = SpeechCacheIdentity.digest(
+                    combinedText,
+                    vForSsml.name,
+                    vForSsml.primaryLanguage,
+                    vForSsml.selectedLanguage,
+                    pitch?.toString(),
+                    rate?.toString(),
+                    vForSsml.mathMode.toString(),
+                    dictionaryIdentity,
+                )
+                val fileName = if (cacheAudio) "tts_v2_$cacheKey.mp3" else "tts_session_${System.nanoTime()}.mp3"
                 val outFile = File(outDir, fileName)
 
                 if (cacheAudio && outFile.exists() && outFile.length() > 0) {
                     // Cache hit! reuse the file without calling Azure
+                    startPlayback(requestId, outFile, vForSsml)
                     recordHistory(combinedText, vForSsml, outFile.absolutePath)
-                    
-                    // Simple playback logic (duplicated from below for now to keep flow linear)
-                    startPlayback(outFile, vForSsml)
                     return@withContext
                 }
 
@@ -513,9 +602,10 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                     outFile.outputStream().use { it.write(bytes) }
                 }
 
-                // Save history record
+                startPlayback(requestId, outFile, vForSsml, deleteAfterPlayback = !cacheAudio)
                 recordHistory(combinedText, vForSsml, outFile.absolutePath.takeIf { cacheAudio })
-                startPlayback(outFile, vForSsml, deleteAfterPlayback = !cacheAudio)
+            } catch (cancelled: CancellationException) {
+                throw cancelled
             } catch (t: Throwable) {
                 OperationalLogger.warn(
                     operation = "speech.azure_synthesis",
@@ -523,8 +613,9 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                     exceptionClass = t.loggingClassName(),
                 )
                 // Fallback to platform TTS on error
+                if (requestGeneration.get() != requestId) throw CancellationException("Speech request was replaced")
+                speakWithPlatformTts(requestId, combinedText, voice, pitch, rate)
                 recordHistory(combinedText, voice)
-                speakWithPlatformTts(combinedText, voice, pitch, rate)
             }
         }
     }
@@ -532,10 +623,9 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
     override suspend fun speakRecordedAudio(audioFilePath: String, textForHistory: String?, voice: Voice?): Boolean {
         val file = File(audioFilePath)
         if (!file.exists() || file.length() <= 0L) return false
+        val requestId = beginRequest()
 
         val played = runCatching {
-            stop()
-
             withContext(Dispatchers.Main) {
                 suspendCancellableCoroutine<Boolean> { cont ->
                     val player = MediaPlayer()
@@ -553,7 +643,7 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                                 }
                             }
                         } finally {
-                            finishPlayback()
+                            finishPlayback(requestId)
                             if (cont.isActive) cont.resume(success)
                         }
                     }
@@ -592,18 +682,20 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                         player.setDataSource(file.absolutePath)
                         player.prepare()
                         synchronized(playerLock) {
+                            check(requestGeneration.get() == requestId) { "Speech request was replaced" }
                             mediaPlayer?.let { try { it.stop(); it.release() } catch (_: Throwable) {} }
                             mediaPlayer = player
+                            markPlaybackStarted(textForHistory ?: file.nameWithoutExtension, voice, requestId)
+                            player.start()
                         }
-                        markPlaybackStarted(textForHistory ?: file.nameWithoutExtension, voice)
-                        player.start()
                     } catch (_: Throwable) {
                         finalizePlayback(false)
                     }
                 }
             }
-        }.getOrElse {
-            finishPlayback()
+        }.getOrElse { error ->
+            if (error is CancellationException) throw error
+            finishPlayback(requestId)
             false
         }
 
@@ -616,7 +708,8 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
         return played
     }
     
-    private fun startPlayback(file: File, voice: Voice, deleteAfterPlayback: Boolean = false) {
+    private fun startPlayback(requestId: Long, file: File, voice: Voice, deleteAfterPlayback: Boolean = false) {
+        check(requestGeneration.get() == requestId) { "Speech request was replaced" }
         val player = MediaPlayer()
                 requestAudioFocus()
 
@@ -629,25 +722,26 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                         mediaPlayer = null
                     }
                 }
-                finishPlayback()
+                finishPlayback(requestId)
                 if (deleteAfterPlayback) runCatching { file.delete() }
             } catch (_: Throwable) {}
         }
         player.setOnErrorListener { mp, _, _ ->
             try { synchronized(playerLock) { if (mediaPlayer === mp) { mp.reset(); mp.release(); mediaPlayer = null } } } catch (_: Throwable) {}
             if (deleteAfterPlayback) runCatching { file.delete() }
-            finishPlayback()
+            finishPlayback(requestId)
             true
         }
         try { player.setAudioAttributes(ttsAudioAttributes) } catch (_: Throwable) {}
         player.setDataSource(file.absolutePath)
         player.prepare()
         synchronized(playerLock) {
+            check(requestGeneration.get() == requestId) { "Speech request was replaced" }
             mediaPlayer?.let { try { it.stop(); it.release() } catch (_: Throwable) {} }
             mediaPlayer = player
+            markPlaybackStarted(file.nameWithoutExtension, voice, requestId)
+            player.start()
         }
-        markPlaybackStarted(file.nameWithoutExtension, voice)
-        player.start()
     }
 
     private fun effectiveVoice(
@@ -665,6 +759,7 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
     }
 
     private suspend fun maybePlayFromHistoryCache(
+        requestId: Long,
         text: String,
         voice: Voice?,
         pitch: Double?,
@@ -708,29 +803,7 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
 
             val file = File(path)
             if (!file.exists() || file.length() <= 0L) return false
-
-            // Append a history record for this playback referencing the cached file
-            runCatching {
-                val now = System.currentTimeMillis()
-                val visibleInHistory = koin?.getOrNull<io.github.jdreioe.wingmate.domain.SettingsRepository>()
-                    ?.get()?.historyVisible ?: true
-                withContext(Dispatchers.IO) {
-                    saidRepo.add(
-                        io.github.jdreioe.wingmate.domain.SaidText(
-                            date = now,
-                            saidText = text,
-                            voiceName = v.name,
-                            pitch = pitch ?: v.pitch,
-                            speed = rate ?: v.rate,
-                            audioFilePath = file.absolutePath,
-                            createdAt = now,
-                            position = 0,
-                            primaryLanguage = v.selectedLanguage.takeIf(String::isNotBlank) ?: v.primaryLanguage,
-                            visibleInHistory = visibleInHistory
-                        )
-                    )
-                }
-            }
+            if (!file.name.matches(Regex("tts_v2_[0-9a-f]{64}\\.mp3"))) return false
 
             // Play the cached file with MediaPlayer (mirror Azure playback path)
             val player = MediaPlayer()
@@ -746,12 +819,12 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                             mediaPlayer = null
                         }
                     }
-                    finishPlayback()
+                    finishPlayback(requestId)
                 } catch (_: Throwable) {}
             }
             player.setOnErrorListener { mp, _, _ ->
                 try { synchronized(playerLock) { if (mediaPlayer === mp) { mp.reset(); mp.release(); mediaPlayer = null } } } catch (_: Throwable) {}
-                finishPlayback()
+                finishPlayback(requestId)
                 true
             }
             // Ensure proper routing for car/AA through media usage speech attributes.
@@ -760,22 +833,27 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                 player.setDataSource(file.absolutePath)
                 player.prepare()
                 synchronized(playerLock) {
+                    check(requestGeneration.get() == requestId) { "Speech request was replaced" }
                     mediaPlayer?.let { try { it.stop(); it.release() } catch (_: Throwable) {} }
                     mediaPlayer = player
+                    markPlaybackStarted(text, v, requestId)
+                    player.start()
                 }
-                markPlaybackStarted(text, v)
-                player.start()
+                recordHistory(text, v, file.absolutePath)
                 true
             } catch (_: Throwable) {
                 try { player.release() } catch (_: Throwable) {}
-                finishPlayback()
+                finishPlayback(requestId)
                 false
             }
-        }.getOrElse { false }
+        }.getOrElse { error ->
+            if (error is CancellationException) throw error
+            false
+        }
     }
 
 
-    private suspend fun speakWithPlatformTts(text: String, voice: Voice?, pitch: Double?, rate: Double?) {
+    private suspend fun speakWithPlatformTts(requestId: Long, text: String, voice: Voice?, pitch: Double?, rate: Double?) {
         val cleanText = text.replace(Regex("<[^>]+>"), "") // Strip tags for system TTS fallback
         withContext(Dispatchers.Main) {
             val parsedVoiceId = AndroidTtsVoiceId.parse(voice?.name)
@@ -791,14 +869,18 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
             // Route TTS through media channel to keep Android Auto routing consistent.
             try { t.setAudioAttributes(ttsAudioAttributes) } catch (_: Throwable) {}
             requestAudioFocus()
-            val utteranceId = "wingmate-${System.currentTimeMillis()}"
+            val utteranceId = "wingmate-$requestId-${System.nanoTime()}"
             pendingTtsUtterances.set(1)
-            markPlaybackStarted(cleanText, voice)
-            val result = t.speak(cleanText, TextToSpeech.QUEUE_FLUSH, null, utteranceId)
+            val result = synchronized(playerLock) {
+                check(requestGeneration.get() == requestId) { "Speech request was replaced" }
+                t.speak(cleanText, TextToSpeech.QUEUE_FLUSH, null, utteranceId)
+            }
             if (result != TextToSpeech.SUCCESS) {
                 pendingTtsUtterances.set(0)
-                finishPlayback()
+                finishPlayback(requestId)
+                error("Device text-to-speech rejected playback")
             }
+            markPlaybackStarted(cleanText, voice, requestId)
         }
     }
 
@@ -842,6 +924,7 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
     }
 
     override suspend fun pause() {
+        if (!isPlaying) return
         // Pause MediaPlayer if used; for platform TTS simulate pause with stop()
         synchronized(playerLock) {
             mediaPlayer?.let { if (it.isPlaying) it.pause() }
@@ -853,19 +936,28 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
         isPaused = true
         pausedAtSegment = true
         isPlaying = false
+        state = SpeechPlaybackState(requestGeneration.get(), SpeechPlaybackStatus.PAUSED)
         updatePlaybackState(PlaybackState.STATE_PAUSED)
         abandonAudioFocus()
     }
 
     override suspend fun stop() {
+        val requestId = requestGeneration.incrementAndGet()
+        activeRequestJob?.cancel()
+        activeRequestJob = null
+        stopNativePlayback()
+        state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.IDLE)
+    }
+
+    private fun stopNativePlayback() {
         synchronized(playerLock) {
             try {
                 mediaPlayer?.let { try { it.stop(); it.release() } catch (_: Throwable) {} }
             } finally {
                 mediaPlayer = null
             }
+            try { tts?.stop() } catch (_: Throwable) {}
         }
-        try { tts?.stop() } catch (_: Throwable) {}
         pendingTtsUtterances.set(0)
         abandonAudioFocus()
         
@@ -886,13 +978,16 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
             isPaused = false
             pausedAtSegment = false
             // Resume playing segments from where we left off
-            playSegmentsFromIndex(currentSegmentIndex)
+            state = SpeechPlaybackState(requestGeneration.get(), SpeechPlaybackStatus.PREPARING)
+            playSegmentsFromIndex(requestGeneration.get(), currentSegmentIndex)
         }
     }
 
     override fun isPlaying(): Boolean = isPlaying
 
     override fun isPaused(): Boolean = isPaused
+
+    override fun playbackState(): SpeechPlaybackState = state
 
     override suspend fun guessPronunciation(text: String, language: String): String? {
         val langCode = language.take(2).lowercase()
@@ -934,21 +1029,21 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
         }
     }
 
-    private suspend fun playSegmentsFromIndex(startIndex: Int) {
+    private suspend fun playSegmentsFromIndex(requestId: Long, startIndex: Int) {
         val koin = GlobalContext.getOrNull()
         val settingsRepo = koin?.let { runCatching { it.get<io.github.jdreioe.wingmate.domain.SettingsRepository>() }.getOrNull() }
         val uiSettings = settingsRepo?.let { runCatching { it.get() }.getOrNull() }
         
         // If user prefers system TTS, use platform TTS approach
         if (uiSettings?.ttsEngine == io.github.jdreioe.wingmate.domain.TtsEngine.SYSTEM) {
-            playSegmentsWithPlatformTts(currentSegments.drop(startIndex), currentVoice, currentPitch, currentRate)
+            playSegmentsWithPlatformTts(requestId, currentSegments.drop(startIndex), currentVoice, currentPitch, currentRate)
         } else {
             // For Azure TTS: concatenate remaining segments and use main speak logic
             val remainingSegments = currentSegments.drop(startIndex)
             if (remainingSegments.isNotEmpty()) {
                 val remainingText = remainingSegments.joinToString(" ") { it.text }
                 // Call the original speakSegments logic but bypass the text processing
-                playTextWithAzure(remainingText, currentVoice, currentPitch, currentRate)
+                playTextWithAzure(requestId, remainingText, currentVoice, currentPitch, currentRate)
             }
         }
         
@@ -961,13 +1056,13 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
         }
     }
 
-    private suspend fun playTextWithAzure(text: String, voice: Voice?, pitch: Double?, rate: Double?) {
+    private suspend fun playTextWithAzure(requestId: Long, text: String, voice: Voice?, pitch: Double?, rate: Double?) {
         // Use the existing Azure TTS logic from the original speakSegments method
         // This is a simplified version that just calls the platform TTS as fallback
-        speakWithPlatformTts(text, voice, pitch, rate)
+        speakWithPlatformTts(requestId, text, voice, pitch, rate)
     }
 
-    private suspend fun playSegmentsWithPlatformTts(segments: List<SpeechSegment>, voice: Voice?, pitch: Double?, rate: Double?) {
+    private suspend fun playSegmentsWithPlatformTts(requestId: Long, segments: List<SpeechSegment>, voice: Voice?, pitch: Double?, rate: Double?) {
         withContext(Dispatchers.Main) {
             val parsedVoiceId = AndroidTtsVoiceId.parse(voice?.name)
             val t = ensureTts(parsedVoiceId.enginePackageName)
@@ -976,7 +1071,7 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
 
             val combinedText = segments.joinToString(" ") { it.text }.trim()
             pendingTtsUtterances.set(0)
-            markPlaybackStarted(combinedText, voice)
+            check(requestGeneration.get() == requestId) { "Speech request was replaced" }
             
             // Iterate segments to handle breaks correctly for platform TTS
             for ((index, segment) in segments.withIndex()) {
@@ -1000,15 +1095,19 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                     
                     // Queue the speech
                     val params = android.os.Bundle()
-                    val utteranceId = "wingmate-${System.currentTimeMillis()}-$index"
+                    val utteranceId = "wingmate-$requestId-$index-${System.nanoTime()}"
                     params.putString(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, utteranceId)
                     
                     // Use QUEUE_ADD to chain segments seamlessly
                     val queueMode = if (index == 0) TextToSpeech.QUEUE_FLUSH else TextToSpeech.QUEUE_ADD
                     pendingTtsUtterances.incrementAndGet()
-                    val speakResult = t.speak(segment.text, queueMode, params, utteranceId)
+                    val speakResult = synchronized(playerLock) {
+                        check(requestGeneration.get() == requestId) { "Speech request was replaced" }
+                        t.speak(segment.text, queueMode, params, utteranceId)
+                    }
                     if (speakResult != TextToSpeech.SUCCESS) {
-                        onTtsUtteranceFinished()
+                        onTtsUtteranceFinished(utteranceId)
+                        error("Device text-to-speech rejected a speech segment")
                     }
                 }
                 
@@ -1016,15 +1115,19 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                 if (segment.pauseDurationMs > 0) {
                     // playSilentUtterance is available API 21+ (Wingmate is min 24/26 usually)
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                        val silenceId = "silence-${System.currentTimeMillis()}-$index"
+                        val silenceId = "wingmate-$requestId-silence-$index-${System.nanoTime()}"
                         pendingTtsUtterances.incrementAndGet()
-                        val silenceResult = t.playSilentUtterance(
-                            segment.pauseDurationMs,
-                            TextToSpeech.QUEUE_ADD,
-                            silenceId
-                        )
+                        val silenceResult = synchronized(playerLock) {
+                            check(requestGeneration.get() == requestId) { "Speech request was replaced" }
+                            t.playSilentUtterance(
+                                segment.pauseDurationMs,
+                                TextToSpeech.QUEUE_ADD,
+                                silenceId
+                            )
+                        }
                         if (silenceResult != TextToSpeech.SUCCESS) {
-                            onTtsUtteranceFinished()
+                            onTtsUtteranceFinished(silenceId)
+                            error("Device text-to-speech rejected a pause segment")
                         }
                     } else {
                         // Fallback using Thread.sleep is NOT safe on main thread, but pre-Lollipop is ancient.
@@ -1032,13 +1135,20 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
                         @Suppress("DEPRECATION")
                         run {
                             pendingTtsUtterances.incrementAndGet()
-                            val silenceResult = t.playSilence(
-                                segment.pauseDurationMs,
-                                TextToSpeech.QUEUE_ADD,
-                                null
-                            )
+                            val silenceId = "wingmate-$requestId-silence-$index-${System.nanoTime()}"
+                            val silenceResult = synchronized(playerLock) {
+                                check(requestGeneration.get() == requestId) { "Speech request was replaced" }
+                                t.playSilence(
+                                    segment.pauseDurationMs,
+                                    TextToSpeech.QUEUE_ADD,
+                                    hashMapOf<String, String>().apply {
+                                        put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, silenceId)
+                                    }
+                                )
+                            }
                             if (silenceResult != TextToSpeech.SUCCESS) {
-                                onTtsUtteranceFinished()
+                                onTtsUtteranceFinished(silenceId)
+                                error("Device text-to-speech rejected a pause segment")
                             }
                         }
                     }
@@ -1051,7 +1161,9 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
             }
 
             if (pendingTtsUtterances.get() == 0) {
-                finishPlayback()
+                finishPlayback(requestId)
+            } else {
+                markPlaybackStarted(combinedText, voice, requestId)
             }
         }
     }
@@ -1102,6 +1214,8 @@ class AndroidSpeechService(private val context: Context) : SpeechService {
         val storedConfig = if (repo != null) {
             try {
                 withContext(Dispatchers.IO) { repo.getSpeechConfig() }
+            } catch (cancelled: CancellationException) {
+                throw cancelled
             } catch (_: Throwable) {
                 null
             }

--- a/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/SpeechCacheIdentity.kt
+++ b/core/data/src/commonMain/kotlin/io/github/jdreioe/wingmate/infrastructure/SpeechCacheIdentity.kt
@@ -1,0 +1,29 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.withTimeoutOrNull
+import okio.ByteString.Companion.encodeUtf8
+
+/** Versioned, unambiguous identity for synthesized speech bytes. */
+internal object SpeechCacheIdentity {
+    private const val VERSION = "v2"
+
+    fun digest(vararg components: String?): String {
+        val canonical = buildString {
+            append(VERSION)
+            components.forEach { component ->
+                val value = component.orEmpty()
+                append('|')
+                append(value.length)
+                append(':')
+                append(value)
+            }
+        }
+        return canonical.encodeUtf8().sha256().hex()
+    }
+}
+
+internal suspend fun awaitSpeechInitialization(
+    initialization: Deferred<Boolean>,
+    timeoutMillis: Long,
+): Boolean = withTimeoutOrNull(timeoutMillis) { initialization.await() } == true

--- a/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/SpeechCacheIdentityTest.kt
+++ b/core/data/src/commonTest/kotlin/io/github/jdreioe/wingmate/infrastructure/SpeechCacheIdentityTest.kt
@@ -1,0 +1,56 @@
+package io.github.jdreioe.wingmate.infrastructure
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SpeechCacheIdentityTest {
+    @Test
+    fun javaHashCollisionDoesNotReuseSpeechAudio() {
+        check("Aa".hashCode() == "BB".hashCode())
+
+        assertNotEquals(
+            SpeechCacheIdentity.digest("Aa", "voice", "1.0"),
+            SpeechCacheIdentity.digest("BB", "voice", "1.0"),
+        )
+    }
+
+    @Test
+    fun componentBoundariesArePartOfIdentity() {
+        assertNotEquals(
+            SpeechCacheIdentity.digest("ab", "c"),
+            SpeechCacheIdentity.digest("a", "bc"),
+        )
+        assertEquals(
+            SpeechCacheIdentity.digest("text", "voice"),
+            SpeechCacheIdentity.digest("text", "voice"),
+        )
+    }
+
+    @Test
+    fun initializationWaitsForDelayedSuccess() = runBlocking {
+        val initialization = CompletableDeferred<Boolean>()
+        launch {
+            delay(10)
+            initialization.complete(true)
+        }
+
+        assertEquals(true, awaitSpeechInitialization(initialization, timeoutMillis = 1_000))
+    }
+
+    @Test
+    fun initializationFailureAndTimeoutAreRejected() = runBlocking {
+        assertEquals(
+            false,
+            awaitSpeechInitialization(CompletableDeferred(false), timeoutMillis = 1_000),
+        )
+        assertEquals(
+            false,
+            awaitSpeechInitialization(CompletableDeferred(), timeoutMillis = 10),
+        )
+    }
+}

--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSpeechService.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSpeechService.kt
@@ -5,6 +5,8 @@ import io.github.jdreioe.wingmate.domain.PronunciationDictionaryRepository
 import io.github.jdreioe.wingmate.domain.SaidText
 import io.github.jdreioe.wingmate.domain.SaidTextRepository
 import io.github.jdreioe.wingmate.domain.SpeechService
+import io.github.jdreioe.wingmate.domain.SpeechPlaybackState
+import io.github.jdreioe.wingmate.domain.SpeechPlaybackStatus
 import io.github.jdreioe.wingmate.domain.SpeechTextProcessor
 import io.github.jdreioe.wingmate.domain.SpeechSegment
 import io.github.jdreioe.wingmate.domain.SettingsRepository
@@ -17,9 +19,13 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.statement.bodyAsText
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.BetaInteropApi
 import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -29,12 +35,14 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import platform.AVFAudio.AVAudioPlayer
+import platform.AVFAudio.AVAudioPlayerDelegateProtocol
 import platform.Foundation.NSData
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
 import platform.Foundation.create
+import platform.darwin.NSObject
 
-@OptIn(ExperimentalForeignApi::class)
+@OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
 class IosSpeechService(
     private val httpClient: HttpClient,
     private val configRepository: ConfigRepository,
@@ -50,6 +58,15 @@ class IosSpeechService(
     private val pendingSpeechCache = mutableSetOf<PendingCache>()
     private val pendingSpeechCacheMutex = Mutex()
     private var currentPlayer: AVAudioPlayer? = null
+    private var currentPlayerRequestId: Long = 0
+    private var requestGeneration: Long = 0
+    private var activeRequestJob: Job? = null
+    private var state = SpeechPlaybackState()
+    private val playerDelegate = object : NSObject(), AVAudioPlayerDelegateProtocol {
+        override fun audioPlayerDidFinishPlaying(player: AVAudioPlayer, successfully: Boolean) {
+            handlePlayerFinished(player, successfully)
+        }
+    }
 
     init {
         configureAudioSession()
@@ -59,6 +76,36 @@ class IosSpeechService(
         // No-op in common metadata; the Swift app can configure the session at runtime.
     }
 
+    private suspend fun beginRequest(): Long = withContext(Dispatchers.Main) {
+        val job = currentCoroutineContext()[Job]
+        activeRequestJob?.takeIf { it !== job }?.cancel()
+        activeRequestJob = job
+        requestGeneration += 1
+        currentPlayer?.stop()
+        currentPlayer = null
+        currentPlayerRequestId = 0
+        state = SpeechPlaybackState(requestGeneration, SpeechPlaybackStatus.PREPARING)
+        requestGeneration
+    }
+
+    private suspend fun <T> executeRequest(requestId: Long, block: suspend () -> T): T = try {
+        block()
+    } catch (cancelled: CancellationException) {
+        if (requestGeneration == requestId) {
+            state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.IDLE)
+        }
+        throw cancelled
+    } catch (error: Throwable) {
+        failRequest(requestId)
+        throw error
+    }
+
+    private fun failRequest(requestId: Long) {
+        if (requestGeneration == requestId) {
+            state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.FAILED, "Speech could not be played")
+        }
+    }
+
     override suspend fun speak(text: String, voice: Voice?, pitch: Double?, rate: Double?) {
         speakWithCachePolicy(text, voice, pitch, rate, cacheAudio = true)
     }
@@ -66,14 +113,18 @@ class IosSpeechService(
     override suspend fun speakWithCachePolicy(text: String, voice: Voice?, pitch: Double?, rate: Double?, cacheAudio: Boolean) {
         val normalizedText = SpeechTextProcessor.normalizeShorthandSsml(text)
         if (normalizedText.isBlank()) return
+        val requestId = beginRequest()
 
-        val effectiveVoice = voice ?: defaultVoice()
-        val cacheKey = "text|$normalizedText|${effectiveVoice.name}|$pitch|$rate|math=${effectiveVoice.mathMode}"
-        val cached = if (cacheAudio) sentenceAudioCacheMutex.withLock { sentenceAudioCache[cacheKey] } else null
-        val audioBytes = cached ?: synthesize(normalizedText, effectiveVoice) ?: return
-        if (cacheAudio && cached == null) sentenceAudioCacheMutex.withLock { sentenceAudioCache[cacheKey] = audioBytes }
-        playAudio(audioBytes)
-        trySaveHistory(normalizedText, effectiveVoice, pitch, rate, null)
+        executeRequest(requestId) {
+            val effectiveVoice = voice ?: defaultVoice()
+            val cacheKey = "text|$normalizedText|${effectiveVoice.name}|$pitch|$rate|math=${effectiveVoice.mathMode}"
+            val cached = if (cacheAudio) sentenceAudioCacheMutex.withLock { sentenceAudioCache[cacheKey] } else null
+            val audioBytes = cached ?: synthesize(normalizedText, effectiveVoice)
+                ?: error("Azure Speech is not configured")
+            if (cacheAudio && cached == null) sentenceAudioCacheMutex.withLock { sentenceAudioCache[cacheKey] = audioBytes }
+            playAudio(requestId, audioBytes)
+            trySaveHistory(normalizedText, effectiveVoice, pitch, rate, null)
+        }
     }
 
     override suspend fun speakSegments(segments: List<SpeechSegment>, voice: Voice?, pitch: Double?, rate: Double?) {
@@ -82,14 +133,18 @@ class IosSpeechService(
 
     override suspend fun speakSegmentsWithCachePolicy(segments: List<SpeechSegment>, voice: Voice?, pitch: Double?, rate: Double?, cacheAudio: Boolean) {
         if (segments.isEmpty()) return
-        val combinedText = segments.joinToString(separator = "") { it.text }
-        val effectiveVoice = voice ?: defaultVoice()
-        val cacheKey = "segments|${segments.joinToString()}|${effectiveVoice.name}|$pitch|$rate|math=${effectiveVoice.mathMode}"
-        val cached = if (cacheAudio) sentenceAudioCacheMutex.withLock { sentenceAudioCache[cacheKey] } else null
-        val audioBytes = cached ?: synthesizeSegments(segments, effectiveVoice) ?: return
-        if (cacheAudio && cached == null) sentenceAudioCacheMutex.withLock { sentenceAudioCache[cacheKey] = audioBytes }
-        playAudio(audioBytes)
-        trySaveHistory(combinedText, effectiveVoice, pitch, rate, null)
+        val requestId = beginRequest()
+        executeRequest(requestId) {
+            val combinedText = segments.joinToString(separator = "") { it.text }
+            val effectiveVoice = voice ?: defaultVoice()
+            val cacheKey = "segments|${segments.joinToString()}|${effectiveVoice.name}|$pitch|$rate|math=${effectiveVoice.mathMode}"
+            val cached = if (cacheAudio) sentenceAudioCacheMutex.withLock { sentenceAudioCache[cacheKey] } else null
+            val audioBytes = cached ?: synthesizeSegments(segments, effectiveVoice)
+                ?: error("Azure Speech is not configured")
+            if (cacheAudio && cached == null) sentenceAudioCacheMutex.withLock { sentenceAudioCache[cacheKey] = audioBytes }
+            playAudio(requestId, audioBytes)
+            trySaveHistory(combinedText, effectiveVoice, pitch, rate, null)
+        }
     }
 
     override suspend fun cacheSpeech(text: String, voice: Voice?, pitch: Double?, rate: Double?): Boolean {
@@ -118,37 +173,56 @@ class IosSpeechService(
 
     override suspend fun speakRecordedAudio(audioFilePath: String, textForHistory: String?, voice: Voice?): Boolean {
         if (!NSFileManager.defaultManager.fileExistsAtPath(audioFilePath)) return false
+        val requestId = beginRequest()
         return runCatching {
-            playFile(audioFilePath)
+            playFile(requestId, audioFilePath)
             val spokenText = textForHistory?.trim().orEmpty()
             if (spokenText.isNotEmpty()) {
                 val selectedVoice = voice ?: defaultVoice()
                 trySaveHistory(spokenText, selectedVoice, selectedVoice.pitch, selectedVoice.rate, audioFilePath)
             }
             true
-        }.onFailure {
+        }.onFailure { error ->
+            if (error is CancellationException) throw error
+            failRequest(requestId)
             OperationalLogger.warn("speech_recording.play", "failed")
         }.getOrDefault(false)
     }
 
     override suspend fun pause() = withContext(Dispatchers.Main) {
-        currentPlayer?.pause()
+        currentPlayer?.takeIf { it.playing }?.let {
+            it.pause()
+            state = SpeechPlaybackState(currentPlayerRequestId, SpeechPlaybackStatus.PAUSED)
+        }
         Unit
     }
 
     override suspend fun stop() = withContext(Dispatchers.Main) {
+        requestGeneration += 1
+        activeRequestJob?.cancel()
+        activeRequestJob = null
         currentPlayer?.stop()
         currentPlayer = null
+        currentPlayerRequestId = 0
+        state = SpeechPlaybackState(requestGeneration, SpeechPlaybackStatus.IDLE)
     }
 
     override suspend fun resume() = withContext(Dispatchers.Main) {
-        currentPlayer?.play()
+        val player = currentPlayer ?: return@withContext
+        if (state.status != SpeechPlaybackStatus.PAUSED) return@withContext
+        if (!player.play()) {
+            failRequest(currentPlayerRequestId)
+            error("Audio playback could not be resumed")
+        }
+        state = SpeechPlaybackState(currentPlayerRequestId, SpeechPlaybackStatus.PLAYING)
         Unit
     }
 
-    override fun isPlaying(): Boolean = false
+    override fun isPlaying(): Boolean = currentPlayer?.playing == true && state.status == SpeechPlaybackStatus.PLAYING
 
-    override fun isPaused(): Boolean = false
+    override fun isPaused(): Boolean = currentPlayer != null && state.status == SpeechPlaybackStatus.PAUSED
+
+    override fun playbackState(): SpeechPlaybackState = state
 
     override suspend fun guessPronunciation(text: String, language: String): String? {
         val langCode = language.take(2).lowercase()
@@ -198,36 +272,45 @@ class IosSpeechService(
         AzureTtsClient.synthesize(httpClient, ssml, config)
     }
 
-    private suspend fun playFile(path: String) = withContext(Dispatchers.Main) {
-        runCatching {
-            val url = NSURL.fileURLWithPath(path)
-            val audioPlayer = AVAudioPlayer(contentsOfURL = url, error = null)
-            currentPlayer?.stop()
-            currentPlayer = audioPlayer
-            audioPlayer.prepareToPlay()
-            audioPlayer.play()
-        }.onFailure { t ->
-            OperationalLogger.warn("speech_recording.play", "failed")
-        }
+    private suspend fun playFile(requestId: Long, path: String) = withContext(Dispatchers.Main) {
+        check(requestGeneration == requestId) { "Speech request was replaced" }
+        val url = NSURL.fileURLWithPath(path)
+        val audioPlayer = AVAudioPlayer(contentsOfURL = url, error = null)
+        startPlayer(requestId, audioPlayer)
     }
 
-    private suspend fun playAudio(audioBytes: ByteArray) = withContext(Dispatchers.Main) {
-        if (audioBytes.isEmpty()) return@withContext
-        runCatching {
-            val data = audioBytes.usePinned { pinned ->
-                NSData.create(bytes = pinned.addressOf(0), length = audioBytes.size.toULong())
-            }
-            val audioPlayer = AVAudioPlayer(data = data, error = null)
-            currentPlayer?.stop()
-            currentPlayer = audioPlayer
-            audioPlayer.prepareToPlay()
-            audioPlayer.play()
-        }.onFailure { t ->
-            OperationalLogger.warn(
-                operation = "speech_audio.play",
-                outcome = "failed",
-                exceptionClass = t.loggingClassName(),
-            )
+    private suspend fun playAudio(requestId: Long, audioBytes: ByteArray) = withContext(Dispatchers.Main) {
+        require(audioBytes.isNotEmpty()) { "Speech synthesis returned no audio" }
+        check(requestGeneration == requestId) { "Speech request was replaced" }
+        val data = audioBytes.usePinned { pinned ->
+            NSData.create(bytes = pinned.addressOf(0), length = audioBytes.size.toULong())
+        }
+        val audioPlayer = AVAudioPlayer(data = data, error = null)
+        startPlayer(requestId, audioPlayer)
+    }
+
+    private fun startPlayer(requestId: Long, audioPlayer: AVAudioPlayer) {
+        audioPlayer.delegate = playerDelegate
+        check(audioPlayer.prepareToPlay()) { "Audio playback could not be prepared" }
+        currentPlayer = audioPlayer
+        currentPlayerRequestId = requestId
+        if (!audioPlayer.play()) {
+            currentPlayer = null
+            currentPlayerRequestId = 0
+            error("Audio playback could not be started")
+        }
+        state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.PLAYING)
+    }
+
+    private fun handlePlayerFinished(player: AVAudioPlayer, successfully: Boolean) {
+        if (currentPlayer !== player) return
+        val requestId = currentPlayerRequestId
+        currentPlayer = null
+        currentPlayerRequestId = 0
+        state = if (successfully) {
+            SpeechPlaybackState(requestId, SpeechPlaybackStatus.IDLE)
+        } else {
+            SpeechPlaybackState(requestId, SpeechPlaybackStatus.FAILED, "Speech playback failed")
         }
     }
 

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/repository.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/repository.kt
@@ -77,6 +77,20 @@ interface ConfigRepository {
     }
 }
 
+enum class SpeechPlaybackStatus {
+    IDLE,
+    PREPARING,
+    PLAYING,
+    PAUSED,
+    FAILED,
+}
+
+data class SpeechPlaybackState(
+    val requestId: Long = 0,
+    val status: SpeechPlaybackStatus = SpeechPlaybackStatus.IDLE,
+    val error: String? = null,
+)
+
 interface SpeechService {
     suspend fun speak(text: String, voice: Voice? = null, pitch: Double? = null, rate: Double? = null)
     suspend fun speakWithCachePolicy(
@@ -109,6 +123,11 @@ interface SpeechService {
     suspend fun resume()
     fun isPlaying(): Boolean
     fun isPaused(): Boolean
+    fun playbackState(): SpeechPlaybackState = when {
+        isPaused() -> SpeechPlaybackState(status = SpeechPlaybackStatus.PAUSED)
+        isPlaying() -> SpeechPlaybackState(status = SpeechPlaybackStatus.PLAYING)
+        else -> SpeechPlaybackState()
+    }
     suspend fun guessPronunciation(text: String, language: String = "en"): String? = null
 }
 

--- a/iosApp/iosApp/Base.lproj/Localizable.strings
+++ b/iosApp/iosApp/Base.lproj/Localizable.strings
@@ -75,6 +75,7 @@
 "azure.credentials.replace" = "Replace Azure credentials";
 "common.error" = "Error";
 "common.retry" = "Retry";
+"speech.playback_failed" = "Speech could not be played. Please try again.";
 "common.ok" = "OK";
 "common.saving" = "Saving…";
 "common.save" = "Save";

--- a/iosApp/iosApp/ViewModels/IosViewModel.swift
+++ b/iosApp/iosApp/ViewModels/IosViewModel.swift
@@ -54,6 +54,10 @@ struct SentencePhraseToken: Identifiable, Equatable {    var id: String = UUID()
 
 @MainActor
 final class IosViewModel: ObservableObject {
+    private enum PendingSpeechRetry {
+        case text(String)
+        case boardSentence(String, String)
+    }
     private final class StoreObserver: NSObject, Shared.RxObserver {
         private let onNextState: (Shared.PhraseListStoreState) -> Void
         private let onCompleteState: () -> Void
@@ -79,15 +83,27 @@ final class IosViewModel: ObservableObject {
         AzureHybridSequencer(
             speak: { [weak self] text in
                 guard let self = self else { return }
-                _ = try? await self.bridge.speak(text: text)
+                do {
+                    try await self.bridge.speak(text: text)
+                } catch {
+                    self.setSpeechFailure(retry: .text(text))
+                }
             },
             pause: { [weak self] in
                 guard let self = self else { return }
-                _ = try? await self.bridge.pause()
+                do {
+                    try await self.bridge.pause()
+                } catch {
+                    self.setSpeechFailure()
+                }
             },
             stop: { [weak self] in
                 guard let self = self else { return }
-                _ = try? await self.bridge.stop()
+                do {
+                    try await self.bridge.stop()
+                } catch {
+                    self.setSpeechFailure()
+                }
             }
         )
     }()
@@ -158,6 +174,9 @@ final class IosViewModel: ObservableObject {
     @Published var usageLoggingEnabled: Bool = false
     @Published var featureUsageReportingEnabled: Bool = false
     @Published var historyVisible: Bool = true
+    @Published private(set) var speechErrorMessage: String? = nil
+    private var pendingSpeechRetry: PendingSpeechRetry? = nil
+    var canRetryFailedSpeech: Bool { pendingSpeechRetry != nil }
     @Published var startupUsesScreens: Bool = false
     @Published var startupBoardSetId: String? = nil
     private var hasShownOfflineBanner: Bool = UserDefaults.standard.bool(forKey: "offline_banner_shown")
@@ -672,7 +691,14 @@ final class IosViewModel: ObservableObject {
             speakSystemText(plain, isInputText: isInputText)
             return
         }
-        Task { _ = try? await bridge.speak(text: t) }
+        Task {
+            do {
+                try await bridge.speak(text: t)
+                clearSpeechFailure()
+            } catch {
+                setSpeechFailure(retry: .text(t))
+            }
+        }
     }
 
     /// Speak on-device, honoring shorthand SSML (pauses + language tags) via shared
@@ -700,7 +726,35 @@ final class IosViewModel: ObservableObject {
             SystemTtsManager.shared.speak(segments: segments, language: primaryLanguage)
             return
         }
-        Task { _ = try? await bridge.speakBoardSentence(text: text, cacheAudio: cacheAudio) }
+        Task {
+            do {
+                try await bridge.speakBoardSentence(text: text, cacheAudio: cacheAudio)
+                clearSpeechFailure()
+            } catch {
+                setSpeechFailure(retry: .boardSentence(text, boardSetId))
+            }
+        }
+    }
+
+    private func setSpeechFailure(retry: PendingSpeechRetry? = nil) {
+        pendingSpeechRetry = retry
+        speechErrorMessage = NSLocalizedString("speech.playback_failed", comment: "")
+    }
+
+    private func clearSpeechFailure() {
+        speechErrorMessage = nil
+        pendingSpeechRetry = nil
+    }
+
+    func retryFailedSpeech() {
+        guard let retry = pendingSpeechRetry else { return }
+        clearSpeechFailure()
+        switch retry {
+        case .text(let text):
+            speak(text)
+        case .boardSentence(let text, let boardSetId):
+            speakBoardSentence(text, boardSetId: boardSetId)
+        }
     }
 
     func playBoardButtonSound(_ dataUrl: String) {
@@ -840,7 +894,13 @@ final class IosViewModel: ObservableObject {
         } else if !isOnline && useSystemTtsWhenOffline {
             SystemTtsManager.shared.pause()
         } else {
-            Task { _ = try? await bridge.pause() }
+            Task {
+                do {
+                    try await bridge.pause()
+                } catch {
+                    setSpeechFailure()
+                }
+            }
         }
     }
 
@@ -858,7 +918,13 @@ final class IosViewModel: ObservableObject {
         } else if !isOnline && useSystemTtsWhenOffline {
             SystemTtsManager.shared.stop()
         } else {
-            Task { _ = try? await bridge.stop() }
+            Task {
+                do {
+                    try await bridge.stop()
+                } catch {
+                    setSpeechFailure()
+                }
+            }
         }
     }
 

--- a/iosApp/iosApp/Views/MainContentView.swift
+++ b/iosApp/iosApp/Views/MainContentView.swift
@@ -157,6 +157,22 @@ struct MainContentView: View {
                     Button("common.retry") { model.retryPhraseLoad() }
                 }
             }
+            if let speechError = model.speechErrorMessage {
+                HStack(spacing: 12) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                    Text(speechError)
+                        .accessibilityLabel(speechError)
+                    Spacer()
+                    if model.canRetryFailedSpeech {
+                        Button("common.retry") { model.retryFailedSpeech() }
+                            .buttonStyle(.borderedProminent)
+                    }
+                }
+                .padding(12)
+                .background(RoundedRectangle(cornerRadius: 10).fill(Color.red.opacity(0.1)))
+                .accessibilityElement(children: .contain)
+            }
             if model.state.isLoading { ProgressView().frame(maxWidth: .infinity, alignment: .center) }
 
             #if DEBUG

--- a/iosApp/iosApp/da.lproj/Localizable.strings
+++ b/iosApp/iosApp/da.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 
 "common.error" = "FEJL";
 "common.retry" = "Prøv igen";
+"speech.playback_failed" = "Talen kunne ikke afspilles. Prøv igen.";
 "common.ok" = "OK";
 "common.saving" = "Gemmmer";
 "common.save" = "Gem";

--- a/iosApp/iosApp/de.lproj/Localizable.strings
+++ b/iosApp/iosApp/de.lproj/Localizable.strings
@@ -84,6 +84,7 @@
 "azure.credentials.replace" = "Azure-Anmeldedaten ersetzen";
 "common.error" = "Fehler";
 "common.retry" = "Erneut versuchen";
+"speech.playback_failed" = "Die Sprachausgabe konnte nicht abgespielt werden. Bitte versuche es erneut.";
 "common.ok" = "OK";
 "common.saving" = "Speichern…";
 "common.save" = "Speichern";

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/AzureSpeechService.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/AzureSpeechService.kt
@@ -3,6 +3,8 @@ package io.github.jdreioe.wingmate.kde
 import io.github.jdreioe.wingmate.domain.ConfigRepository
 import io.github.jdreioe.wingmate.domain.PronunciationDictionaryRepository
 import io.github.jdreioe.wingmate.domain.SpeechService
+import io.github.jdreioe.wingmate.domain.SpeechPlaybackState
+import io.github.jdreioe.wingmate.domain.SpeechPlaybackStatus
 import io.github.jdreioe.wingmate.domain.SpeechSegment
 import io.github.jdreioe.wingmate.domain.Voice
 import io.github.jdreioe.wingmate.infrastructure.AzureTtsClient
@@ -10,6 +12,7 @@ import io.ktor.client.HttpClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.concurrent.thread
+import java.util.concurrent.atomic.AtomicLong
 
 class AzureSpeechService(
     private val configRepository: ConfigRepository,
@@ -24,11 +27,18 @@ class AzureSpeechService(
     private var currentProcess: Process? = null
     @Volatile
     private var paused = false
+    private val generation = AtomicLong(0)
+    @Volatile private var state = SpeechPlaybackState()
+    private val ownershipLock = Any()
 
     override suspend fun speak(text: String, voice: Voice?, pitch: Double?, rate: Double?) {
+        val requestId = generation.incrementAndGet()
+        stopNative()
+        state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.PREPARING)
         val config = configRepository.getSpeechConfig()
         
         if (config == null || config.subscriptionKey.isBlank() || config.endpoint.isBlank()) {
+            failRequest(requestId)
             throw IllegalStateException("Azure Speech configuration is missing or incomplete")
         }
 
@@ -44,15 +54,25 @@ class AzureSpeechService(
         val ssml = AzureTtsClient.generateSsml(text, voiceToUse, pronunciationRepository.getAll())
             
             // Use WAV format for easier playback with aplay
-        val audioData = AzureTtsClient.synthesize(
-            client,
-            ssml,
-            config,
-            AzureTtsClient.AudioFormat.WAV_24KHZ_16BIT
-        )
+        val audioData = try {
+            AzureTtsClient.synthesize(
+                client,
+                ssml,
+                config,
+                AzureTtsClient.AudioFormat.WAV_24KHZ_16BIT
+            )
+        } catch (error: Throwable) {
+            failRequest(requestId)
+            throw error
+        }
             
         println("[SPEECH] Received ${audioData.size} bytes audio. Playing...")
-        playAudio(audioData)
+        try {
+            playAudio(requestId, audioData)
+        } catch (error: Throwable) {
+            failRequest(requestId)
+            throw error
+        }
     }
 
     override suspend fun speakSegments(segments: List<SpeechSegment>, voice: Voice?, pitch: Double?, rate: Double?) {
@@ -61,15 +81,19 @@ class AzureSpeechService(
         speak(text, voice, pitch, rate)
     }
 
-    private suspend fun playAudio(data: ByteArray) = withContext(Dispatchers.IO) {
-        stop() // Stop previous
-        
+    private suspend fun playAudio(requestId: Long, data: ByteArray) = withContext(Dispatchers.IO) {
+        check(generation.get() == requestId) { "Speech request was replaced" }
         paused = false
-        val process = ProcessBuilder("aplay")
-            .redirectErrorStream(true)
-            .start()
-            
-            currentProcess = process
+        val process = synchronized(ownershipLock) {
+            check(generation.get() == requestId) { "Speech request was replaced" }
+            ProcessBuilder("aplay")
+                .redirectErrorStream(true)
+                .start()
+                .also {
+                    currentProcess = it
+                    state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.PLAYING)
+                }
+        }
             
             process.outputStream.use { 
                 it.write(data)
@@ -92,6 +116,7 @@ class AzureSpeechService(
         if (currentProcess === process) {
             currentProcess = null
             paused = false
+            state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.IDLE)
         }
         check(exitCode == 0) { "aplay exited with code $exitCode" }
         println("[SPEECH] Audio playback finished.")
@@ -101,19 +126,29 @@ class AzureSpeechService(
         currentProcess?.takeIf { it.isAlive }?.let {
             signal(it, "-STOP")
             paused = true
+            state = SpeechPlaybackState(generation.get(), SpeechPlaybackStatus.PAUSED)
         }
     }
 
     override suspend fun stop() {
-        paused = false
-        currentProcess?.destroy()
-        currentProcess = null
+        val requestId = generation.incrementAndGet()
+        stopNative()
+        state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.IDLE)
+    }
+
+    private fun stopNative() {
+        synchronized(ownershipLock) {
+            paused = false
+            currentProcess?.destroy()
+            currentProcess = null
+        }
     }
 
     override suspend fun resume() {
         currentProcess?.takeIf { it.isAlive && paused }?.let {
             signal(it, "-CONT")
             paused = false
+            state = SpeechPlaybackState(generation.get(), SpeechPlaybackStatus.PLAYING)
         }
     }
 
@@ -122,6 +157,14 @@ class AzureSpeechService(
     }
 
     override fun isPaused(): Boolean = currentProcess?.isAlive == true && paused
+
+    override fun playbackState(): SpeechPlaybackState = state
+
+    private fun failRequest(requestId: Long) {
+        if (generation.get() == requestId) {
+            state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.FAILED, "Speech could not be played")
+        }
+    }
 
     private fun signal(process: Process, signal: String) {
         val result = ProcessBuilder("kill", signal, process.pid().toString()).start().waitFor()

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -20,6 +20,7 @@ import io.github.jdreioe.wingmate.domain.PronunciationDictionaryRepository
 import io.github.jdreioe.wingmate.domain.PronunciationEntry
 import io.github.jdreioe.wingmate.domain.SpeechServiceConfig
 import io.github.jdreioe.wingmate.domain.SpeechTextProcessor
+import io.github.jdreioe.wingmate.domain.SpeechPlaybackStatus
 import io.github.jdreioe.wingmate.domain.TextPredictionService
 import io.github.jdreioe.wingmate.domain.SaidTextRepository
 import io.github.jdreioe.wingmate.domain.SaidText
@@ -519,7 +520,7 @@ class KotlinBridge(private val port: Int = 8765) {
 
                     val generation = speechGeneration.incrementAndGet()
                     speechJob?.cancel()
-                    speechState = SpeechStateResponse(state = "playing", playing = true)
+                    speechState = SpeechStateResponse(state = "preparing", requestId = generation)
                     speechJob = scope.launch {
                         performSpeech(generation, text)
                     }
@@ -587,7 +588,7 @@ class KotlinBridge(private val port: Int = 8765) {
                 }
                 val generation = speechGeneration.incrementAndGet()
                 speechJob?.cancel()
-                speechState = SpeechStateResponse(state = "playing", playing = true)
+                speechState = SpeechStateResponse(state = "preparing", requestId = generation)
                 speechJob = scope.launch {
                     performSpeech(generation, text, voiceName, recordHistory = false)
                 }
@@ -599,7 +600,7 @@ class KotlinBridge(private val port: Int = 8765) {
                 speechJob = null
                 speechService.stop()
                 azureSpeechService.stop()
-                speechState = SpeechStateResponse(state = "cancelled")
+                speechState = SpeechStateResponse(state = "cancelled", requestId = speechGeneration.get())
                 call.respond(HttpStatusCode.OK)
             }
 
@@ -626,7 +627,25 @@ class KotlinBridge(private val port: Int = 8765) {
             }
             
             get("/api/speak/status") {
-                call.respond(speechState)
+                val nativeState = listOf(speechService.playbackState(), azureSpeechService.playbackState())
+                    .firstOrNull { it.status != SpeechPlaybackStatus.IDLE }
+                val response = when (nativeState?.status) {
+                    SpeechPlaybackStatus.PREPARING -> speechState.copy(
+                        state = "preparing", playing = false, paused = false, requestId = speechGeneration.get(),
+                    )
+                    SpeechPlaybackStatus.PLAYING -> speechState.copy(
+                        state = "playing", playing = true, paused = false, requestId = speechGeneration.get(),
+                    )
+                    SpeechPlaybackStatus.PAUSED -> speechState.copy(
+                        state = "paused", playing = false, paused = true, requestId = speechGeneration.get(),
+                    )
+                    SpeechPlaybackStatus.FAILED -> speechState.copy(
+                        state = "error", playing = false, paused = false,
+                        error = nativeState.error ?: "Speech failed", requestId = speechGeneration.get(),
+                    )
+                    else -> speechState
+                }
+                call.respond(response)
             }
             
             // Pronunciation Dictionary
@@ -1482,13 +1501,13 @@ class KotlinBridge(private val port: Int = 8765) {
                     (predictionService as SimpleNGramPredictionService).learnPhrase(text)
                 }
             }
-            speechState = SpeechStateResponse(state = "completed")
+            speechState = SpeechStateResponse(state = "completed", requestId = generation)
             speechJob = null
         } catch (error: Throwable) {
             if (speechGeneration.get() == generation) {
                 val message = error.message ?: "Speech failed"
                 println("[SPEECH] Speech failed (${error::class.simpleName})")
-                speechState = SpeechStateResponse(state = "error", error = message)
+                speechState = SpeechStateResponse(state = "error", error = message, requestId = generation)
                 speechJob = null
             }
         }
@@ -1538,6 +1557,7 @@ data class SpeechStateResponse(
     val playing: Boolean = false,
     val paused: Boolean = false,
     val error: String? = null,
+    val requestId: Long = 0,
 )
 
 @Serializable

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/LinuxSpeechService.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/LinuxSpeechService.kt
@@ -2,32 +2,50 @@ package io.github.jdreioe.wingmate.kde
 
 import io.github.jdreioe.wingmate.domain.SpeechSegment
 import io.github.jdreioe.wingmate.domain.SpeechService
+import io.github.jdreioe.wingmate.domain.SpeechPlaybackState
+import io.github.jdreioe.wingmate.domain.SpeechPlaybackStatus
 import io.github.jdreioe.wingmate.domain.Voice
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Linux speech service using system TTS (espeak-ng, festival, or similar).
  */
 class LinuxSpeechService : SpeechService {
-    private var currentProcess: Process? = null
-    private var _isPaused = false
+    @Volatile private var currentProcess: Process? = null
+    @Volatile private var _isPaused = false
+    private val generation = AtomicLong(0)
+    @Volatile private var state = SpeechPlaybackState()
+    private val ownershipLock = Any()
     
     override suspend fun speak(text: String, voice: Voice?, pitch: Double?, rate: Double?) {
         withContext(Dispatchers.IO) {
-            // Stop any current speech
-            stop()
+            val requestId = generation.incrementAndGet()
+            stopNative()
+            state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.PREPARING)
             
             // Try different TTS engines in order of preference
             val ttsCommand = findTtsCommand()
             if (ttsCommand != null) {
                 val args = buildCommandArgs(ttsCommand, text, voice, pitch, rate)
                 println("[SPEECH] Executing TTS engine: ${File(ttsCommand).name}")
-                val process = ProcessBuilder(args)
-                    .redirectErrorStream(true)
-                    .start()
-                currentProcess = process
+                val process = try {
+                    synchronized(ownershipLock) {
+                        check(generation.get() == requestId) { "Speech request was replaced" }
+                        ProcessBuilder(args)
+                            .redirectErrorStream(true)
+                            .start()
+                            .also {
+                                currentProcess = it
+                                state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.PLAYING)
+                            }
+                        }
+                } catch (error: Throwable) {
+                    failRequest(requestId)
+                    throw error
+                }
                 
                 // Drain process output without logging it; engines may echo the spoken text.
                 val reader = process.inputStream.bufferedReader()
@@ -37,10 +55,12 @@ class LinuxSpeechService : SpeechService {
                 if (currentProcess === process) {
                     currentProcess = null
                     _isPaused = false
+                    state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.IDLE)
                 }
                 check(exitCode == 0) { "System TTS exited with code $exitCode" }
                 println("[SPEECH] TTS command finished.")
             } else {
+                failRequest(requestId)
                 throw IllegalStateException("No Linux TTS engine found; install espeak-ng, festival, or Piper")
             }
         }
@@ -64,19 +84,28 @@ class LinuxSpeechService : SpeechService {
         if (process?.isAlive == true) {
             Runtime.getRuntime().exec(arrayOf("kill", "-STOP", process.pid().toString())).waitFor()
             _isPaused = true
+            state = SpeechPlaybackState(generation.get(), SpeechPlaybackStatus.PAUSED)
         } else {
             _isPaused = false
         }
     }
     
     override suspend fun stop() {
-        _isPaused = false
-        currentProcess?.let {
-            if (it.isAlive) {
-                it.destroyForcibly()
+        val requestId = generation.incrementAndGet()
+        stopNative()
+        state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.IDLE)
+    }
+
+    private fun stopNative() {
+        synchronized(ownershipLock) {
+            _isPaused = false
+            currentProcess?.let {
+                if (it.isAlive) {
+                    it.destroyForcibly()
+                }
             }
+            currentProcess = null
         }
-        currentProcess = null
     }
     
     override suspend fun resume() {
@@ -85,6 +114,7 @@ class LinuxSpeechService : SpeechService {
             currentProcess?.let {
                 if (it.isAlive) {
                     Runtime.getRuntime().exec(arrayOf("kill", "-CONT", it.pid().toString()))
+                    state = SpeechPlaybackState(generation.get(), SpeechPlaybackStatus.PLAYING)
                 }
             }
         }
@@ -96,6 +126,14 @@ class LinuxSpeechService : SpeechService {
     
     override fun isPaused(): Boolean {
         return currentProcess?.isAlive == true && _isPaused
+    }
+
+    override fun playbackState(): SpeechPlaybackState = state
+
+    private fun failRequest(requestId: Long) {
+        if (generation.get() == requestId) {
+            state = SpeechPlaybackState(requestId, SpeechPlaybackStatus.FAILED, "Speech could not be played")
+        }
     }
     
     private fun findTtsCommand(): String? {

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/KoinBridge.kt
@@ -129,35 +129,19 @@ class KoinBridge : KoinComponent {
     fun processSpeechText(text: String): List<SpeechSegment> = SpeechTextProcessor.processText(text)
 
     suspend fun speak(text: String) {
-        try {
-            get<SpeechService>().speak(text)
-        } catch (t: Throwable) {
-            OperationalLogger.warn("swift_bridge.speak", "failed", exceptionClass = t.loggingClassName())
-        }
+        get<SpeechService>().speak(text)
     }
 
     suspend fun speakBoardSentence(text: String, cacheAudio: Boolean) {
-        try {
-            get<SpeechService>().speakWithCachePolicy(text = text, cacheAudio = cacheAudio)
-        } catch (t: Throwable) {
-            OperationalLogger.warn("swift_bridge.speak_board_sentence", "failed", exceptionClass = t.loggingClassName())
-        }
+        get<SpeechService>().speakWithCachePolicy(text = text, cacheAudio = cacheAudio)
     }
 
     suspend fun pause() {
-        try {
-            get<SpeechService>().pause()
-        } catch (t: Throwable) {
-            OperationalLogger.warn("swift_bridge.pause", "failed", exceptionClass = t.loggingClassName())
-        }
+        get<SpeechService>().pause()
     }
 
     suspend fun stop() {
-        try {
-            get<SpeechService>().stop()
-        } catch (t: Throwable) {
-            OperationalLogger.warn("swift_bridge.stop", "failed", exceptionClass = t.loggingClassName())
-        }
+        get<SpeechService>().stop()
     }
 
     suspend fun selectVoiceAndMaybeUpdatePrimary(voice: Voice) {


### PR DESCRIPTION
## Summary

- Add request-aware playback state and cancellation handling across Android, iOS, and Linux.
- Improve speech fallback, initialization, error recovery, and stale playback prevention.
- Introduce versioned SHA-256 speech cache identities and validate cached audio files.
- Add localization and playback-state integration for iOS.

## Testing

- Added `SpeechCacheIdentityTest` coverage for cache identity generation.
- Not run: full platform test suites and CI verification.