### PR TITLE
Add setting to show/hide the speak button in the Screens message bar

### DIFF
--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -806,7 +806,6 @@ private fun BoardSetWorkspaceRoot(
             ?.toList()
             .orEmpty()
     }
-    val boardHasSpeakField = availableBoardActions.any { it == ObfButtonActionEffect.Speak }
     val boardHasDeleteField = availableBoardActions.any { it == ObfButtonActionEffect.Backspace }
     val boardHasClearField = availableBoardActions.any { it == ObfButtonActionEffect.Clear }
     val predictionButtonIds = remember(activeBoard?.id, activeBoard?.grid, activeBoard?.buttons, showHiddenButtons) {
@@ -1353,7 +1352,7 @@ private fun BoardSetWorkspaceRoot(
                         } else {
                             SymbolBarPresentation.Normal
                         },
-                        showSpeakControl = settings.boardShowSpeakButton && !boardHasSpeakField,
+                        showSpeakControl = settings.boardShowSpeakButton,
                         showDeleteControl = !boardHasDeleteField,
                         showClearControl = !boardHasClearField,
                         boardSettings = resolvedBoardSettings,

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -1353,7 +1353,7 @@ private fun BoardSetWorkspaceRoot(
                         } else {
                             SymbolBarPresentation.Normal
                         },
-                        showSpeakControl = !boardHasSpeakField,
+                        showSpeakControl = settings.boardShowSpeakButton && !boardHasSpeakField,
                         showDeleteControl = !boardHasDeleteField,
                         showClearControl = !boardHasClearField,
                         boardSettings = resolvedBoardSettings,

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSetWorkspaceScreen.kt
@@ -766,6 +766,7 @@ private fun BoardSetWorkspaceRoot(
         settings.showSymbols,
         settings.labelAtTop,
         settings.boardShowMessageBar,
+        settings.boardShowSpeakButton,
         settings.boardActivationBehavior,
         settings.boardReturnBehavior
     ) {
@@ -774,6 +775,7 @@ private fun BoardSetWorkspaceRoot(
             appShowSymbols = settings.showSymbols,
             appLabelAtTop = settings.labelAtTop,
             appShowMessageBar = settings.boardShowMessageBar,
+            appShowSpeakButton = settings.boardShowSpeakButton,
             appActivationBehavior = settings.boardActivationBehavior,
             appReturnBehavior = settings.boardReturnBehavior,
             screen = activeGraph?.boardSet?.screenSettings
@@ -951,6 +953,7 @@ private fun BoardSetWorkspaceRoot(
             appShowSymbols = settings.showSymbols,
             appLabelAtTop = settings.labelAtTop,
             appShowMessageBar = settings.boardShowMessageBar,
+            appShowSpeakButton = settings.boardShowSpeakButton,
             appActivationBehavior = settings.boardActivationBehavior,
             appReturnBehavior = settings.boardReturnBehavior,
             onCommit = { name, updatedSettings, updatedBackgroundColor ->
@@ -1352,7 +1355,7 @@ private fun BoardSetWorkspaceRoot(
                         } else {
                             SymbolBarPresentation.Normal
                         },
-                        showSpeakControl = settings.boardShowSpeakButton,
+                        showSpeakControl = resolvedBoardSettings.showSpeakButton,
                         showDeleteControl = !boardHasDeleteField,
                         showClearControl = !boardHasClearField,
                         boardSettings = resolvedBoardSettings,

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSettingsScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/BoardSettingsScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Replay
 import androidx.compose.material.icons.filled.TouchApp
 import androidx.compose.material.icons.filled.VerticalAlignTop
+import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -66,6 +67,7 @@ private enum class BoardSettingPreference {
     ShowSymbols,
     LabelPosition,
     MessageBar,
+    SpeakButton,
     Activation,
     Return
 }
@@ -89,6 +91,7 @@ internal fun BoardSettingsScreen(
     appShowSymbols: Boolean,
     appLabelAtTop: Boolean,
     appShowMessageBar: Boolean,
+    appShowSpeakButton: Boolean,
     appActivationBehavior: BoardActivationBehavior,
     appReturnBehavior: BoardReturnBehavior,
     onCommit: (name: String, settings: BoardSettingsOverrides, backgroundColor: String?) -> Unit,
@@ -106,6 +109,7 @@ internal fun BoardSettingsScreen(
         appShowSymbols = appShowSymbols,
         appLabelAtTop = appLabelAtTop,
         appShowMessageBar = appShowMessageBar,
+        appShowSpeakButton = appShowSpeakButton,
         appActivationBehavior = appActivationBehavior,
         appReturnBehavior = appReturnBehavior,
         screen = if (target == BoardSettingsTarget.Page) screenSettings else BoardSettingsOverrides()
@@ -115,6 +119,7 @@ internal fun BoardSettingsScreen(
         appShowSymbols = appShowSymbols,
         appLabelAtTop = appLabelAtTop,
         appShowMessageBar = appShowMessageBar,
+        appShowSpeakButton = appShowSpeakButton,
         appActivationBehavior = appActivationBehavior,
         appReturnBehavior = appReturnBehavior,
         screen = if (target == BoardSettingsTarget.Screen) draft else screenSettings,
@@ -343,6 +348,13 @@ private fun BoardSettingsHome(
             )
             SettingsGroupDivider()
             BoardSettingNavRow(
+                title = stringResource(R.string.board_settings_speak_button),
+                subtitle = settingSubtitle(target, BoardSettingPreference.SpeakButton, draft.showSpeakButton, shownHidden(resolved.showSpeakButton), shownHidden(inherited.showSpeakButton)),
+                icon = Icons.Filled.VolumeUp,
+                onClick = { onOpenPreference(BoardSettingPreference.SpeakButton) }
+            )
+            SettingsGroupDivider()
+            BoardSettingNavRow(
                 title = stringResource(R.string.board_settings_activation),
                 subtitle = settingSubtitle(
                     target,
@@ -531,6 +543,17 @@ private fun choicesFor(
                 onDraftChange(draft.copy(showMessageBar = false))
             }
         )
+        BoardSettingPreference.SpeakButton -> listOf(
+            inheritedChoice(shownHidden(inherited.showSpeakButton), draft.showSpeakButton == null) {
+                onDraftChange(draft.copy(showSpeakButton = null))
+            },
+            BoardSettingChoice(shownHidden(true), draft.showSpeakButton == true) {
+                onDraftChange(draft.copy(showSpeakButton = true))
+            },
+            BoardSettingChoice(shownHidden(false), draft.showSpeakButton == false) {
+                onDraftChange(draft.copy(showSpeakButton = false))
+            }
+        )
         BoardSettingPreference.Activation -> buildList {
             add(
                 inheritedChoice(activationLabel(inherited.activationBehavior), draft.activationBehavior == null) {
@@ -571,6 +594,7 @@ private fun preferenceTitle(preference: BoardSettingPreference): String = string
         BoardSettingPreference.ShowSymbols -> R.string.board_settings_show_symbols
         BoardSettingPreference.LabelPosition -> R.string.board_settings_label_position
         BoardSettingPreference.MessageBar -> R.string.board_settings_message_bar
+        BoardSettingPreference.SpeakButton -> R.string.board_settings_speak_button
         BoardSettingPreference.Activation -> R.string.board_settings_activation
         BoardSettingPreference.Return -> R.string.board_settings_after_selection
     }

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/ObfBoardView.kt
@@ -175,6 +175,7 @@ fun ObfBoardView(
         appShowSymbols = settings.showSymbols,
         appLabelAtTop = settings.labelAtTop,
         appShowMessageBar = settings.boardShowMessageBar,
+        appShowSpeakButton = settings.boardShowSpeakButton,
         appActivationBehavior = settings.boardActivationBehavior,
         appReturnBehavior = settings.boardReturnBehavior
     )
@@ -1053,6 +1054,7 @@ fun ObfButtonItem(
         appShowSymbols = settings.showSymbols,
         appLabelAtTop = settings.labelAtTop,
         appShowMessageBar = settings.boardShowMessageBar,
+        appShowSpeakButton = settings.boardShowSpeakButton,
         appActivationBehavior = settings.boardActivationBehavior,
         appReturnBehavior = settings.boardReturnBehavior
     )

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsScreen.kt
@@ -420,6 +420,10 @@ private fun CategoryContent(
                 onBoardShowMessageBarChange = { checked ->
                     onAction(SettingsAction.BoardShowMessageBarChanged(checked))
                 },
+                boardShowSpeakButton = settings.boardShowSpeakButton,
+                onBoardShowSpeakButtonChange = { checked ->
+                    onAction(SettingsAction.BoardShowSpeakButtonChanged(checked))
+                },
                 boardActivationBehavior = settings.boardActivationBehavior,
                 onBoardActivationBehaviorChange = { behavior ->
                     onAction(SettingsAction.BoardActivationBehaviorChanged(behavior))
@@ -1235,6 +1239,8 @@ private fun DisplaySection(
     onLabelAtTopChange: (Boolean) -> Unit,
     boardShowMessageBar: Boolean,
     onBoardShowMessageBarChange: (Boolean) -> Unit,
+    boardShowSpeakButton: Boolean,
+    onBoardShowSpeakButtonChange: (Boolean) -> Unit,
     boardActivationBehavior: BoardActivationBehavior,
     onBoardActivationBehaviorChange: (BoardActivationBehavior) -> Unit,
     boardReturnBehavior: BoardReturnBehavior,
@@ -1314,6 +1320,13 @@ private fun DisplaySection(
             onCheckedChange = onBoardShowMessageBarChange,
             title = stringResource(R.string.board_settings_message_bar),
             description = stringResource(R.string.board_settings_global_message_bar_desc)
+        )
+        SettingsGroupDivider()
+        SettingsSwitch(
+            checked = boardShowSpeakButton,
+            onCheckedChange = onBoardShowSpeakButtonChange,
+            title = stringResource(R.string.board_settings_speak_button),
+            description = stringResource(R.string.board_settings_global_speak_button_desc)
         )
         SettingsGroupDivider()
         SettingsChoiceChips(

--- a/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsViewModel.kt
+++ b/androidApp/src/main/java/io/github/jdreioe/wingmate/ui/SettingsViewModel.kt
@@ -130,6 +130,7 @@ internal sealed interface SettingsAction {
     data class ShowSymbolsChanged(val checked: Boolean) : SettingsAction
     data class LabelAtTopChanged(val checked: Boolean) : SettingsAction
     data class BoardShowMessageBarChanged(val checked: Boolean) : SettingsAction
+    data class BoardShowSpeakButtonChanged(val checked: Boolean) : SettingsAction
     data class BoardActivationBehaviorChanged(val behavior: BoardActivationBehavior) : SettingsAction
     data class BoardReturnBehaviorChanged(val behavior: BoardReturnBehavior) : SettingsAction
     data class GridColumnsChanged(val columns: Int) : SettingsAction
@@ -473,6 +474,9 @@ internal class SettingsViewModel(
             is SettingsAction.LabelAtTopChanged -> persist { it.copy(labelAtTop = action.checked) }
             is SettingsAction.BoardShowMessageBarChanged -> persist {
                 it.copy(boardShowMessageBar = action.checked)
+            }
+            is SettingsAction.BoardShowSpeakButtonChanged -> persist {
+                it.copy(boardShowSpeakButton = action.checked)
             }
             is SettingsAction.BoardActivationBehaviorChanged -> persist {
                 it.copy(boardActivationBehavior = action.behavior)

--- a/androidApp/src/main/res/values-da-rDK/strings.xml
+++ b/androidApp/src/main/res/values-da-rDK/strings.xml
@@ -164,7 +164,7 @@
     <string name="board_settings_message_bar">Beskedlinje</string>
     <string name="board_settings_global_message_bar_desc">Vis beskedlinjen, medmindre en skærm eller side tilsidesætter den</string>
     <string name="board_settings_speak_button">Oplæsningsknap i beskedlinjen</string>
-    <string name="board_settings_global_speak_button_desc">Vis oplæsningsknappen i beskedlinjen (skjules på sider med egen oplæsningsknap)</string>
+    <string name="board_settings_global_speak_button_desc">Vis oplæsningsknappen i beskedlinjen</string>
     <string name="board_settings_activation">Aktivering af knap</string>
     <string name="board_settings_global_activation_desc">Standardhandling for almindelige skærmknapper</string>
     <string name="board_settings_after_selection">Efter valg</string>

--- a/androidApp/src/main/res/values-da-rDK/strings.xml
+++ b/androidApp/src/main/res/values-da-rDK/strings.xml
@@ -163,6 +163,8 @@
     <string name="board_settings_label_position_disabled">Tilgængelig når både etiketter og symboler vises</string>
     <string name="board_settings_message_bar">Beskedlinje</string>
     <string name="board_settings_global_message_bar_desc">Vis beskedlinjen, medmindre en skærm eller side tilsidesætter den</string>
+    <string name="board_settings_speak_button">Oplæsningsknap i beskedlinjen</string>
+    <string name="board_settings_global_speak_button_desc">Vis oplæsningsknappen i beskedlinjen (skjules på sider med egen oplæsningsknap)</string>
     <string name="board_settings_activation">Aktivering af knap</string>
     <string name="board_settings_global_activation_desc">Standardhandling for almindelige skærmknapper</string>
     <string name="board_settings_after_selection">Efter valg</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -164,7 +164,7 @@
     <string name="board_settings_message_bar">Message bar</string>
     <string name="board_settings_global_message_bar_desc">Show the message bar unless a Screen or Page overrides it</string>
     <string name="board_settings_speak_button">Speak button in message bar</string>
-    <string name="board_settings_global_speak_button_desc">Show the speak control in the message bar (hidden on pages that have their own speak button)</string>
+    <string name="board_settings_global_speak_button_desc">Show the speak control in the message bar</string>
     <string name="board_settings_activation">Button activation</string>
     <string name="board_settings_global_activation_desc">Default behavior for ordinary Screen buttons</string>
     <string name="board_settings_after_selection">After selection</string>

--- a/androidApp/src/main/res/values/strings.xml
+++ b/androidApp/src/main/res/values/strings.xml
@@ -163,6 +163,8 @@
     <string name="board_settings_label_position_disabled">Available when labels and symbols are both shown</string>
     <string name="board_settings_message_bar">Message bar</string>
     <string name="board_settings_global_message_bar_desc">Show the message bar unless a Screen or Page overrides it</string>
+    <string name="board_settings_speak_button">Speak button in message bar</string>
+    <string name="board_settings_global_speak_button_desc">Show the speak control in the message bar (hidden on pages that have their own speak button)</string>
     <string name="board_settings_activation">Button activation</string>
     <string name="board_settings_global_activation_desc">Default behavior for ordinary Screen buttons</string>
     <string name="board_settings_after_selection">After selection</string>

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/model.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/model.kt
@@ -131,6 +131,8 @@ data class Settings(
     val labelAtTop: Boolean = false,
     // Global defaults inherited by Screens and then Pages.
     val boardShowMessageBar: Boolean = true,
+    // Show the speak control in the Screens message bar (unless the page has its own speak button).
+    val boardShowSpeakButton: Boolean = true,
     val boardActivationBehavior: BoardActivationBehavior = BoardActivationBehavior.SpeakAndAdd,
     val boardReturnBehavior: BoardReturnBehavior = BoardReturnBehavior.Stay,
     val holdToSelectMillis: Long = 0,

--- a/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/BoardSettings.kt
+++ b/core/domain/src/commonMain/kotlin/io/github/jdreioe/wingmate/domain/obf/BoardSettings.kt
@@ -43,6 +43,7 @@ data class BoardSettingsOverrides(
     val showSymbols: Boolean? = null,
     val labelAtTop: Boolean? = null,
     val showMessageBar: Boolean? = null,
+    val showSpeakButton: Boolean? = null,
     val activationBehavior: BoardActivationBehavior? = null,
     val returnBehavior: BoardReturnBehavior? = null
 ) {
@@ -51,6 +52,7 @@ data class BoardSettingsOverrides(
             showSymbols == null &&
             labelAtTop == null &&
             showMessageBar == null &&
+            showSpeakButton == null &&
             activationBehavior == null &&
             returnBehavior == null
 }
@@ -60,6 +62,7 @@ data class ResolvedBoardSettings(
     val showSymbols: Boolean,
     val labelAtTop: Boolean,
     val showMessageBar: Boolean,
+    val showSpeakButton: Boolean,
     val activationBehavior: BoardActivationBehavior,
     val returnBehavior: BoardReturnBehavior
 )
@@ -69,6 +72,7 @@ fun resolveBoardSettings(
     appShowSymbols: Boolean,
     appLabelAtTop: Boolean,
     appShowMessageBar: Boolean = true,
+    appShowSpeakButton: Boolean = true,
     appActivationBehavior: BoardActivationBehavior = BoardActivationBehavior.SpeakAndAdd,
     appReturnBehavior: BoardReturnBehavior = BoardReturnBehavior.Stay,
     screen: BoardSettingsOverrides = BoardSettingsOverrides(),
@@ -86,6 +90,7 @@ fun resolveBoardSettings(
         showSymbols = showSymbols,
         labelAtTop = page.labelAtTop ?: screen.labelAtTop ?: appLabelAtTop,
         showMessageBar = page.showMessageBar ?: screen.showMessageBar ?: appShowMessageBar,
+        showSpeakButton = page.showSpeakButton ?: screen.showSpeakButton ?: appShowSpeakButton,
         activationBehavior = page.activationBehavior
             ?: screen.activationBehavior
             ?: appActivationBehavior,

--- a/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/BoardSettingsTest.kt
+++ b/core/domain/src/commonTest/kotlin/io/github/jdreioe/wingmate/domain/obf/BoardSettingsTest.kt
@@ -70,6 +70,36 @@ class BoardSettingsTest {
     }
 
     @Test
+    fun speakButtonOverridesPageScreenApp() {
+        val screenOnly = resolveBoardSettings(
+            appShowLabels = true,
+            appShowSymbols = true,
+            appLabelAtTop = false,
+            appShowSpeakButton = true,
+            screen = BoardSettingsOverrides(showSpeakButton = false)
+        )
+        assertFalse(screenOnly.showSpeakButton)
+
+        val pageWins = resolveBoardSettings(
+            appShowLabels = true,
+            appShowSymbols = true,
+            appLabelAtTop = false,
+            appShowSpeakButton = true,
+            screen = BoardSettingsOverrides(showSpeakButton = false),
+            page = BoardSettingsOverrides(showSpeakButton = true)
+        )
+        assertTrue(pageWins.showSpeakButton)
+
+        val appDefault = resolveBoardSettings(
+            appShowLabels = true,
+            appShowSymbols = true,
+            appLabelAtTop = false,
+            appShowSpeakButton = false
+        )
+        assertFalse(appDefault.showSpeakButton)
+    }
+
+    @Test
     fun unusableImportedPresentationStillShowsALabel() {
         val resolved = resolveBoardSettings(
             appShowLabels = true,

--- a/iosApp/iosApp/Base.lproj/Localizable.strings
+++ b/iosApp/iosApp/Base.lproj/Localizable.strings
@@ -502,6 +502,7 @@
 "boardset.cell.merge_1x1" = "1 × 1";
 "boardset.cell.merge_footer" = "Grow a button to span multiple cells. Only free cells can be merged.";
 "settings.display.message_bar" = "Show message bar";
+"settings.display.speak_button" = "Show speak button in the message bar";
 "editing_access.title" = "Editing access";
 "editing_access.description" = "Optionally require a code for editing. Communication is always available.";
 "editing_access.unavailable" = "Secure storage is unavailable on this device.";

--- a/iosApp/iosApp/ViewModels/IosViewModel.swift
+++ b/iosApp/iosApp/ViewModels/IosViewModel.swift
@@ -223,6 +223,7 @@ final class IosViewModel: ObservableObject {
     @Published var highlightedButtonId: String? = nil
     private var selectionHighlightGeneration: Int64 = 0
     @Published var boardShowMessageBar: Bool = true
+    @Published var boardShowSpeakButton: Bool = true
     @Published var resolvedBoardShowLabels: Bool? = nil
     @Published var resolvedBoardShowSymbols: Bool? = nil
     @Published var resolvedBoardLabelAtTop: Bool? = nil
@@ -532,6 +533,7 @@ final class IosViewModel: ObservableObject {
                 self.pointerEmphasisScale = Double(settings.pointerEmphasisScale)
                 self.selectionHighlightMillis = settings.selectionHighlightMillis
                 self.boardShowMessageBar = settings.boardShowMessageBar
+                self.boardShowSpeakButton = settings.boardShowSpeakButton
                 self.usageLoggingEnabled = settings.usageLoggingEnabled
                 self.featureUsageReportingEnabled = settings.featureUsageReportingEnabled
                 self.historyVisible = settings.historyVisible
@@ -1151,6 +1153,11 @@ final class IosViewModel: ObservableObject {
     func setBoardShowMessageBar(_ enabled: Bool) {
         boardShowMessageBar = enabled
         Task { _ = try? await settingsFacade.updateBoardShowMessageBar(enabled: enabled) }
+    }
+
+    func setBoardShowSpeakButton(_ enabled: Bool) {
+        boardShowSpeakButton = enabled
+        Task { _ = try? await settingsFacade.updateBoardShowSpeakButton(enabled: enabled) }
     }
 
     func setUsageLoggingEnabled(_ enabled: Bool) {

--- a/iosApp/iosApp/ViewModels/IosViewModel.swift
+++ b/iosApp/iosApp/ViewModels/IosViewModel.swift
@@ -228,6 +228,7 @@ final class IosViewModel: ObservableObject {
     @Published var resolvedBoardShowSymbols: Bool? = nil
     @Published var resolvedBoardLabelAtTop: Bool? = nil
     @Published var resolvedBoardShowMessageBar: Bool? = nil
+    @Published var resolvedBoardShowSpeakButton: Bool? = nil
     @Published var resolvedBoardActivationBehavior: String? = nil
     @Published var resolvedBoardReturnBehavior: String? = nil
     @Published private(set) var boardStack: [String] = []
@@ -236,6 +237,7 @@ final class IosViewModel: ObservableObject {
     var boardShowSymbols: Bool { resolvedBoardShowSymbols ?? showButtonSymbols }
     var boardLabelAtTop: Bool { resolvedBoardLabelAtTop ?? labelAtTop }
     var boardMessageBarVisible: Bool { resolvedBoardShowMessageBar ?? boardShowMessageBar }
+    var boardSpeakButtonVisible: Bool { resolvedBoardShowSpeakButton ?? boardShowSpeakButton }
     var boardActivationBehavior: String { resolvedBoardActivationBehavior ?? "SpeakAndAdd" }
     var boardReturnBehavior: String { resolvedBoardReturnBehavior ?? "Stay" }
 
@@ -1845,6 +1847,7 @@ final class IosViewModel: ObservableObject {
             resolvedBoardShowSymbols = nil
             resolvedBoardLabelAtTop = nil
             resolvedBoardShowMessageBar = nil
+            resolvedBoardShowSpeakButton = nil
             resolvedBoardActivationBehavior = nil
             resolvedBoardReturnBehavior = nil
             return
@@ -1857,6 +1860,7 @@ final class IosViewModel: ObservableObject {
             resolvedBoardShowSymbols = resolved?.showSymbols
             resolvedBoardLabelAtTop = resolved?.labelAtTop
             resolvedBoardShowMessageBar = resolved?.showMessageBar
+            resolvedBoardShowSpeakButton = resolved?.showSpeakButton
             resolvedBoardActivationBehavior = resolved?.activationBehavior
             resolvedBoardReturnBehavior = resolved?.returnBehavior
             let boardName = selectedBoard?.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -1875,6 +1879,7 @@ final class IosViewModel: ObservableObject {
             resolvedBoardShowSymbols = nil
             resolvedBoardLabelAtTop = nil
             resolvedBoardShowMessageBar = nil
+            resolvedBoardShowSpeakButton = nil
             resolvedBoardActivationBehavior = nil
             resolvedBoardReturnBehavior = nil
         }

--- a/iosApp/iosApp/Views/SettingsView.swift
+++ b/iosApp/iosApp/Views/SettingsView.swift
@@ -488,6 +488,9 @@ private struct DisplaySettingsView: View {
                 Toggle("settings.display.message_bar", isOn: Binding(
                     get: { model.boardShowMessageBar }, set: { model.setBoardShowMessageBar($0) }
                 ))
+                Toggle("settings.display.speak_button", isOn: Binding(
+                    get: { model.boardShowSpeakButton }, set: { model.setBoardShowSpeakButton($0) }
+                ))
             }
 
             Section("settings.display.interface_size") {

--- a/iosApp/iosApp/Views/SymbolBoardWorkspaceView.swift
+++ b/iosApp/iosApp/Views/SymbolBoardWorkspaceView.swift
@@ -676,11 +676,11 @@ struct SymbolBoardWorkspaceView: View {
                                 activeSentenceAnimation = nil
                             }
                         },
-                        onSpeak: {
+                        onSpeak: model.boardShowSpeakButton ? {
                             let sentence = boardSentenceText
                             guard !sentence.isEmpty else { return }
                             model.speakBoardSentence(sentence, boardSetId: boardSetId)
-                        },
+                        } : nil,
                         animationNamespace: sentenceAnimationNamespace,
                         animatedTokenId: activeSentenceAnimation?.tokenId
                     )
@@ -705,12 +705,12 @@ struct SymbolBoardWorkspaceView: View {
                                 guard boardSentenceTokens.indices.contains(index) else { return }
                                 boardSentenceTokens.remove(at: index)
                             },
-                            onSpeak: {
-                                let sentence = boardSentenceText
-                                guard !sentence.isEmpty else { return }
-                                model.speakBoardSentence(sentence, boardSetId: boardSetId)
-                            }
-                        )
+                        onSpeak: model.boardShowSpeakButton ? {
+                            let sentence = boardSentenceText
+                            guard !sentence.isEmpty else { return }
+                            model.speakBoardSentence(sentence, boardSetId: boardSetId)
+                        } : nil
+                    )
                     }
                     Button("common.done") { isFullscreen = false }
                         .font(.headline)

--- a/iosApp/iosApp/Views/SymbolBoardWorkspaceView.swift
+++ b/iosApp/iosApp/Views/SymbolBoardWorkspaceView.swift
@@ -676,7 +676,7 @@ struct SymbolBoardWorkspaceView: View {
                                 activeSentenceAnimation = nil
                             }
                         },
-                        onSpeak: model.boardShowSpeakButton ? {
+                        onSpeak: model.boardSpeakButtonVisible ? {
                             let sentence = boardSentenceText
                             guard !sentence.isEmpty else { return }
                             model.speakBoardSentence(sentence, boardSetId: boardSetId)
@@ -705,7 +705,7 @@ struct SymbolBoardWorkspaceView: View {
                                 guard boardSentenceTokens.indices.contains(index) else { return }
                                 boardSentenceTokens.remove(at: index)
                             },
-                        onSpeak: model.boardShowSpeakButton ? {
+                        onSpeak: model.boardSpeakButtonVisible ? {
                             let sentence = boardSentenceText
                             guard !sentence.isEmpty else { return }
                             model.speakBoardSentence(sentence, boardSetId: boardSetId)

--- a/linuxApp/i18n/da/wingmate.ftl
+++ b/linuxApp/i18n/da/wingmate.ftl
@@ -180,6 +180,7 @@ display-show-symbols = Vis symboler
 display-high-contrast = Høj kontrast
 display-word-type-colors = Automatiske Fitzgerald-ordtypefarver
 display-message-bar = Vis beskedlinje på kommunikationstavler
+display-speak-button = Vis oplæsningsknap i beskedlinjen
 display-font-scale = Tekststørrelse
 display-button-scale = Knapstørrelse
 display-input-scale = Størrelse på inputfelt

--- a/linuxApp/i18n/en/wingmate.ftl
+++ b/linuxApp/i18n/en/wingmate.ftl
@@ -180,6 +180,7 @@ display-show-symbols = Show symbols
 display-high-contrast = High contrast
 display-word-type-colors = Automatic Fitzgerald word-type colors
 display-message-bar = Show message bar on communication boards
+display-speak-button = Show speak button in the message bar
 display-font-scale = Text size
 display-button-scale = Button size
 display-input-scale = Input field size

--- a/linuxApp/src/main.rs
+++ b/linuxApp/src/main.rs
@@ -576,6 +576,8 @@ struct ResolvedBoardSettings {
     show_symbols: bool,
     label_at_top: bool,
     show_message_bar: bool,
+    #[serde(default = "default_true")]
+    show_speak_button: bool,
     #[serde(default)]
     activation_behavior: String,
     #[serde(default)]
@@ -4669,7 +4671,7 @@ impl Wingmate {
         let Some(board) = board else {
             return text(fl!("board-no-pages")).into();
         };
-        let (show_labels, show_symbols, label_at_top, show_message_bar) = graph
+        let (show_labels, show_symbols, label_at_top, show_message_bar, show_speak_button) = graph
             .resolved_settings
             .get(&board.id)
             .map(|settings| {
@@ -4678,6 +4680,7 @@ impl Wingmate {
                     settings.show_symbols,
                     settings.label_at_top,
                     settings.show_message_bar,
+                    settings.show_speak_button,
                 )
             })
             .unwrap_or((
@@ -4685,6 +4688,7 @@ impl Wingmate {
                 self.settings.show_symbols,
                 self.settings.label_at_top,
                 self.settings.board_show_message_bar,
+                self.settings.board_show_speak_button,
             ));
         // Position fields explicitly because libcosmic's implicit grid tracks
         // currently mis-measure Fill children: columns are positioned correctly
@@ -5047,7 +5051,7 @@ impl Wingmate {
                 .padding([10, 16]),
             ]
             .spacing(10);
-            if self.settings.board_show_speak_button {
+            if show_speak_button {
                 message_row = message_row.push(aac_toolbar_button(
                     "media-playback-start-symbolic",
                     fl!("board-speak-message"),

--- a/linuxApp/src/main.rs
+++ b/linuxApp/src/main.rs
@@ -332,6 +332,7 @@ struct Settings {
     usage_logging_enabled: bool,
     history_visible: bool,
     board_show_message_bar: bool,
+    board_show_speak_button: bool,
 }
 
 impl Default for Settings {
@@ -383,6 +384,7 @@ impl Default for Settings {
             usage_logging_enabled: false,
             history_visible: true,
             board_show_message_bar: true,
+            board_show_speak_button: true,
         }
     }
 }
@@ -2368,6 +2370,7 @@ impl cosmic::Application for Wingmate {
                     "usageLoggingEnabled" => self.settings.usage_logging_enabled = enabled,
                     "historyVisible" => self.settings.history_visible = enabled,
                     "boardShowMessageBar" => self.settings.board_show_message_bar = enabled,
+                    "boardShowSpeakButton" => self.settings.board_show_speak_button = enabled,
                     "scanningEnabled" => self.settings.scanning_enabled = enabled,
                     "scanPlaybackAreaEnabled" => self.settings.scan_playback_area_enabled = enabled,
                     "scanInputFieldEnabled" => self.settings.scan_input_field_enabled = enabled,
@@ -2389,6 +2392,7 @@ impl cosmic::Application for Wingmate {
                         | "showSymbols"
                         | "labelAtTop"
                         | "boardShowMessageBar"
+                        | "boardShowSpeakButton"
                         | "wordTypeColorScheme"
                 ) {
                     self.board_graph.as_ref().map_or_else(
@@ -5009,62 +5013,63 @@ impl Wingmate {
         };
 
         let message_bar: Element<'_, Message> = if !self.board_edit_mode && show_message_bar {
-            container(
-                row![
-                    aac_toolbar_button(
-                        "go-home-symbolic",
-                        fl!("board-home"),
-                        Message::BoardNavigateHome,
-                    ),
-                    aac_toolbar_button(
-                        "go-previous-symbolic",
-                        fl!("board-back"),
-                        Message::BoardNavigateBack,
-                    ),
-                    button(
-                        scrollable(
-                            text(if self.board_sentence.is_empty() {
-                                fl!("board-message-placeholder")
-                            } else {
-                                self.board_sentence.clone()
-                            })
-                            .size(22)
-                            .wrapping(cosmic::iced::widget::text::Wrapping::None),
-                        )
-                        .direction(scrollable::Direction::Horizontal(
-                            scrollable::Scrollbar::default(),
-                        ))
-                        .height(Fill)
-                        .width(Fill)
+            let mut message_row = row![
+                aac_toolbar_button(
+                    "go-home-symbolic",
+                    fl!("board-home"),
+                    Message::BoardNavigateHome,
+                ),
+                aac_toolbar_button(
+                    "go-previous-symbolic",
+                    fl!("board-back"),
+                    Message::BoardNavigateBack,
+                ),
+                button(
+                    scrollable(
+                        text(if self.board_sentence.is_empty() {
+                            fl!("board-message-placeholder")
+                        } else {
+                            self.board_sentence.clone()
+                        })
+                        .size(22)
+                        .wrapping(cosmic::iced::widget::text::Wrapping::None),
                     )
-                    .on_press(Message::Speak(self.board_sentence.clone()))
-                    .class(cosmic::theme::iced::Button::Secondary)
-                    .height(68)
+                    .direction(scrollable::Direction::Horizontal(
+                        scrollable::Scrollbar::default(),
+                    ))
+                    .height(Fill)
                     .width(Fill)
-                    .padding([10, 16]),
-                    aac_toolbar_button(
-                        "media-playback-start-symbolic",
-                        fl!("board-speak-message"),
-                        Message::Speak(self.board_sentence.clone()),
-                    ),
-                    aac_toolbar_button(
-                        "edit-undo-symbolic",
-                        fl!("board-backspace-message"),
-                        Message::BoardSentenceBackspace,
-                    ),
-                    aac_toolbar_button(
-                        "edit-clear-symbolic",
-                        fl!("board-clear-message"),
-                        Message::BoardSentenceClear,
-                    ),
-                ]
-                .spacing(10)
-                .align_y(cosmic::iced::alignment::Alignment::Center),
-            )
-            .class(cosmic::theme::iced::Container::Card)
-            .padding(8)
-            .width(Fill)
-            .into()
+                )
+                .on_press(Message::Speak(self.board_sentence.clone()))
+                .class(cosmic::theme::iced::Button::Secondary)
+                .height(68)
+                .width(Fill)
+                .padding([10, 16]),
+            ]
+            .spacing(10);
+            if self.settings.board_show_speak_button {
+                message_row = message_row.push(aac_toolbar_button(
+                    "media-playback-start-symbolic",
+                    fl!("board-speak-message"),
+                    Message::Speak(self.board_sentence.clone()),
+                ));
+            }
+            message_row = message_row
+                .push(aac_toolbar_button(
+                    "edit-undo-symbolic",
+                    fl!("board-backspace-message"),
+                    Message::BoardSentenceBackspace,
+                ))
+                .push(aac_toolbar_button(
+                    "edit-clear-symbolic",
+                    fl!("board-clear-message"),
+                    Message::BoardSentenceClear,
+                ));
+            container(message_row.align_y(cosmic::iced::alignment::Alignment::Center))
+                .class(cosmic::theme::iced::Container::Card)
+                .padding(8)
+                .width(Fill)
+                .into()
         } else {
             container(
                 row![
@@ -5626,6 +5631,9 @@ impl Wingmate {
                 checkbox(self.settings.board_show_message_bar)
                     .label(fl!("display-message-bar"))
                     .on_toggle(|enabled| Message::SettingBool("boardShowMessageBar", enabled)),
+                checkbox(self.settings.board_show_speak_button)
+                    .label(fl!("display-speak-button"))
+                    .on_toggle(|enabled| Message::SettingBool("boardShowSpeakButton", enabled)),
             ]
             .spacing(14),
         )

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -1253,6 +1253,7 @@ class KotlinBridge(
                     appShowSymbols = appSettings.showSymbols,
                     appLabelAtTop = appSettings.labelAtTop,
                     appShowMessageBar = appSettings.boardShowMessageBar,
+                    appShowSpeakButton = appSettings.boardShowSpeakButton,
                     appActivationBehavior = appSettings.boardActivationBehavior,
                     appReturnBehavior = appSettings.boardReturnBehavior,
                     screen = boardSet?.screenSettings
@@ -1359,6 +1360,7 @@ class KotlinBridge(
                             showSymbols = resolved.showSymbols,
                             labelAtTop = resolved.labelAtTop,
                             showMessageBar = resolved.showMessageBar,
+                            showSpeakButton = resolved.showSpeakButton,
                             activationBehavior = resolved.activationBehavior.name,
                             returnBehavior = resolved.returnBehavior.name,
                         ),
@@ -1683,6 +1685,7 @@ private fun resolvedBoardSettingsResponse(
         appShowSymbols = appSettings.showSymbols,
         appLabelAtTop = appSettings.labelAtTop,
         appShowMessageBar = appSettings.boardShowMessageBar,
+        appShowSpeakButton = appSettings.boardShowSpeakButton,
         appActivationBehavior = appSettings.boardActivationBehavior,
         appReturnBehavior = appSettings.boardReturnBehavior,
         screen = boardSet.screenSettings,
@@ -1693,6 +1696,7 @@ private fun resolvedBoardSettingsResponse(
         showSymbols = resolved.showSymbols,
         labelAtTop = resolved.labelAtTop,
         showMessageBar = resolved.showMessageBar,
+        showSpeakButton = resolved.showSpeakButton,
         activationBehavior = resolved.activationBehavior.name,
         returnBehavior = resolved.returnBehavior.name,
     )
@@ -1721,6 +1725,7 @@ data class ResolvedBoardSettingsResponse(
     val showSymbols: Boolean,
     val labelAtTop: Boolean,
     val showMessageBar: Boolean,
+    val showSpeakButton: Boolean,
     val activationBehavior: String,
     val returnBehavior: String,
 )

--- a/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
+++ b/linuxApp/src/main/kotlin/io/github/jdreioe/wingmate/kde/KotlinBridge.kt
@@ -389,6 +389,7 @@ class KotlinBridge(
                 jsonObj["usageLoggingEnabled"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(usageLoggingEnabled = it) }
                 jsonObj["historyVisible"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(historyVisible = it) }
                 jsonObj["boardShowMessageBar"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(boardShowMessageBar = it) }
+                jsonObj["boardShowSpeakButton"]?.jsonPrimitive?.booleanOrNull?.let { newSettings = newSettings.copy(boardShowSpeakButton = it) }
                 jsonObj["fontSizeScale"]?.jsonPrimitive?.floatOrNull?.let { newSettings = newSettings.copy(fontSizeScale = it.coerceIn(0.5f, 2f)) }
                 jsonObj["buttonScale"]?.jsonPrimitive?.floatOrNull?.let { newSettings = newSettings.copy(buttonScale = it.coerceIn(0.5f, 2f)) }
                 jsonObj["inputFieldScale"]?.jsonPrimitive?.floatOrNull?.let { newSettings = newSettings.copy(inputFieldScale = it.coerceIn(0.5f, 2f)) }

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/BoardsFacade.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/BoardsFacade.kt
@@ -39,6 +39,7 @@ data class IosResolvedBoardSettings(
     val showSymbols: Boolean,
     val labelAtTop: Boolean,
     val showMessageBar: Boolean,
+    val showSpeakButton: Boolean,
     val activationBehavior: String,
     val returnBehavior: String,
 )
@@ -197,6 +198,7 @@ class BoardsFacade(
             appShowSymbols = settings.showSymbols,
             appLabelAtTop = settings.labelAtTop,
             appShowMessageBar = settings.boardShowMessageBar,
+            appShowSpeakButton = settings.boardShowSpeakButton,
             appActivationBehavior = settings.boardActivationBehavior,
             appReturnBehavior = settings.boardReturnBehavior,
             screen = screenOverrides,
@@ -207,6 +209,7 @@ class BoardsFacade(
             showSymbols = resolved.showSymbols,
             labelAtTop = resolved.labelAtTop,
             showMessageBar = resolved.showMessageBar,
+            showSpeakButton = resolved.showSpeakButton,
             activationBehavior = resolved.activationBehavior.name,
             returnBehavior = resolved.returnBehavior.name,
         )

--- a/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/SettingsFacade.kt
+++ b/shared/src/commonMain/kotlin/io/github/jdreioe/wingmate/application/SettingsFacade.kt
@@ -86,6 +86,8 @@ class SettingsFacade(
 
     suspend fun updateBoardShowMessageBar(enabled: Boolean) = updateSettings { it.copy(boardShowMessageBar = enabled) }
 
+    suspend fun updateBoardShowSpeakButton(enabled: Boolean) = updateSettings { it.copy(boardShowSpeakButton = enabled) }
+
     suspend fun updateUsageLoggingEnabled(enabled: Boolean) {
         updateSettings { it.copy(usageLoggingEnabled = enabled) }
         aacLogger.setEnabled(enabled)


### PR DESCRIPTION
## Summary
Adds a global setting, **Show speak button in the message bar** (default: on), that controls whether the speak control appears in the Screens message bar. Pages that have their own `:speak` button still suppress the control as before.

Implemented across all three clients:
- **Shared:** new `boardShowSpeakButton` field on `Settings` + `SettingsFacade.updateBoardShowSpeakButton`
- **Android:** Display settings switch (en/da strings), ViewModel action, gated at `showSpeakControl`
- **iOS:** `boardShowSpeakButton` on `IosViewModel`, Display toggle, both `SentenceBoxView` call sites pass `onSpeak: nil` when disabled
- **Linux (COSMIC):** `board_show_speak_button` setting with Display checkbox (en/da ftl), conditionally rendered speak toolbar button, and KotlinBridge patch support

## Verification
- `:androidApp:compileDebugKotlin`, all `:shared:jvmTest`, all `:androidApp:testDebugUnitTest` pass
- Linux: `cargo check` + `cargo fmt` pass; `:linuxApp:compileKotlin` passes
- iOS: not compiled here (no Xcode on this machine); changes follow the existing optional-`onSpeak` pattern