### PR TITLE
[#200] Resolve Dependabot dependency advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    open-pull-requests-limit: 10
     groups:
       gradle:
         patterns: ["*"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,27 @@ plugins {
     alias(libs.plugins.playPublisher) apply false
 }
 
+buildscript {
+    configurations.classpath {
+        resolutionStrategy {
+            // Force patched versions of transitive build/plugin-classpath deps so
+            // Dependabot stays clean without waiting on plugin upstream releases.
+            // BouncyCastle 1.84 closes the critical (GHSA-574f-3g2m-x479) and both
+            // medium (GHSA-c3fc-8qff-9hwx, GHSA-wg6q-6289-32hp) advisories.
+            force(
+                "org.bouncycastle:bcprov-jdk18on:1.84",
+                "org.bouncycastle:bcpkix-jdk18on:1.84",
+                "org.bouncycastle:bcutil-jdk18on:1.84",
+                // jose4j: GHSA-3677-xxcr-wjqv, jdom2: GHSA-2363-cqg2-863c,
+                // commons-lang3: GHSA-j288-q9x7-2f5v
+                "org.bitbucket.b_c:jose4j:0.9.6",
+                "org.jdom:jdom2:2.0.6.1",
+                "org.apache.commons:commons-lang3:3.18.0"
+            )
+        }
+    }
+}
+
 allprojects {
     repositories {
         google()

--- a/docs/CI_SECURITY.md
+++ b/docs/CI_SECURITY.md
@@ -41,6 +41,28 @@ in `.github/workflows/security.yml` and `.github/workflows/secret-scan.yml`
 before merge. Workflow files can define and fail checks, but GitHub repository
 rules are what make those checks mandatory.
 
+## Dependency advisories
+
+Gradle dependencies resolve to patched Netty (4.2.16.Final) via Ktor 3.5, and
+the build/plugin classpath pins patched transitive builds for BouncyCastle
+(1.84), jose4j (0.9.6), jdom2 (2.0.6.1), and commons-lang3 (3.18.0) via a
+`resolutionStrategy` in `build.gradle.kts`. This keeps Dependabot clean for the
+dependencies the project can influence.
+
+Two remaining advisories are accepted risks because they are pinned by the
+Kotlin toolchain itself and have no safe upstream fix short of moving to a Kotlin
+beta:
+
+- `kotlin-gradle-plugin` GHSA-r937-wjx7-w2jp (medium): patched in Kotlin
+  `2.4.20-Beta1`; the project builds on stable Kotlin 2.3.10. Revisit on the next
+  stable Kotlin release.
+- `io.opentelemetry:opentelemetry-api` GHSA-rcgg-9c38-7xpx (medium): pulled
+  transitively by `swift-export-embeddable` (Kotlin 2.3.10) for iOS tooling;
+  patched in opentelemetry-api 1.62.0. Tracked with the Kotlin upgrade above.
+
+The `Dependency vulnerability review` job rejects newly introduced high-or-critical
+advisories, so these two cannot silently regrow past the accepted list above.
+
 ## Deliberate hardware exclusions
 
 CI does not exercise physical gaze trackers, USB/FTDI partner-window hardware,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ okio = "3.9.0"
 # Refactored Architecture Dependencies
 koin = "4.1.1"
 sqldelight = "2.2.1"
-ktor = "3.4.0"
+ktor = "3.5.2"
 kotlinx-datetime = "0.6.0"
 kotlinx-serialization = "1.10.0"
 


### PR DESCRIPTION
## Summary

Resolves the open Dependabot advisories tracked in #200 (79 Maven alerts).

### Netty (66 alerts) — `gradle/libs.versions.toml`
Bumped **ktor `3.4.0 → 3.5.2`**. `ktor-server-netty` (the Linux native-bridge HTTP server) now transitively resolves every `io.netty:*` module to **4.2.16.Final** (was 4.2.9), patched past all reported advisories including the decompression-bomb DoS, HTTP/2 ByteBuf leak, request-smuggling, and event-loop hang items.

Verified with `./gradlew :linuxApp:dependencies --configuration runtimeClasspath` — no Netty line resolves below 4.2.16.Final.

### Build/plugin classpath — `build.gradle.kts`
Added a `buildscript` `resolutionStrategy` forcing patched transitive versions that AGP/play-publisher pin on the build classloader:
- **BouncyCastle 1.84** — closes the **critical** GHSA-574f-3g2m-x479 plus two medium advisories
- **jose4j 0.9.6** (GHSA-3677-xxcr-wjqv)
- **jdom2 2.0.6.1** (GHSA-2363-cqg2-863c)
- **commons-lang3 3.18.0** (GHSA-j288-q9x7-2f5v)

(Upgrading play-publisher to 4.1.1 and AGP to 9.1.0 were tested and did not move these pinned versions, so forcing is the effective fix.)

### Dependabot — `.github/dependabot.yml`
Added `open-pull-requests-limit: 10` so Gradle updates land incrementally instead of accumulating.

### Accepted risks — `docs/CI_SECURITY.md`
Documented the two remaining advisories that are pinned to the Kotlin toolchain with fixes only in a beta:
- `kotlin-gradle-plugin` GHSA-r937-wjx7-w2jp (fix in Kotlin 2.4.20-Beta1; project stays on stable 2.3.10)
- `io.opentelemetry:opentelemetry-api` GHSA-rcgg-9c38-7xpx (pulled by `swift-export-embeddable`)

## Verification
- `:linuxApp:compileKotlin`, `:androidApp:compileDebugKotlin`, `:linuxApp:test`, `:shared:jvmTest` all pass.
- `gh dependabot alerts` reflects merged `main`; after merge the 66 Netty + 4 build-classpath alerts drop to the 2 documented accepted risks.
- CI's `Dependency vulnerability review` job already fails on new high/critical advisories.

Closes #200