### PR TITLE
Fix multilingual voice regression by backfilling catalog metadata

### DIFF
--- a/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSpeechService.kt
+++ b/core/data/src/iosMain/kotlin/io/github/jdreioe/wingmate/infrastructure/IosSpeechService.kt
@@ -124,7 +124,7 @@ class IosSpeechService(
                 base.copy(pitch = pitch ?: base.pitch, rate = rate ?: base.rate)
             }
             if (engine == TtsEngine.SYSTEM) error("System speech is handled by the iOS host")
-            val cacheKey = "${engine.name}|text|$normalizedText|${effectiveVoice.name}|$pitch|$rate|math=${effectiveVoice.mathMode}"
+            val cacheKey = "${engine.name}|text|$normalizedText|${effectiveVoice.name}|${effectiveVoice.primaryLanguage}|${effectiveVoice.selectedLanguage}|$pitch|$rate|math=${effectiveVoice.mathMode}"
             val cached = if (cacheAudio) sentenceAudioCacheMutex.withLock { sentenceAudioCache[cacheKey] } else null
             val audioBytes = cached ?: synthesize(normalizedText, effectiveVoice)
                 ?: error("The selected cloud speech engine is not configured")
@@ -148,7 +148,7 @@ class IosSpeechService(
                 base.copy(pitch = pitch ?: base.pitch, rate = rate ?: base.rate)
             }
             if (engine == TtsEngine.SYSTEM) error("System speech is handled by the iOS host")
-            val cacheKey = "${engine.name}|segments|${segments.joinToString()}|${effectiveVoice.name}|$pitch|$rate|math=${effectiveVoice.mathMode}"
+            val cacheKey = "${engine.name}|segments|${segments.joinToString()}|${effectiveVoice.name}|${effectiveVoice.primaryLanguage}|${effectiveVoice.selectedLanguage}|$pitch|$rate|math=${effectiveVoice.mathMode}"
             val cached = if (cacheAudio) sentenceAudioCacheMutex.withLock { sentenceAudioCache[cacheKey] } else null
             val audioBytes = cached ?: synthesizeSegments(segments, effectiveVoice)
                 ?: error("The selected cloud speech engine is not configured")
@@ -166,7 +166,7 @@ class IosSpeechService(
         val effectiveVoice = (voice ?: defaultVoice()).forCloudProvider(engine).let { base ->
             base.copy(pitch = pitch ?: base.pitch, rate = rate ?: base.rate)
         }
-        val cacheKey = "${engine.name}|text|$normalizedText|${effectiveVoice.name}|$pitch|$rate|math=${effectiveVoice.mathMode}"
+        val cacheKey = "${engine.name}|text|$normalizedText|${effectiveVoice.name}|${effectiveVoice.primaryLanguage}|${effectiveVoice.selectedLanguage}|$pitch|$rate|math=${effectiveVoice.mathMode}"
         if (sentenceAudioCacheMutex.withLock { cacheKey in sentenceAudioCache }) return true
 
         val request = PendingCache(normalizedText, voice, pitch, rate)

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/voice.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/voice.kt
@@ -102,6 +102,24 @@ fun Voice.withPreferredSupportedLanguage(preferredLanguage: String?): Voice {
 }
 
 /**
+ * Backfills catalog-only metadata (secondary locales, provider, model) onto a voice
+ * persisted by an older Wingmate version. Older builds saved the selected voice
+ * without the cloud catalog's fields, so multilingual voices only offered their
+ * primary locale. The persisted voice keeps any metadata it already carries.
+ */
+fun Voice.withCatalogMetadata(catalog: List<Voice>): Voice {
+    val fresh = catalog.firstOrNull { it.name == name } ?: return this
+    return copy(
+        supportedLanguages = supportedLanguages ?: fresh.supportedLanguages,
+        provider = provider ?: fresh.provider,
+        googleModel = googleModel ?: fresh.googleModel,
+        providerVoiceName = providerVoiceName ?: fresh.providerVoiceName,
+        displayName = displayName ?: fresh.displayName,
+        primaryLanguage = primaryLanguage ?: fresh.primaryLanguage,
+    )
+}
+
+/**
  * Collapse Google's locale-prefixed names into one entry per model and speaker.
  * The entry retains every locale in which that speaker is available.
  */

--- a/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/VoiceCatalogTest.kt
+++ b/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/VoiceCatalogTest.kt
@@ -55,4 +55,46 @@ class VoiceCatalogTest {
         assertEquals(listOf("da-DK", "en-US"), voices.single().supportedLanguages)
         assertEquals("en-US", voices.single().withPreferredSupportedLanguage("en-US").selectedLanguage)
     }
+
+    @Test
+    fun persistedVoiceIsBackfilledWithCatalogMetadata() {
+        val persisted = Voice(name = "en-US-BrianMultilingual", primaryLanguage = "en-US")
+        val catalog = listOf(
+            Voice(
+                name = "en-US-BrianMultilingual",
+                primaryLanguage = "en-US",
+                supportedLanguages = listOf("en-US", "da-DK", "de-DE"),
+                provider = VoiceProvider.AZURE,
+            ),
+        )
+
+        val enriched = persisted.withCatalogMetadata(catalog)
+
+        assertEquals(listOf("en-US", "da-DK", "de-DE"), enriched.supportedLanguages)
+        assertEquals(VoiceProvider.AZURE, enriched.provider)
+        assertEquals("en-US", enriched.primaryLanguage)
+    }
+
+    @Test
+    fun persistedVoiceKeepsOwnMetadataAndIsUntouchedWhenCatalogLacksIt() {
+        val persisted = Voice(
+            name = "en-US-BrianMultilingual",
+            supportedLanguages = listOf("fr-FR"),
+            provider = VoiceProvider.GOOGLE,
+        )
+
+        assertEquals(persisted, persisted.withCatalogMetadata(emptyList()))
+        assertEquals(
+            listOf("fr-FR"),
+            persisted.withCatalogMetadata(
+                listOf(Voice(name = "en-US-BrianMultilingual", supportedLanguages = listOf("da-DK"), provider = VoiceProvider.AZURE)),
+            ).supportedLanguages,
+        )
+        assertEquals(
+            VoiceProvider.GOOGLE,
+            persisted.withCatalogMetadata(
+                listOf(Voice(name = "en-US-BrianMultilingual", supportedLanguages = listOf("da-DK"), provider = VoiceProvider.AZURE)),
+            ).provider,
+        )
+    }
 }

--- a/feature/communication/presentation/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/usecases.kt
+++ b/feature/communication/presentation/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/usecases.kt
@@ -74,7 +74,12 @@ class VoiceUseCase(
 ) {
     suspend fun list(): List<Voice> = repo.getVoices()
     suspend fun listForEngine(engine: TtsEngine): List<Voice> = repo.getVoices().forTtsEngine(engine)
-    suspend fun selected(): Voice? = repo.getSelected()
+    suspend fun selected(): Voice? {
+        val persisted = repo.getSelected() ?: return null
+        val enriched = persisted.withCatalogMetadata(repo.getVoices())
+        if (enriched != persisted) repo.saveSelected(enriched)
+        return enriched
+    }
     suspend fun select(voice: Voice) {
         repo.saveSelected(voice)
         val provider = voice.provider
@@ -97,8 +102,12 @@ class VoiceUseCase(
     }
     suspend fun refreshFromAzure(): List<Voice> {
         val list = azure.list()
-        // Cache list for offline/next launch
-        repo.saveVoices(list)
+        // Keep the last working catalog if the refresh comes back empty, and backfill
+        // the saved selection with catalog-only metadata (secondary locales, provider).
+        if (list.isNotEmpty()) {
+            repo.saveVoices(list)
+            persistCatalogMetadataForSelected(list)
+        }
         featureUsageReporter.reportEvent(
             FeatureUsageEvents.VOICE_REFRESHED,
             "count" to list.size.toString()
@@ -109,12 +118,21 @@ class VoiceUseCase(
     suspend fun refreshFromGoogle(): List<Voice> {
         val list = google.list()
         // Keep the last working catalog if validation or refresh fails.
-        if (list.isNotEmpty()) repo.saveVoices(list)
+        if (list.isNotEmpty()) {
+            repo.saveVoices(list)
+            persistCatalogMetadataForSelected(list)
+        }
         featureUsageReporter.reportEvent(
             FeatureUsageEvents.VOICE_REFRESHED,
             "provider" to "google",
             "count" to list.size.toString(),
         )
         return list
+    }
+
+    private suspend fun persistCatalogMetadataForSelected(catalog: List<Voice>) {
+        val persisted = repo.getSelected() ?: return
+        val enriched = persisted.withCatalogMetadata(catalog)
+        if (enriched != persisted) repo.saveSelected(enriched)
     }
 }


### PR DESCRIPTION
## Summary

- Backfill catalog-only voice metadata (secondary locales, provider, model) onto voices persisted by older Wingmate builds, so multilingual voices no longer fall back to only their primary locale.
- `Voice.withCatalogMetadata()` fills only missing fields, keeping any metadata a persisted voice already carries; it's a no-op when the catalog doesn't contain the voice.
- On launch and after Azure/Google catalog refreshes, the saved selection is enriched and re-persisted when it gains metadata.
- Keep the last working catalog when a refresh returns an empty list, instead of overwriting it.
- Include `primaryLanguage`/`selectedLanguage` in the iOS audio cache key so a backfilled voice doesn't serve stale audio from the old key.
- Add domain tests covering metadata backfill, preservation of owned metadata, and the missing-catalog case.

## Testing

- Ran `VoiceCatalogTest` in `core/domain` — new backfill tests pass.
- Confirmed `IosSpeechService` cache key now includes both language fields; behavior unchanged when they're null.
- Not run: `./gradlew allTests` across KMP targets; not run: manual device check on iOS that a previously saved multilingual voice now offers secondary locales end to end.